### PR TITLE
Fix wildcard values in local CSV database match

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/CompoundDBAnnotation.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/CompoundDBAnnotation.java
@@ -371,13 +371,18 @@ public interface CompoundDBAnnotation extends Cloneable, FeatureAnnotation {
     clone.put(MzPpmDifferenceType.class,
         (float) MathUtils.getPpmDiff(Objects.requireNonNullElse(clone.getPrecursorMZ(), 0d),
             row.getAverageMZ()));
-    if (get(CCSType.class) != null && row.getAverageCCS() != null) {
+
+    // if the compound entry contained <=0 for RT or mobility
+    // do not check. This is defined as wildcard in the documentation and outside valid values
+    var compCcs = get(CCSType.class);
+    if (compCcs != null && compCcs > 0 && row.getAverageCCS() != null) {
       clone.put(CCSRelativeErrorType.class,
-          PercentTolerance.getPercentError(get(CCSType.class), row.getAverageCCS()));
+          PercentTolerance.getPercentError(compCcs, row.getAverageCCS()));
     }
-    if (get(RTType.class) != null && row.getAverageRT() != null) {
+    var compRt = get(RTType.class);
+    if (compRt != null && compRt > 0 && row.getAverageRT() != null) {
       clone.put(RtRelativeErrorType.class,
-          PercentTolerance.getPercentError(get(RTType.class), row.getAverageRT()));
+          PercentTolerance.getPercentError(compRt, row.getAverageRT()));
     }
 
     return clone;

--- a/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/SimpleCompoundDBAnnotation.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/compoundannotations/SimpleCompoundDBAnnotation.java
@@ -259,21 +259,25 @@ public class SimpleCompoundDBAnnotation implements CompoundDBAnnotation {
       return false;
     }
 
+    // values <=0 are wildcards and always match because they are invalid. see documentation
     final Float rt = getRT();
-    if (rtTolerance != null && rt != null && (row.getAverageRT() == null
+    if (rtTolerance != null && rt != null && rt > 0 && (row.getAverageRT() == null
         || !rtTolerance.checkWithinTolerance(row.getAverageRT(), rt))) {
       return false;
     }
 
+    // values <=0 are wildcards and always match because they are invalid. see documentation
     final Float mobility = getMobility();
-    if (mobilityTolerance != null && mobility != null && (row.getAverageMobility() == null
-        || !mobilityTolerance.checkWithinTolerance(mobility, row.getAverageMobility()))) {
+    if (mobilityTolerance != null && mobility != null && mobility > 0 && (
+        row.getAverageMobility() == null || !mobilityTolerance.checkWithinTolerance(mobility,
+            row.getAverageMobility()))) {
       return false;
     }
 
+    // values <=0 are wildcards and always match because they are invalid. see documentation
     final Float ccs = getCCS();
-    return percentCCSTolerance == null || ccs == null || (row.getAverageCCS() != null && !(
-        Math.abs(1 - (row.getAverageCCS() / ccs)) > percentCCSTolerance));
+    return percentCCSTolerance == null || ccs == null || ccs <= 0 || (row.getAverageCCS() != null
+        && !(Math.abs(1 - (row.getAverageCCS() / ccs)) > percentCCSTolerance));
   }
 
   @Override

--- a/src/main/java/io/github/mzmine/modules/dataprocessing/id_localcsvsearch/LocalCSVDatabaseSearchTask.java
+++ b/src/main/java/io/github/mzmine/modules/dataprocessing/id_localcsvsearch/LocalCSVDatabaseSearchTask.java
@@ -280,6 +280,13 @@ public class LocalCSVDatabaseSearchTask extends AbstractTask {
     }
   }
 
+  @Nullable
+  private static Float replaceWildcardLowerEq0WithNull(final DataType<Float> type,
+      final Map<DataType<?>, String> map) {
+    float value = Float.parseFloat(map.getOrDefault(type, "-1"));
+    return value > 0 ? value : null;
+  }
+
   @NotNull
   private CompoundDBAnnotation getCompoundFromLine(@NotNull String[] values,
       @NotNull List<ImportType> linesWithIndices, @NotNull final List<ImportType> commentFields) {
@@ -312,11 +319,11 @@ public class LocalCSVDatabaseSearchTask extends AbstractTask {
     final String lineAdduct = entry.get(adductType);
     final Double lineMZ =
         (entry.get(precursorMz) != null) ? Double.parseDouble(entry.get(precursorMz)) : null;
-    final Float lineRT = (entry.get(rtType) != null) ? Float.parseFloat(entry.get(rtType)) : null;
-    final Float lineMob =
-        (entry.get(mobType) != null) ? Float.parseFloat(entry.get(mobType)) : null;
-    final Float lineCCS =
-        (entry.get(ccsType) != null) ? Float.parseFloat(entry.get(ccsType)) : null;
+
+    // make sure to replace <=0 with null as this is defined as wildcards that match every value
+    Float lineRT = replaceWildcardLowerEq0WithNull(rtType, entry);
+    Float lineMob = replaceWildcardLowerEq0WithNull(mobType, entry);
+    Float lineCCS = replaceWildcardLowerEq0WithNull(ccsType, entry);
     final Double neutralMass =
         entry.get(neutralMassType) != null ? Double.parseDouble(entry.get(neutralMassType)) : null;
     final String smiles = entry.get(smilesType);


### PR DESCRIPTION
RT, mobility, CCS <=0 are wildcards that match everything.

replace with null during loading.