### PR TITLE
Add NumberFormatType and change NumberType to T extends Number

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/fx/DataTypeCellFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/fx/DataTypeCellFactory.java
@@ -28,15 +28,12 @@ package io.github.mzmine.datamodel.features.types.fx;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.types.DataType;
-import io.github.mzmine.datamodel.features.types.LinkedGraphicalType;
-import io.github.mzmine.datamodel.features.types.modifiers.GraphicalColumType;
 import io.github.mzmine.datamodel.features.types.modifiers.SubColumnsFactory;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.NumberRangeType;
-import io.github.mzmine.datamodel.features.types.numbers.abstr.NumberType;
+import io.github.mzmine.datamodel.features.types.numbers.abstr.NumberFormatType;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.geometry.Pos;
-import javafx.scene.Node;
 import javafx.scene.control.TreeTableCell;
 import javafx.scene.control.TreeTableColumn;
 import javafx.util.Callback;
@@ -106,7 +103,7 @@ public class DataTypeCellFactory implements
           }
 
 
-          if (type instanceof NumberType) {
+          if (type instanceof NumberFormatType) {
             setAlignment(Pos.CENTER_RIGHT);
             setGraphic(null);
           } else {

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/fx/EditComboCellFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/fx/EditComboCellFactory.java
@@ -33,7 +33,7 @@ import io.github.mzmine.datamodel.features.types.modifiers.AddElementDialog;
 import io.github.mzmine.datamodel.features.types.modifiers.GraphicalColumType;
 import io.github.mzmine.datamodel.features.types.modifiers.SubColumnsFactory;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.ListDataType;
-import io.github.mzmine.datamodel.features.types.numbers.abstr.NumberType;
+import io.github.mzmine.datamodel.features.types.numbers.abstr.NumberFormatType;
 import java.util.ArrayList;
 import java.util.List;
 import javafx.geometry.Pos;
@@ -137,7 +137,7 @@ public class EditComboCellFactory implements
             setGraphic(null);
           }
         }
-        if (type instanceof NumberType) {
+        if (type instanceof NumberFormatType) {
           setAlignment(Pos.CENTER_RIGHT);
         } else {
           setAlignment(Pos.CENTER);

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/SimpleStatisticsType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/SimpleStatisticsType.java
@@ -36,7 +36,7 @@ import io.github.mzmine.datamodel.features.types.DataType;
 import io.github.mzmine.datamodel.features.types.fx.DataTypeCellFactory;
 import io.github.mzmine.datamodel.features.types.fx.DataTypeCellValueFactory;
 import io.github.mzmine.datamodel.features.types.modifiers.SubColumnsFactory;
-import io.github.mzmine.datamodel.features.types.numbers.abstr.NumberType;
+import io.github.mzmine.datamodel.features.types.numbers.abstr.NumberFormatType;
 import io.github.mzmine.datamodel.features.types.numbers.stats.MaximumType;
 import io.github.mzmine.datamodel.features.types.numbers.stats.MeanType;
 import io.github.mzmine.datamodel.features.types.numbers.stats.MinimumType;
@@ -53,7 +53,7 @@ import javax.xml.stream.XMLStreamWriter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public abstract class SimpleStatisticsType extends NumberType<SimpleStatistics> implements
+public abstract class SimpleStatisticsType extends NumberFormatType<SimpleStatistics> implements
     SubColumnsFactory {
 
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/abstr/LongType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/abstr/LongType.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2004-2022 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.datamodel.features.types.numbers.abstr;
+
+import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.features.ModularDataModel;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import io.github.mzmine.datamodel.features.types.modifiers.BindingsType;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.List;
+import javafx.beans.property.Property;
+import javafx.beans.property.SimpleObjectProperty;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public abstract class LongType extends NumberType<Long> {
+
+  protected LongType() {
+    super(new DecimalFormat("0"));
+  }
+
+  @Override
+  public NumberFormat getFormat() {
+    return DEFAULT_FORMAT;
+  }
+
+  @Override
+  public NumberFormat getExportFormat() {
+    return DEFAULT_FORMAT;
+  }
+
+  @Override
+  public Class<Long> getValueClass() {
+    return Long.class;
+  }
+
+  public @NotNull String getFormattedString(int value) {
+    return getFormat().format(value);
+  }
+
+  @Override
+  public Property<Long> createProperty() {
+    return new SimpleObjectProperty<>();
+  }
+
+  @Override
+  public void saveToXML(@NotNull XMLStreamWriter writer, @Nullable Object value,
+      @NotNull ModularFeatureList flist, @NotNull ModularFeatureListRow row,
+      @Nullable ModularFeature feature, @Nullable RawDataFile file) throws XMLStreamException {
+    if (value == null) {
+      return;
+    }
+    if (!(value instanceof Long)) {
+      throw new IllegalArgumentException(
+          "Wrong value type for data type: " + this.getClass().getName() + " value class: "
+              + value.getClass());
+    }
+    writer.writeCharacters(String.valueOf(value));
+  }
+
+  @Override
+  public Object loadFromXML(@NotNull XMLStreamReader reader, @NotNull MZmineProject project,
+      @NotNull ModularFeatureList flist, @NotNull ModularFeatureListRow row,
+      @Nullable ModularFeature feature, @Nullable RawDataFile file) throws XMLStreamException {
+    String str = reader.getElementText();
+    if (str == null || str.isEmpty()) {
+      return null;
+    }
+    return Long.parseLong(str);
+  }
+
+  @Override
+  public Object evaluateBindings(@NotNull BindingsType bindingType,
+      @NotNull List<? extends ModularDataModel> models) {
+    Object result = super.evaluateBindings(bindingType, models);
+    if (result == null) {
+      // general cases here - special cases handled in other classes
+      switch (bindingType) {
+        case AVERAGE: {
+          // calc average center of ranges
+          int mean = 0;
+          int c = 0;
+          for (var model : models) {
+            Long value = model.get(this);
+            if (value != null) {
+              mean += value;
+              c++;
+            }
+          }
+          return c == 0 ? 0f : mean / (double) c;
+        }
+        case SUM, CONSENSUS: {
+          // calc average center of ranges
+          int sum = 0;
+          for (var model : models) {
+            Long value = model.get(this);
+            if (value != null) {
+              sum += value;
+            }
+          }
+          return sum;
+        }
+        case RANGE: {
+          // calc average center of ranges
+          Range<Long> range = null;
+          for (var model : models) {
+            Long value = model.get(this);
+            if (value != null) {
+              if (range == null) {
+                range = Range.singleton(value);
+              } else {
+                range.span(Range.singleton(value));
+              }
+            }
+          }
+          return range;
+        }
+        case MIN: {
+          // calc average center of ranges
+          Long min = null;
+          for (var model : models) {
+            Long value = model.get(this);
+            if (value != null && (min == null || value < min)) {
+              min = value;
+            }
+          }
+          return min;
+        }
+        case MAX: {
+          // calc average center of ranges
+          Long max = null;
+          for (var model : models) {
+            Long value = model.get(this);
+            if (value != null && (max == null || value > max)) {
+              max = value;
+            }
+          }
+          return max;
+        }
+      }
+    }
+    return result;
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/abstr/NumberFormatType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/abstr/NumberFormatType.java
@@ -25,29 +25,29 @@
 
 package io.github.mzmine.datamodel.features.types.numbers.abstr;
 
-import com.google.common.collect.Range;
-import io.github.mzmine.datamodel.RawDataFile;
-import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.types.DataType;
-import io.github.mzmine.datamodel.features.types.fx.DataTypeCellFactory;
-import io.github.mzmine.datamodel.features.types.fx.DataTypeCellValueFactory;
-import io.github.mzmine.datamodel.features.types.modifiers.SubColumnsFactory;
-import io.github.mzmine.datamodel.features.types.numbers.MZType;
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.List;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.scene.control.TreeTableColumn;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-public abstract class NumberType<T extends Number & Comparable<?>> extends
-    NumberFormatType<T> {
+public abstract class NumberFormatType<T> extends DataType<T> {
 
-  protected NumberType(NumberFormat defaultFormat) {
-    super(defaultFormat);
+  protected final NumberFormat DEFAULT_FORMAT;
+
+  protected NumberFormatType(NumberFormat defaultFormat) {
+    DEFAULT_FORMAT = defaultFormat;
   }
 
+  public abstract NumberFormat getFormat();
+
+  public abstract NumberFormat getExportFormat();
+
+  public NumberFormat getFormat(boolean export) {
+    return export ? getExportFormat() : getFormat();
+  }
+
+  @Override
+  public @NotNull String getFormattedString(final T value, final boolean export) {
+    return value != null ? getFormat(export).format(value) : "";
+  }
 
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/abstr/NumberFormatType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/abstr/NumberFormatType.java
@@ -29,6 +29,12 @@ import io.github.mzmine.datamodel.features.types.DataType;
 import java.text.NumberFormat;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * A DataType that has a NumberFormat to format its content. May be a simple number or Range or
+ * complex object resolving to numbers.
+ *
+ * @param <T> any
+ */
 public abstract class NumberFormatType<T> extends DataType<T> {
 
   protected final NumberFormat DEFAULT_FORMAT;

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/abstr/NumberRangeType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/abstr/NumberRangeType.java
@@ -43,7 +43,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class NumberRangeType<T extends Number & Comparable<?>> extends
-    NumberType<Range<T>> implements SubColumnsFactory {
+    NumberFormatType<Range<T>> implements SubColumnsFactory {
 
   // this is a trick, we need a datatype to get the sub column value
   // we use this as the first column and any other for the second

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/abstr/NumberType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/numbers/abstr/NumberType.java
@@ -25,25 +25,15 @@
 
 package io.github.mzmine.datamodel.features.types.numbers.abstr;
 
-import com.google.common.collect.Range;
-import io.github.mzmine.datamodel.RawDataFile;
-import io.github.mzmine.datamodel.features.ModularFeatureListRow;
-import io.github.mzmine.datamodel.features.types.DataType;
-import io.github.mzmine.datamodel.features.types.fx.DataTypeCellFactory;
-import io.github.mzmine.datamodel.features.types.fx.DataTypeCellValueFactory;
-import io.github.mzmine.datamodel.features.types.modifiers.SubColumnsFactory;
-import io.github.mzmine.datamodel.features.types.numbers.MZType;
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.List;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.scene.control.TreeTableColumn;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-public abstract class NumberType<T extends Number & Comparable<?>> extends
-    NumberFormatType<T> {
+/**
+ * Simple Number Type for anything that inherits from Number. This is useful for instanceof checks
+ * when iterating over data types.
+ *
+ * @param <T> a number
+ */
+public abstract class NumberType<T extends Number & Comparable<?>> extends NumberFormatType<T> {
 
   protected NumberType(NumberFormat defaultFormat) {
     super(defaultFormat);


### PR DESCRIPTION
NubmerFromatType is now just a type that contaisn a number format. 

NumberType (maybe we rename it to SimpleNumberType) is the parent of DoubleType, IntType etc. This way we can get a number from
ModularDataModel.get(anyNumberType.class) --> is Number 