### PR TITLE
Fix charts after update of jfreechart

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/HistogramChartFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/HistogramChartFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -240,7 +240,7 @@ public class HistogramChartFactory {
     }
     // add gaussian
     XYSeriesCollection gsdata = new XYSeriesCollection(gs);
-    int index = plot.getDatasetCount();
+    int index = JFreeChartUtils.getNextDatasetIndex(plot);
     plot.setDataset(index, gsdata);
     plot.setRenderer(index, new XYLineAndShapeRenderer(true, false));
 

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/JFreeChartUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/JFreeChartUtils.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2004-2024 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.gui.chartbasics;
+
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.data.xy.XYDataset;
+
+public class JFreeChartUtils {
+
+  /**
+   * Plot may contain null datasets
+   *
+   * @return num datasets including null
+   */
+  public static int getDatasetCountNullable(XYPlot plot) {
+    return plot.getDatasets().size();
+  }
+
+  /**
+   * Plot may contain null datasets
+   *
+   * @return num datasets EXCLUDING null
+   */
+  public static int getDatasetCountNotNull(XYPlot plot) {
+    return plot.getDatasetCount();
+  }
+
+  /**
+   * Plot may contain null datasets - find first index where dataset is null or return the
+   * totalDataset num to append
+   */
+  public static int getNextDatasetIndex(XYPlot plot) {
+    int totalDatasets = getDatasetCountNullable(plot);
+    for (int i = 0; i < totalDatasets; i++) {
+      if (plot.getDataset(i) == null) {
+        return i;
+      }
+    }
+    return totalDatasets;
+  }
+
+
+  /**
+   * Removes all feature data sets.
+   *
+   * @param notify If false, the plot is not redrawn. This is useful, if multiple data sets are
+   *               added right after and the plot shall not be updated until then.
+   */
+  public static void removeAllDataSetsOf(JFreeChart chart, Class<? extends XYDataset> clazz,
+      boolean notify) {
+    if (!(chart.getPlot() instanceof XYPlot plot)) {
+      return;
+    }
+
+    plot.setNotify(false);
+    int numDatasets = JFreeChartUtils.getDatasetCountNullable(plot);
+    for (int i = 0; i < numDatasets; i++) {
+      XYDataset ds = plot.getDataset(i);
+      if (clazz.isInstance(ds)) {
+        plot.setDataset(i, null);
+        plot.setRenderer(i, null);
+      }
+    }
+    plot.setNotify(true);
+    if (notify) {
+      chart.fireChartChanged();
+    }
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/gui/javafx/EChartViewer.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/gui/javafx/EChartViewer.java
@@ -26,6 +26,7 @@
 package io.github.mzmine.gui.chartbasics.gui.javafx;
 
 import io.github.mzmine.gui.chartbasics.ChartLogicsFX;
+import io.github.mzmine.gui.chartbasics.JFreeChartUtils;
 import io.github.mzmine.gui.chartbasics.gestures.ChartGestureHandler;
 import io.github.mzmine.gui.chartbasics.gestures.interf.GestureHandlerFactory;
 import io.github.mzmine.gui.chartbasics.graphicsexport.GraphicsExportModule;
@@ -403,77 +404,81 @@ public class EChartViewer extends ChartViewer implements DatasetChangeListener {
    * @return Data array[columns][rows]
    */
   public Object[][] getDataArrayForExport() {
-    if (getChart().getPlot() instanceof XYPlot && getChart().getXYPlot() != null
-      /*&& getChart().getXYPlot().getDataset() != null*/) { // getDataset() may be null if the
-      // first dataset was removed, but the plot may still hold other datasets
-      try {
-        List<Object[]> modelList = new ArrayList<>();
-
-        for (int d = 0; d < getChart().getXYPlot().getDatasetCount(); d++) {
-          XYDataset data = getChart().getXYPlot().getDataset(d);
-          if (data instanceof XYZDataset xyz) {
-            int series = data.getSeriesCount();
-            Object[][] model = new Object[series * 3][];
-            for (int s = 0; s < series; s++) {
-              int size = 2 + xyz.getItemCount(s);
-              Object[] x = new Object[size];
-              Object[] y = new Object[size];
-              Object[] z = new Object[size];
-              // create new Array model[row][col]
-              // Write header
-              Comparable title = data.getSeriesKey(series);
-              x[0] = title;
-              y[0] = "";
-              z[0] = "";
-              x[1] = getChart().getXYPlot().getDomainAxis().getLabel();
-              y[1] = getChart().getXYPlot().getRangeAxis().getLabel();
-              z[1] = "z-axis";
-              // write data
-              for (int i = 0; i < xyz.getItemCount(s); i++) {
-                x[i + 2] = xyz.getX(s, i);
-                y[i + 2] = xyz.getY(s, i);
-                z[i + 2] = xyz.getZ(s, i);
-              }
-              model[s * 3] = x;
-              model[s * 3 + 1] = y;
-              model[s * 3 + 2] = z;
-            }
-
-            Collections.addAll(modelList, model);
-          } else if (data != null) {
-            int series = data.getSeriesCount();
-            Object[][] model = new Object[series * 2][];
-            for (int s = 0; s < series; s++) {
-              int size = 2 + data.getItemCount(s);
-              Object[] x = new Object[size];
-              Object[] y = new Object[size];
-              // create new Array model[row][col]
-              // Write header
-              Comparable title = data.getSeriesKey(s);
-              x[0] = title;
-              y[0] = "";
-              x[1] = getChart().getXYPlot().getDomainAxis().getLabel();
-              y[1] = getChart().getXYPlot().getRangeAxis().getLabel();
-              // write data
-              for (int i = 0; i < data.getItemCount(s); i++) {
-                x[i + 2] = data.getX(s, i);
-                y[i + 2] = data.getY(s, i);
-              }
-              model[s * 2] = x;
-              model[s * 2 + 1] = y;
-            }
-
-            Collections.addAll(modelList, model);
-          }
-        }
-
-        return modelList.toArray(new Object[modelList.size()][]);
-      } catch (Exception ex) {
-        logger.log(Level.WARNING, "Cannot retrieve data for export", ex);
-        return null;
-      }
+    if (!(getChart().getPlot() instanceof XYPlot plot)) {
+      return null;
     }
-    return null;
+    // getDataset() may be null if the
+    // first dataset was removed, but the plot may still hold other datasets
+    try {
+      List<Object[]> modelList = new ArrayList<>();
+
+      int numDatasets = JFreeChartUtils.getDatasetCountNullable(plot);
+      for (int d = 0; d < numDatasets; d++) {
+        XYDataset data = plot.getDataset(d);
+        if (data == null) {
+          continue;
+        }
+        else if (data instanceof XYZDataset xyz) {
+          int series = data.getSeriesCount();
+          Object[][] model = new Object[series * 3][];
+          for (int s = 0; s < series; s++) {
+            int size = 2 + xyz.getItemCount(s);
+            Object[] x = new Object[size];
+            Object[] y = new Object[size];
+            Object[] z = new Object[size];
+            // create new Array model[row][col]
+            // Write header
+            Comparable title = data.getSeriesKey(series);
+            x[0] = title;
+            y[0] = "";
+            z[0] = "";
+            x[1] = plot.getDomainAxis().getLabel();
+            y[1] = plot.getRangeAxis().getLabel();
+            z[1] = "z-axis";
+            // write data
+            for (int i = 0; i < xyz.getItemCount(s); i++) {
+              x[i + 2] = xyz.getX(s, i);
+              y[i + 2] = xyz.getY(s, i);
+              z[i + 2] = xyz.getZ(s, i);
+            }
+            model[s * 3] = x;
+            model[s * 3 + 1] = y;
+            model[s * 3 + 2] = z;
+          }
+
+          Collections.addAll(modelList, model);
+        } else if (data != null) {
+          int series = data.getSeriesCount();
+          Object[][] model = new Object[series * 2][];
+          for (int s = 0; s < series; s++) {
+            int size = 2 + data.getItemCount(s);
+            Object[] x = new Object[size];
+            Object[] y = new Object[size];
+            // create new Array model[row][col]
+            // Write header
+            Comparable title = data.getSeriesKey(s);
+            x[0] = title;
+            y[0] = "";
+            x[1] = plot.getDomainAxis().getLabel();
+            y[1] = plot.getRangeAxis().getLabel();
+            // write data
+            for (int i = 0; i < data.getItemCount(s); i++) {
+              x[i + 2] = data.getX(s, i);
+              y[i + 2] = data.getY(s, i);
+            }
+            model[s * 2] = x;
+            model[s * 2 + 1] = y;
+          }
+
+          Collections.addAll(modelList, model);
+        }
+      }
+
+      return modelList.toArray(new Object[modelList.size()][]);
+    } catch (Exception ex) {
+      logger.log(Level.WARNING, "Cannot retrieve data for export", ex);
+      return null;
+    }
   }
 
   public void addAxesRangeChangedListener(AxesRangeChangedListener l) {

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/gui/swing/EChartPanel.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/gui/swing/EChartPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,6 +25,17 @@
 
 package io.github.mzmine.gui.chartbasics.gui.swing;
 
+import io.github.mzmine.gui.chartbasics.JFreeChartUtils;
+import io.github.mzmine.gui.chartbasics.gestures.ChartGestureHandler;
+import io.github.mzmine.gui.chartbasics.gestures.interf.GestureHandlerFactory;
+import io.github.mzmine.gui.chartbasics.graphicsexport.ChartExportUtil;
+import io.github.mzmine.gui.chartbasics.gui.swing.menu.JMenuExportToClipboard;
+import io.github.mzmine.gui.chartbasics.gui.swing.menu.JMenuExportToExcel;
+import io.github.mzmine.gui.chartbasics.gui.wrapper.ChartViewWrapper;
+import io.github.mzmine.gui.chartbasics.listener.AxesRangeChangedListener;
+import io.github.mzmine.gui.chartbasics.listener.AxisRangeChangedListener;
+import io.github.mzmine.gui.chartbasics.listener.ZoomHistory;
+import io.github.mzmine.util.io.XSSFExcelWriterReader;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,17 +59,6 @@ import org.jfree.data.Range;
 import org.jfree.data.RangeType;
 import org.jfree.data.xy.XYDataset;
 import org.jfree.data.xy.XYZDataset;
-
-import io.github.mzmine.gui.chartbasics.gestures.ChartGestureHandler;
-import io.github.mzmine.gui.chartbasics.gestures.interf.GestureHandlerFactory;
-import io.github.mzmine.gui.chartbasics.graphicsexport.ChartExportUtil;
-import io.github.mzmine.gui.chartbasics.gui.swing.menu.JMenuExportToClipboard;
-import io.github.mzmine.gui.chartbasics.gui.swing.menu.JMenuExportToExcel;
-import io.github.mzmine.gui.chartbasics.gui.wrapper.ChartViewWrapper;
-import io.github.mzmine.gui.chartbasics.listener.AxesRangeChangedListener;
-import io.github.mzmine.gui.chartbasics.listener.AxisRangeChangedListener;
-import io.github.mzmine.gui.chartbasics.listener.ZoomHistory;
-import io.github.mzmine.util.io.XSSFExcelWriterReader;
 
 /**
  * Enhanced ChartPanel with extra chart gestures (drag mouse over entities (e.g., axis, titles)
@@ -281,12 +281,12 @@ public class EChartPanel extends ChartPanel {
    * @return Data array[columns][rows]
    */
   public Object[][] getDataArrayForExport() {
-    if (getChart().getPlot() instanceof XYPlot && getChart().getXYPlot() != null
-        && getChart().getXYPlot().getDataset() != null) {
+    if (getChart().getPlot() instanceof XYPlot plot) {
       try {
         List<Object[]> modelList = new ArrayList<>();
 
-        for (int d = 0; d < getChart().getXYPlot().getDatasetCount(); d++) {
+        int numDatasets = JFreeChartUtils.getDatasetCountNullable(plot);
+        for (int d = 0; d < numDatasets; d++) {
           XYDataset data = getChart().getXYPlot().getDataset(d);
           if (data instanceof XYZDataset) {
             XYZDataset xyz = (XYZDataset) data;

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/SimpleXYZScatterPlot.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/SimpleXYZScatterPlot.java
@@ -25,6 +25,7 @@
 
 package io.github.mzmine.gui.chartbasics.simplechart;
 
+import io.github.mzmine.gui.chartbasics.JFreeChartUtils;
 import io.github.mzmine.gui.chartbasics.chartthemes.EStandardChartTheme;
 import io.github.mzmine.gui.chartbasics.gui.javafx.EChartViewer;
 import io.github.mzmine.gui.chartbasics.listener.RegionSelectionListener;
@@ -427,7 +428,8 @@ public class SimpleXYZScatterPlot<T extends PlotXYZDataProvider> extends EChartV
     // mabye there is a more efficient way of searching for the selected value index.
     int index = -1;
     int datasetIndex = -1;
-    for (int i = 0; i < plot.getDatasetCount(); i++) {
+    int numDatasets = JFreeChartUtils.getDatasetCountNullable(plot);
+    for (int i = 0; i < numDatasets; i++) {
       XYDataset dataset = plot.getDataset(i);
       if (dataset instanceof ColoredXYZDataset) {
         index = ((ColoredXYZDataset) dataset).getValueIndex(domainValue, rangeValue);
@@ -610,8 +612,8 @@ public class SimpleXYZScatterPlot<T extends PlotXYZDataProvider> extends EChartV
   @Override
   public LinkedHashMap<Integer, XYDataset> getAllDatasets() {
     final LinkedHashMap<Integer, XYDataset> datasetMap = new LinkedHashMap<>();
-
-    for (int i = 0; i < plot.getDatasetCount(); i++) {
+    int numDatasets = JFreeChartUtils.getDatasetCountNullable(plot);
+    for (int i = 0; i < numDatasets; i++) {
       XYDataset dataset = plot.getDataset(i);
       if (dataset != null) {
         datasetMap.put(i, dataset);

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/generators/SimpleXYLabelGenerator.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/generators/SimpleXYLabelGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,6 +25,7 @@
 
 package io.github.mzmine.gui.chartbasics.simplechart.generators;
 
+import io.github.mzmine.gui.chartbasics.JFreeChartUtils;
 import io.github.mzmine.gui.chartbasics.gui.javafx.EChartViewer;
 import io.github.mzmine.gui.chartbasics.simplechart.SimpleChartUtility;
 import io.github.mzmine.gui.chartbasics.simplechart.datasets.ColoredXYDataset;
@@ -95,13 +96,14 @@ public class SimpleXYLabelGenerator implements XYItemLabelGenerator {
     double yLength = (double) plot.getRangeAxis().getRange().getLength();
     double pixelY = yLength / chart.getHeight();
 
-    ArrayList<ColoredXYDataset> allDataSets = new ArrayList<ColoredXYDataset>();
+    ArrayList<ColoredXYDataset> allDataSets = new ArrayList<>();
 
     // Get all data sets of current plot
-    for (int i = 0; i < plot.getDatasetCount(); i++) {
+    int numDatasets = JFreeChartUtils.getDatasetCountNullable(plot);
+    for (int i = 0; i < numDatasets; i++) {
       XYDataset dataset = plot.getDataset(i);
-      if (dataset instanceof ColoredXYDataset) {
-        allDataSets.add((ColoredXYDataset) dataset);
+      if (dataset instanceof ColoredXYDataset cdata) {
+        allDataSets.add(cdata);
       }
     }
 
@@ -109,8 +111,8 @@ public class SimpleXYLabelGenerator implements XYItemLabelGenerator {
     for (ColoredXYDataset checkedDataSet : allDataSets) {
 
       // Search for local maxima
-      double searchMinX = originalX - (POINTS_RESERVE_X / 2) * pixelX;
-      double searchMaxX = originalX + (POINTS_RESERVE_X / 2) * pixelX;
+      double searchMinX = originalX - (POINTS_RESERVE_X / 2f) * pixelX;
+      double searchMaxX = originalX + (POINTS_RESERVE_X / 2f) * pixelX;
       double searchMinY = originalY;
       double searchMaxY = originalY + POINTS_RESERVE_Y * pixelY;
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/charts/ChartUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/charts/ChartUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,6 +25,7 @@
 
 package io.github.mzmine.modules.dataprocessing.featdet_masscalibration.charts;
 
+import io.github.mzmine.gui.chartbasics.JFreeChartUtils;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.dataprocessing.featdet_masscalibration.MassPeakMatch;
 import java.awt.BasicStroke;
@@ -61,8 +62,10 @@ public class ChartUtils {
   }
 
   public static void cleanPlot(XYPlot plot) {
-    for (int i = 0; i < plot.getDatasetCount(); i++) {
+    int numDatasets = JFreeChartUtils.getDatasetCountNullable(plot);
+    for (int i = 0; i < numDatasets; i++) {
       plot.setDataset(i, null);
+      plot.setRenderer(i, null);
     }
     plot.clearRangeMarkers();
     plot.clearAnnotations();
@@ -92,7 +95,7 @@ public class ChartUtils {
     NumberFormat ppmFormat = MZmineCore.getConfiguration().getPPMFormat();
     String tooltipText = String.format(
         "Measured-matched m/z: %s-%s" + "\nMeasured-matched RT: %s-%s" + "\nMass error: %s %s"
-            + "\nMass peak intensity: %s" + "\nScan number: %s",
+        + "\nMass peak intensity: %s" + "\nScan number: %s",
         mzFormat.format(match.getMeasuredMzRatio()), mzFormat.format(match.getMatchedMzRatio()),
         rtFormat.format(match.getMeasuredRetentionTime()),
         match.getMatchedRetentionTime() == -1 ? "none"

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICItemLabelGenerator.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICItemLabelGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,12 +25,11 @@
 
 package io.github.mzmine.modules.visualization.chromatogram;
 
+import io.github.mzmine.gui.chartbasics.JFreeChartUtils;
+import io.github.mzmine.main.MZmineCore;
 import java.util.ArrayList;
-
 import org.jfree.chart.labels.XYItemLabelGenerator;
 import org.jfree.data.xy.XYDataset;
-
-import io.github.mzmine.main.MZmineCore;
 
 /**
  * Item label generator for TIC visualizer
@@ -91,26 +90,28 @@ class TICItemLabelGenerator implements XYItemLabelGenerator {
       return null;
 
     // Calculate data size of 1 screen pixel
-    double xLength = (double) plot.getXYPlot().getDomainAxis().getRange().getLength();
+    var xyPlot = plot.getXYPlot();
+    double xLength = (double) xyPlot.getDomainAxis().getRange().getLength();
     double pixelX = xLength / plot.getWidth();
-    double yLength = (double) plot.getXYPlot().getRangeAxis().getRange().getLength();
+    double yLength = (double) xyPlot.getRangeAxis().getRange().getLength();
     double pixelY = yLength / plot.getHeight();
 
-    ArrayList<TICDataSet> allDataSets = new ArrayList<TICDataSet>();
+    ArrayList<TICDataSet> allDataSets = new ArrayList<>();
 
     // Get all data sets of current plot
-    for (int i = 0; i < plot.getXYPlot().getDatasetCount(); i++) {
-      XYDataset dataset = plot.getXYPlot().getDataset(i);
-      if (dataset instanceof TICDataSet)
-        allDataSets.add((TICDataSet) dataset);
+    int numDatasets = JFreeChartUtils.getDatasetCountNullable(xyPlot);
+    for (int i = 0; i < numDatasets; i++) {
+      XYDataset dataset = xyPlot.getDataset(i);
+      if (dataset instanceof TICDataSet ticData)
+        allDataSets.add(ticData);
     }
 
     // Check each data set for conflicting data points
     for (TICDataSet checkedDataSet : allDataSets) {
 
       // Search for local maxima
-      double searchMinX = originalX - (POINTS_RESERVE_X / 2) * pixelX;
-      double searchMaxX = originalX + (POINTS_RESERVE_X / 2) * pixelX;
+      double searchMinX = originalX - (POINTS_RESERVE_X / 2d) * pixelX;
+      double searchMaxX = originalX + (POINTS_RESERVE_X / 2d) * pixelX;
       double searchMinY = originalY;
       double searchMaxY = originalY + POINTS_RESERVE_Y * pixelY;
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICVisualizerTab.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICVisualizerTab.java
@@ -33,6 +33,7 @@ import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.gui.MZmineDesktop;
+import io.github.mzmine.gui.chartbasics.JFreeChartUtils;
 import io.github.mzmine.gui.mainwindow.MZmineTab;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.visualization.spectra.simplespectra.SpectraVisualizerModule;
@@ -253,7 +254,8 @@ public class TICVisualizerTab extends MZmineTab {
 
           // Find index value
           int index = -1;
-          for (int i = 0; i < plot.getDatasetCount(); i++) {
+          int numDatasets = JFreeChartUtils.getDatasetCountNullable(plot);
+          for (int i = 0; i < numDatasets; i++) {
             if (rendererAll.getLegendItem(i, 1) != null && rendererAll.getLegendItem(i, 1)
                 .getDescription().equals(itemEntity.getSeriesKey())) {
               index = i;

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/scan_histogram/chart/HistogramPanel.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/scan_histogram/chart/HistogramPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -521,9 +521,9 @@ public class HistogramPanel extends BorderPane {
   }
 
   protected void hideGaussianCurve(XYPlot p) {
-    if (p.getDatasetCount() > 1) {
-      p.setRenderer(p.getDatasetCount() - 1, null);
-      p.setDataset(p.getDatasetCount() - 1, null);
+    if (p.getDatasets().size() > 1) {
+      p.setRenderer(p.getDatasets().size() - 1, null);
+      p.setDataset(p.getDatasets().size() - 1, null);
     }
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/spectra/msn_tree/MSnTreeTab.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/spectra/msn_tree/MSnTreeTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -36,6 +36,7 @@ import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.impl.SimpleDataPoint;
 import io.github.mzmine.datamodel.msms.MsMsInfo;
+import io.github.mzmine.gui.chartbasics.JFreeChartUtils;
 import io.github.mzmine.gui.chartbasics.chartgroups.ChartGroup;
 import io.github.mzmine.gui.chartbasics.gui.wrapper.ChartViewWrapper;
 import io.github.mzmine.gui.mainwindow.SimpleTab;
@@ -109,6 +110,7 @@ import javafx.scene.layout.RowConstraints;
 import javafx.scene.text.Text;
 import org.jetbrains.annotations.NotNull;
 import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.plot.XYPlot;
 import org.jfree.data.xy.AbstractXYDataset;
 import org.jfree.data.xy.XYDataset;
 
@@ -347,8 +349,10 @@ public class MSnTreeTab extends SimpleTab {
     circle = new Ellipse2D.Double(-size / 2d, 0, size, size);
 
     for (var p : spectraPlots) {
-      for (int i = 0; i < p.getXYPlot().getDatasetCount(); i++) {
-        final var renderer = p.getXYPlot().getRenderer(i);
+      XYPlot xyPlot = p.getXYPlot();
+      int numDatasets = JFreeChartUtils.getDatasetCountNullable(xyPlot);
+      for (int i = 0; i < numDatasets; i++) {
+        final var renderer = xyPlot.getRenderer(i);
         if (renderer instanceof ArrowRenderer arrowRenderer) {
           final ShapeType type = arrowRenderer.getShapeType();
           renderer.setDefaultShape(getShape(type));
@@ -373,7 +377,8 @@ public class MSnTreeTab extends SimpleTab {
     if (currentRoot != null) {
       final boolean normalize = cbRelative.isSelected();
       for (var p : spectraPlots) {
-        for (int i = 0; i < p.getXYPlot().getDatasetCount(); i++) {
+        int numDatasets = JFreeChartUtils.getDatasetCountNullable(p.getXYPlot());
+        for (int i = 0; i < numDatasets; i++) {
           final XYDataset data = p.getXYPlot().getDataset(i);
           if (data instanceof RelativeOption op) {
             op.setRelative(normalize);

--- a/mzmine-community/src/main/java/io/github/mzmine/util/SpectraPlotUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/SpectraPlotUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,10 +25,10 @@
 
 package io.github.mzmine.util;
 
+import io.github.mzmine.gui.chartbasics.JFreeChartUtils;
+import io.github.mzmine.modules.visualization.spectra.simplespectra.SpectraPlot;
 import java.util.List;
 import org.jfree.data.xy.XYDataset;
-
-import io.github.mzmine.modules.visualization.spectra.simplespectra.SpectraPlot;
 
 public class SpectraPlotUtils {
 
@@ -40,13 +40,16 @@ public class SpectraPlotUtils {
    */
   public static void clearDatasetLabelGenerators(SpectraPlot plot,
       List<Class<? extends XYDataset>> ignore) {
-    for (int i = 0; i < plot.getXYPlot().getDatasetCount(); i++) {
+    int numDatasets = JFreeChartUtils.getDatasetCountNullable(plot.getXYPlot());
+    for (int i = 0; i < numDatasets; i++) {
       XYDataset dataset = plot.getXYPlot().getDataset(i);
       // check if object of dataset is an instance of ignore.class
       boolean remove = true;
       for (Class<? extends XYDataset> datasetClass : ignore) {
-        if ((datasetClass.isInstance(dataset)))
+        if ((datasetClass.isInstance(dataset))) {
           remove = false;
+          break;
+        }
       }
 
       if (remove)
@@ -62,7 +65,8 @@ public class SpectraPlotUtils {
    */
   public static void clearDatasetLabelGenerators(SpectraPlot plot,
       Class<? extends XYDataset> ignore) {
-    for (int i = 0; i < plot.getXYPlot().getDatasetCount(); i++) {
+    int numDatasets = JFreeChartUtils.getDatasetCountNullable(plot.getXYPlot());
+    for (int i = 0; i < numDatasets; i++) {
       XYDataset dataset = plot.getXYPlot().getDataset(i);
       // check if object of dataset is an instance of ignore.class
       if (!(ignore.isInstance(dataset)))


### PR DESCRIPTION
plot.getDatasetCount returns the non null count of datasets (actual)
this must have been different before. We experiences some issues in the TICPlot not deleting old datasets. 

Added utils to get the NotNull or Nullable count of datasets.

There is no way of deleting datasets from jfreechart so we set them null