### PR TITLE
Zoom to full chromatograms in feature table

### DIFF
--- a/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/FeatureShapeChart.java
+++ b/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/FeatureShapeChart.java
@@ -94,8 +94,9 @@ public class FeatureShapeChart extends StackPane {
       // FWHM defines most of the feature / chromatogram
       if (fwhm != null && !Float.isNaN(fwhm) && fwhm > 0f && fwhm / fullWidth > 0.4) {
         // zoom on feature
-        defaultRange = new org.jfree.data.Range(Math.max(rt - 3 * fwhm, rawMinRt),
-            Math.min(rt + 3 * fwhm, rawMaxRt));
+        var window = 5 * fwhm;
+        defaultRange = new org.jfree.data.Range(Math.max(rt - window, rawMinRt),
+            Math.min(rt + window, rawMaxRt));
       } else {
         // show full RT range
         final float length = Math.max(fullWidth, 0.001f);


### PR DESCRIPTION
Check FWHM/full width to show either full chromatograms in table or zoomed in features

MZmine 2 was always showing the full range. I like the zoomed in features - but this does not show the whole chromatograms. Especially when there are more peaks like in GC: 

### Left is current state, right is with full chromatograms 
<img width="1791" alt="image" src="https://github.com/mzmine/mzmine3/assets/10366914/592e5e2b-efa9-4d79-8bd9-9b99860e08c2">
