### PR TITLE
Close zip inflater in MzMLPeaksDecoder

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/msdk/data/MzMLPeaksDecoder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/msdk/data/MzMLPeaksDecoder.java
@@ -313,6 +313,7 @@ public class MzMLPeaksDecoder {
           }
           bos.write(buf, 0, count);
         } catch (DataFormatException e) {
+          decompressor.end();
           throw new IllegalStateException(
               "Encountered wrong data format " + "while trying to decompress binary data!", e);
         }
@@ -320,11 +321,11 @@ public class MzMLPeaksDecoder {
 
       // Get the decompressed data
       decompressedData = bos.toByteArray();
-      decompressor.end();
     } catch (IOException e) {
       // ToDo: add logging
       e.printStackTrace();
     }
+    decompressor.end();
     if (decompressedData == null) {
       throw new IllegalStateException("Decompression of binary data produced no result (null)!");
     }


### PR DESCRIPTION
Most likely this was no issue. Still added a close operation to the zip inflater.

