### PR TITLE
Use MSConvert for import of currently unsupported vendor files

### DIFF
--- a/javafx-framework/src/main/java/io/github/mzmine/javafx/util/FxFileChooser.java
+++ b/javafx-framework/src/main/java/io/github/mzmine/javafx/util/FxFileChooser.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2004-2024 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.javafx.util;
+
+import java.io.File;
+import java.util.List;
+import javafx.stage.FileChooser;
+import javafx.stage.FileChooser.ExtensionFilter;
+import org.jetbrains.annotations.Nullable;
+
+public class FxFileChooser {
+
+  public enum FileSelectionType {
+    OPEN, SAVE
+  }
+
+  public static File openSelectDialog(final FileSelectionType type,
+      final List<ExtensionFilter> filters, @Nullable File initialDir) {
+    // Create chooser.
+    FileChooser fileChooser = new FileChooser();
+    fileChooser.setTitle("Select file");
+    if (filters != null) {
+      fileChooser.getExtensionFilters().addAll(filters);
+    }
+
+    // Set current directory.
+    try {
+      if (initialDir != null) {
+        final File currentDir = initialDir.getParentFile();
+        if (currentDir != null && currentDir.exists()) {
+          fileChooser.setInitialDirectory(currentDir);
+        }
+      }
+    } catch (Exception _) {
+    }
+
+    // Open chooser.
+    File selectedFile = null;
+    if (type == FxFileChooser.FileSelectionType.OPEN) {
+      selectedFile = fileChooser.showOpenDialog(null);
+    } else {
+      selectedFile = fileChooser.showSaveDialog(null);
+    }
+    return selectedFile;
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/MZmineGUI.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/MZmineGUI.java
@@ -62,6 +62,7 @@ import io.github.mzmine.project.impl.ProjectChangeListener;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.GUIUtils;
+import io.github.mzmine.util.files.ExtensionFilters;
 import io.github.mzmine.util.io.SemverVersionReader;
 import io.github.mzmine.util.javafx.groupablelistview.GroupableListView;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibrary;
@@ -309,8 +310,8 @@ public class MZmineGUI extends Application implements MZmineDesktop, JavaFxDeskt
     if (dragboard.hasFiles()) {
       hasFileDropped = true;
 
-      final List<String> rawExtensions = List.of("mzml", "mzxml", "raw", "cdf", "netcdf", "nc",
-          "mzdata", "imzml", "tdf", "d", "tsf", "zip", "gz");
+      final List<String> rawExtensions = ExtensionFilters.ALL_MS_DATA_FILTER.getExtensions()
+          .stream().map(e -> e.replaceAll("\\*\\.", "")).toList();
       final List<String> libraryExtensions = List.of("json", "mgf", "msp", "jdx");
 
       final List<File> rawDataFiles = new ArrayList<>();
@@ -369,13 +370,11 @@ public class MZmineGUI extends Application implements MZmineDesktop, JavaFxDeskt
       if (!rawDataFiles.isEmpty() || !libraryFiles.isEmpty()) {
         if (!rawDataFiles.isEmpty()) {
           logger.finest(() -> "Importing " + rawDataFiles.size() + " raw files via drag and drop: "
-                              + rawDataFiles.stream().map(File::getAbsolutePath)
-                                  .collect(Collectors.joining(", ")));
+              + rawDataFiles.stream().map(File::getAbsolutePath).collect(Collectors.joining(", ")));
         }
         if (!libraryFiles.isEmpty()) {
           logger.finest(() -> "Importing " + libraryFiles.size() + " raw files via drag and drop: "
-                              + libraryFiles.stream().map(File::getAbsolutePath)
-                                  .collect(Collectors.joining(", ")));
+              + libraryFiles.stream().map(File::getAbsolutePath).collect(Collectors.joining(", ")));
         }
 
         // set raw and library files to parameter
@@ -685,7 +684,7 @@ public class MZmineGUI extends Application implements MZmineDesktop, JavaFxDeskt
       stage.getIcons().add(mzMineIcon);
       dialog.setTitle(title);
 
-      TextFlow flow = new TextFlow(new Text(msg));
+      TextFlow flow = new TextFlow(new Text(msg + " "));
       if (url != null) {
         Hyperlink href = new Hyperlink(url);
         flow.getChildren().add(href);

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/preferences/MZminePreferences.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/preferences/MZminePreferences.java
@@ -253,8 +253,7 @@ public class MZminePreferences extends SimpleParameterSet {
     GroupedParameterSetupDialog dialog = new GroupedParameterSetupDialog(valueCheckRequired, this);
 
     // add groups
-    dialog.addParameterGroup("General", numOfThreads, memoryOption, tempDirectory, proxySettings,
-        msConvertPath
+    dialog.addParameterGroup("General", numOfThreads, memoryOption, tempDirectory, proxySettings
         /*, applyTimsPressureCompensation*/);
     dialog.addParameterGroup("Formats", mzFormat, rtFormat, mobilityFormat, ccsFormat,
         intensityFormat, ppmFormat, scoreFormat, unitFormat);

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/preferences/MZminePreferences.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/preferences/MZminePreferences.java
@@ -30,7 +30,6 @@ import io.github.mzmine.gui.chartbasics.chartutils.paintscales.PaintScaleTransfo
 import io.github.mzmine.main.ConfigService;
 import io.github.mzmine.main.KeepInMemory;
 import io.github.mzmine.main.MZmineCore;
-import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.dialogs.GroupedParameterSetupDialog;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
@@ -43,12 +42,15 @@ import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.WindowSettingsParameter;
 import io.github.mzmine.parameters.parametertypes.colorpalette.ColorPaletteParameter;
 import io.github.mzmine.parameters.parametertypes.filenames.DirectoryParameter;
+import io.github.mzmine.parameters.parametertypes.filenames.FileNameParameter;
+import io.github.mzmine.parameters.parametertypes.filenames.FileSelectionType;
 import io.github.mzmine.parameters.parametertypes.paintscale.PaintScalePaletteParameter;
 import io.github.mzmine.parameters.parametertypes.submodules.OptionalModuleParameter;
 import io.github.mzmine.parameters.parametertypes.submodules.ParameterSetParameter;
 import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.StringUtils;
 import io.github.mzmine.util.color.ColorUtils;
+import io.github.mzmine.util.files.ExtensionFilters;
 import io.github.mzmine.util.files.FileAndPathUtil;
 import io.github.mzmine.util.web.Proxy;
 import io.github.mzmine.util.web.ProxyType;
@@ -56,6 +58,7 @@ import io.github.mzmine.util.web.ProxyUtils;
 import io.mzio.users.gui.fx.UsersController;
 import java.io.File;
 import java.text.DecimalFormat;
+import java.util.List;
 import java.util.Map;
 import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
@@ -140,24 +143,24 @@ public class MZminePreferences extends SimpleParameterSet {
   public static final HiddenParameter<Map<String, Boolean>> imsModuleWarnings = new HiddenParameter<>(
       new OptOutParameter("Ion mobility compatibility warnings",
           "Shows a warning message when a module without explicit ion mobility support is "
-          + "used to process ion mobility data."));
+              + "used to process ion mobility data."));
 
   public static final DirectoryParameter tempDirectory = new DirectoryParameter(
       "Temporary file directory", "Directory where temporary files"
-                                  + " will be stored. Directory should be located on a drive with fast read and write "
-                                  + "(e.g., an SSD). Requires a restart of MZmine to take effect (the program argument --temp "
-                                  + "overrides this parameter, if set: --temp D:\\your_tmp_dir\\)",
+      + " will be stored. Directory should be located on a drive with fast read and write "
+      + "(e.g., an SSD). Requires a restart of MZmine to take effect (the program argument --temp "
+      + "overrides this parameter, if set: --temp D:\\your_tmp_dir\\)",
       System.getProperty("java.io.tmpdir"));
 
   public static final ComboParameter<KeepInMemory> memoryOption = new ComboParameter<>(
       "Keep in memory", String.format(
       "Specifies the objects that are kept in memory rather than memory mapping "
-      + "them into temp files in the temp directory. Parameter is overriden by the program "
-      + "argument --memory. Depending on the read/write speed of the temp directory,"
-      + " memory mapping is a fast and memory efficient way to handle data, therefore, the "
-      + "default is to memory map all spectral data and feature data with the option %s. On "
-      + "systems where memory (RAM) is no concern, viable options are %s and %s, to keep all in memory "
-      + "or to keep mass lists and feauture data in memory, respectively.", KeepInMemory.NONE,
+          + "them into temp files in the temp directory. Parameter is overriden by the program "
+          + "argument --memory. Depending on the read/write speed of the temp directory,"
+          + " memory mapping is a fast and memory efficient way to handle data, therefore, the "
+          + "default is to memory map all spectral data and feature data with the option %s. On "
+          + "systems where memory (RAM) is no concern, viable options are %s and %s, to keep all in memory "
+          + "or to keep mass lists and feauture data in memory, respectively.", KeepInMemory.NONE,
       KeepInMemory.ALL, KeepInMemory.MASSES_AND_FEATURES), KeepInMemory.values(),
       KeepInMemory.NONE);
 
@@ -179,7 +182,7 @@ public class MZminePreferences extends SimpleParameterSet {
   public static final ComboParameter<ImageNormalization> imageNormalization = new ComboParameter<ImageNormalization>(
       "Normalize images",
       "Specifies if displayed images shall be normalized to the average TIC or shown according to the raw data."
-      + "only applies to newly generated plots.", ImageNormalization.values(),
+          + "only applies to newly generated plots.", ImageNormalization.values(),
       ImageNormalization.NO_NORMALIZATION);
 
   public static final ComboParameter<PaintScaleTransform> imageTransformation = new ComboParameter<>(
@@ -192,6 +195,22 @@ public class MZminePreferences extends SimpleParameterSet {
       new DecimalFormat("0.###"), UnitFormat.DIVIDE);
   private final BooleanProperty darkModeProperty = new SimpleBooleanProperty(false);
   private NumberFormats guiFormat = exportFormat; // default value
+
+  public static final FileNameParameter msConvertPath = new FileNameParameter("MSConvert path",
+      "Set a path to MSConvert to automatically convert unknown vendor formats to mzML while importing.",
+      List.of(ExtensionFilters.EXE, ExtensionFilters.ALL_FILES), FileSelectionType.OPEN, true);
+
+  public static final BooleanParameter keepConvertedFile = new BooleanParameter(
+      "Keep files converted by MSConvert",
+      "Store the files after conversion by MSConvert to an mzML file.\n"
+          + "This will reduce the import time when re-processing, but require more disc space.",
+      false);
+
+  public static final BooleanParameter applyPeakPicking = new BooleanParameter(
+      "Apply peak picking (recommended)",
+      "Apply vendor peak picking during import of native vendor files with MSConvert.\n"
+          + "Using the vendor peak picking during conversion usually leads to better results that using a generic algorithm.",
+      true);
 
   public MZminePreferences() {
     super(// start with performance
@@ -208,7 +227,9 @@ public class MZminePreferences extends SimpleParameterSet {
         imageNormalization, imageTransformation, showPrecursorWindow, imsModuleWarnings,
         windowSetttings,
         // silent parameters without controls
-        showTempFolderAlert, username);
+        showTempFolderAlert, username,
+        //
+        msConvertPath, keepConvertedFile, applyPeakPicking);
 
     darkModeProperty.subscribe(state -> {
       var oldTheme = getValue(theme);
@@ -232,15 +253,14 @@ public class MZminePreferences extends SimpleParameterSet {
     GroupedParameterSetupDialog dialog = new GroupedParameterSetupDialog(valueCheckRequired, this);
 
     // add groups
-    dialog.addParameterGroup("General",
-        new Parameter[]{numOfThreads, memoryOption, tempDirectory, proxySettings,
-            /*, applyTimsPressureCompensation*/});
-    dialog.addParameterGroup("Formats",
-        new Parameter[]{mzFormat, rtFormat, mobilityFormat, ccsFormat, intensityFormat, ppmFormat,
-            scoreFormat, unitFormat});
-    dialog.addParameterGroup("Visuals",
-        new Parameter[]{defaultColorPalette, defaultPaintScale, chartParam, theme, presentationMode,
-            showPrecursorWindow, imageTransformation, imageNormalization});
+    dialog.addParameterGroup("General", numOfThreads, memoryOption, tempDirectory, proxySettings,
+        msConvertPath
+        /*, applyTimsPressureCompensation*/);
+    dialog.addParameterGroup("Formats", mzFormat, rtFormat, mobilityFormat, ccsFormat,
+        intensityFormat, ppmFormat, scoreFormat, unitFormat);
+    dialog.addParameterGroup("Visuals", defaultColorPalette, defaultPaintScale, chartParam, theme,
+        presentationMode, showPrecursorWindow, imageTransformation, imageNormalization);
+    dialog.addParameterGroup("MS data import", msConvertPath, keepConvertedFile, applyPeakPicking);
 //    dialog.addParameterGroup("Other", new Parameter[]{
     // imsModuleWarnings, showTempFolderAlert, windowSetttings  are hidden parameters
 //    });
@@ -314,8 +334,8 @@ public class MZminePreferences extends SimpleParameterSet {
 
       boolean changeColors = false;
       if (theme.isDark() && (ColorUtils.isDark(bgColor) || ColorUtils.isDark(axisFont.getColor())
-                             || ColorUtils.isDark(itemFont.getColor()) || ColorUtils.isDark(
-          titleFont.getColor()) || ColorUtils.isDark(subTitleFont.getColor()))) {
+          || ColorUtils.isDark(itemFont.getColor()) || ColorUtils.isDark(titleFont.getColor())
+          || ColorUtils.isDark(subTitleFont.getColor()))) {
         if (MZmineCore.getDesktop().displayConfirmation("""
             MZmine detected that you changed the GUI theme.
             The current chart theme colors might not be readable.
@@ -453,12 +473,12 @@ public class MZminePreferences extends SimpleParameterSet {
     return darkModeProperty.getValue();
   }
 
-  public BooleanProperty darkModeProperty() {
-    return darkModeProperty;
-  }
-
   public void setDarkMode(final boolean dark) {
     darkModeProperty.set(dark);
+  }
+
+  public BooleanProperty darkModeProperty() {
+    return darkModeProperty;
   }
 
   /**

--- a/mzmine-community/src/main/java/io/github/mzmine/main/MZmineConfiguration.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/main/MZmineConfiguration.java
@@ -137,4 +137,6 @@ public interface MZmineConfiguration {
   ImageNormalization getImageNormalization();
 
   PaintScaleTransform getImageTransformation();
+
+  File getMsConvertPath();
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/main/impl/MZmineConfigurationImpl.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/main/impl/MZmineConfigurationImpl.java
@@ -37,6 +37,7 @@ import io.github.mzmine.javafx.util.color.Vision;
 import io.github.mzmine.main.MZmineConfiguration;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineModule;
+import io.github.mzmine.modules.io.import_rawdata_msconvert.MSConvert;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.EncryptionKeyParameter;
@@ -135,13 +136,13 @@ public class MZmineConfigurationImpl implements MZmineConfiguration {
         } catch (Exception e) {
           logger.log(Level.SEVERE,
               "Could not create an instance of parameter set class " + parameterSetClass + " "
-              + e.getMessage(), e);
+                  + e.getMessage(), e);
           return null;
         }
       } catch (NoClassDefFoundError | Exception e) {
         logger.log(Level.WARNING,
             "Could not find the module or parameter class " + moduleClass.toString() + " "
-            + e.getMessage(), e);
+                + e.getMessage(), e);
         return null;
       }
 
@@ -166,7 +167,7 @@ public class MZmineConfigurationImpl implements MZmineConfiguration {
     if (!parametersClass.isInstance(parameters)) {
       throw new IllegalArgumentException(
           "Given parameter set is an instance of " + parameters.getClass() + " instead of "
-          + parametersClass);
+              + parametersClass);
     }
     moduleParameters.put(moduleClass.getName(), parameters);
 
@@ -429,7 +430,7 @@ public class MZmineConfigurationImpl implements MZmineConfiguration {
     if (!p.isValid()) {
       logger.warning(
           "Current default color palette set in preferences is invalid. Returning standard "
-          + "colors.");
+              + "colors.");
       p = new SimpleColorPalette(ColorsFX.getSevenColorPalette(Vision.DEUTERANOPIA, true));
       p.setName("default-deuternopia");
     }
@@ -442,7 +443,7 @@ public class MZmineConfigurationImpl implements MZmineConfiguration {
     if (!p.isValid()) {
       logger.warning(
           "Current default paint scale set in preferences is invalid. Returning standard "
-          + "colors.");
+              + "colors.");
       p = new SimpleColorPalette(ColorsFX.getSevenColorPalette(Vision.DEUTERANOPIA, true));
       p.setName("default-deuternopia");
     }
@@ -483,5 +484,17 @@ public class MZmineConfigurationImpl implements MZmineConfiguration {
     final PaintScaleTransform transformation = preferences.getParameter(
         MZminePreferences.imageTransformation).getValue();
     return transformation != null ? transformation : PaintScaleTransform.LINEAR;
+  }
+
+  @Override
+  public File getMsConvertPath() {
+    synchronized (MSConvert.class) {
+      File path = preferences.getValue(MZminePreferences.msConvertPath);
+      if (path == null || !MSConvert.validateMsConvertPath(path)) {
+        path = MSConvert.discoverMsConvertPath();
+        preferences.setParameter(MZminePreferences.msConvertPath, path);
+      }
+      return path;
+    }
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvert.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvert.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2004-2024 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.io.import_rawdata_msconvert;
+
+import io.github.mzmine.javafx.concurrent.threading.FxThread;
+import io.github.mzmine.main.ConfigService;
+import io.github.mzmine.parameters.parametertypes.filenames.FileNameComponent;
+import io.github.mzmine.parameters.parametertypes.filenames.FileSelectionType;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javafx.stage.FileChooser.ExtensionFilter;
+import org.apache.commons.io.FileUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class MSConvert {
+
+  private static final Logger logger = Logger.getLogger(MSConvert.class.getName());
+  private static final Pattern FOLDER_PATTERN = Pattern.compile(
+      "(ProteoWizard)\\s(3).([0-9]+).([0-9]+)(.+)");
+
+  private MSConvert() {
+  }
+
+  public static File getMsConvertPath() {
+    return ConfigService.getConfiguration().getMsConvertPath();
+  }
+
+  public static boolean validateMsConvertPath(File path) {
+    if (!path.exists()) {
+      return false;
+    }
+
+    if (!path.getName().equals("msconvert.exe")) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Nullable
+  public static synchronized File discoverMsConvertPath() {
+    final File file = autoDiscover();
+    if (file != null && file.exists()) {
+      return file;
+    }
+
+    final AtomicReference<File> selected = new AtomicReference<>();
+    FxThread.runOnFxThreadAndWait(() -> {
+      final ExtensionFilter filter = new ExtensionFilter("MSConvert", "msconvert.exe");
+      final FileNameComponent component = new FileNameComponent(List.of(), FileSelectionType.OPEN,
+          List.of(filter));
+      selected.set(component.openSelectDialog(List.of(), FileSelectionType.OPEN, List.of(filter)));
+    });
+
+    return selected.get();
+  }
+
+  private static File autoDiscover() {
+    final List<File> inAppFolder = autoDiscoverInAppFolder();
+
+    final List<File> otherPaths = List.of(new File("C:/Program Files/Proteowizard"),
+        new File("C:/Program Files (x86)/Proteowizard"));
+    final List<File> paths = otherPaths.stream().map(MSConvert::autoDiscoverInPath)
+        .filter(Objects::nonNull).flatMap(List::stream).toList();
+
+    List<File> allVersions = new ArrayList<>();
+    if (!inAppFolder.isEmpty()) {
+      allVersions.addAll(inAppFolder);
+    }
+    allVersions.addAll(paths);
+    if (allVersions.isEmpty()) {
+      return null;
+    }
+
+    final File latestVersion = getLatestVersion(allVersions);
+    logger.finest(() -> "Latest MSConvert version found at %s".formatted(
+        latestVersion.getAbsolutePath().toString()));
+    return latestVersion;
+  }
+
+  @Nullable
+  private static List<File> autoDiscoverInAppFolder() {
+    final File userDirectory = FileUtils.getUserDirectory();
+    final File appFolder = new File(userDirectory, "AppData/Local/Apps");
+    if (!appFolder.exists()) {
+      logger.info(() -> "Cannot locate MSConvert. Path to %s folder does not exist.".formatted(
+          appFolder.getAbsolutePath()));
+      return null;
+    }
+
+    final List<File> proteowizardFolders = listProteowizardFolders(appFolder);
+    if (proteowizardFolders.isEmpty()) {
+      logger.info(() -> "Cannot locate MSConvert. No ProteoWizard 3 folder found in %s.".formatted(
+          appFolder.getAbsolutePath()));
+      return null;
+    }
+    return proteowizardFolders;
+  }
+
+  @Nullable
+  private static List<File> autoDiscoverInPath(File path) {
+    if (!path.exists()) {
+      logger.info(() -> "Cannot locate MSConvert. Path to %s folder does not exist.".formatted(
+          path.getAbsolutePath()));
+      return null;
+    }
+
+    final List<File> proteowizardFolders = listProteowizardFolders(path);
+    if (proteowizardFolders.isEmpty()) {
+      logger.info(() -> "Cannot locate MSConvert. No ProteoWizard 3 folder found in %s.".formatted(
+          path.getAbsolutePath()));
+      return null;
+    }
+    return proteowizardFolders;
+  }
+
+  private static @NotNull List<File> listProteowizardFolders(File appFolder) {
+    final File[] files = appFolder.listFiles();
+    if (files == null) {
+      return List.of();
+    }
+
+    final List<File> proteowizardFolders = new ArrayList<>();
+    for (File file : files) {
+      if (FOLDER_PATTERN.matcher(file.getName()).matches()) {
+        proteowizardFolders.add(file);
+      }
+    }
+    return proteowizardFolders;
+  }
+
+  private static @NotNull File getLatestVersion(@NotNull List<File> proteowizardFolders) {
+    if (proteowizardFolders.isEmpty()) {
+      throw new RuntimeException("Cannot find any version of MSConvert on this computer.");
+    }
+
+    // get the latest MSConvert version
+    final File latestMsConvertFolder = proteowizardFolders.stream()
+        .sorted(MSConvert::compareVersions).toList().getLast();
+
+    final File msconvert = new File(latestMsConvertFolder, "msconvert.exe");
+    if (!msconvert.exists()) {
+      logger.info(
+          () -> "Cannot locate MSConvert. MSConvert does not exist in folder found in %s.".formatted(
+              latestMsConvertFolder.getAbsolutePath()));
+    }
+    return msconvert;
+  }
+
+  private static int compareVersions(File o1, File o2) {
+    final Matcher matcher1 = FOLDER_PATTERN.matcher(o1.getName());
+    final Matcher matcher2 = FOLDER_PATTERN.matcher(o2.getName());
+
+    matcher1.matches();
+    matcher2.matches();
+
+    final String m1v2 = matcher1.group(3);
+    final String m2v2 = matcher2.group(3);
+    if (!m1v2.equals(m2v2)) {
+      return Integer.compare(Integer.parseInt(m1v2), Integer.parseInt(m2v2));
+    }
+
+    final String m1v3 = matcher1.group(4);
+    final String m2v3 = matcher2.group(4);
+    if (!m1v3.equals(m2v3)) {
+      return Integer.compare(Integer.parseInt(m1v3), Integer.parseInt(m2v3));
+    }
+
+    return 0;
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvertImportModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvertImportModule.java
@@ -28,6 +28,7 @@ package io.github.mzmine.modules.io.import_rawdata_msconvert;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.impl.AbstractProcessingModule;
+import io.github.mzmine.modules.io.import_rawdata_all.spectral_processor.ScanImportProcessorConfig;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
@@ -35,24 +36,14 @@ import java.io.File;
 import java.time.Instant;
 import java.util.Collection;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public class MSConvertImportModule extends AbstractProcessingModule {
 
   public MSConvertImportModule() {
-    super("Raw data import (MSConvert)", null, MZmineModuleCategory.RAWDATAIMPORT,
+    super("Raw data import (MSConvert)", MSConvertImportParameters.class, MZmineModuleCategory.RAWDATAIMPORT,
         "Import native raw data using MSConvert as an intermediate step.");
   }
 
-  @Override
-  public @NotNull String getName() {
-    return "";
-  }
-
-  @Override
-  public @Nullable Class<? extends ParameterSet> getParameterSetClass() {
-    return null;
-  }
 
   @Override
   public @NotNull ExitCode runModule(@NotNull MZmineProject project,
@@ -65,7 +56,7 @@ public class MSConvertImportModule extends AbstractProcessingModule {
     }
 
     for (File file : files) {
-      tasks.add(new MSConvertImportTask(moduleCallDate, file, null, project, this.getClass(),
+      tasks.add(new MSConvertImportTask(moduleCallDate, file, ScanImportProcessorConfig.createDefault(), project, this.getClass(),
           parameters));
     }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvertImportModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvertImportModule.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2004-2024 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.io.import_rawdata_msconvert;
+
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.modules.MZmineModuleCategory;
+import io.github.mzmine.modules.impl.AbstractProcessingModule;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.taskcontrol.Task;
+import io.github.mzmine.util.ExitCode;
+import java.io.File;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class MSConvertImportModule extends AbstractProcessingModule {
+
+  public MSConvertImportModule() {
+    super("Raw data import (MSConvert)", null, MZmineModuleCategory.RAWDATAIMPORT,
+        "Import native raw data using MSConvert as an intermediate step.");
+  }
+
+  @Override
+  public @NotNull String getName() {
+    return "";
+  }
+
+  @Override
+  public @Nullable Class<? extends ParameterSet> getParameterSetClass() {
+    return null;
+  }
+
+  @Override
+  public @NotNull ExitCode runModule(@NotNull MZmineProject project,
+      @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
+      @NotNull Instant moduleCallDate) {
+
+    final File[] files = parameters.getValue(MSConvertImportParameters.fileNames);
+    if (files == null || files.length == 0) {
+      return ExitCode.ERROR;
+    }
+
+    for (File file : files) {
+      tasks.add(new MSConvertImportTask(moduleCallDate, file, null, project, this.getClass(),
+          parameters));
+    }
+
+    return ExitCode.OK;
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvertImportParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvertImportParameters.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2004-2024 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.io.import_rawdata_msconvert;
+
+import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.filenames.FileNamesParameter;
+import io.github.mzmine.util.files.ExtensionFilters;
+
+public class MSConvertImportParameters extends SimpleParameterSet {
+
+  public static final FileNamesParameter fileNames = new FileNamesParameter("File names", "",
+      ExtensionFilters.MS_RAW_DATA);
+
+  public MSConvertImportParameters() {
+    super(fileNames);
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvertImportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvertImportTask.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2004-2024 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.io.import_rawdata_msconvert;
+
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.PolarityType;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.gui.preferences.MZminePreferences;
+import io.github.mzmine.main.ConfigService;
+import io.github.mzmine.modules.MZmineModule;
+import io.github.mzmine.modules.io.import_rawdata_all.spectral_processor.ScanImportProcessorConfig;
+import io.github.mzmine.modules.io.import_rawdata_mzml.MSDKmzMLImportTask;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.ParameterUtils;
+import io.github.mzmine.taskcontrol.AbstractTask;
+import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.exceptions.ExceptionUtils;
+import io.github.mzmine.util.files.FileAndPathUtil;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jetbrains.annotations.NotNull;
+
+public class MSConvertImportTask extends AbstractTask {
+
+  private static final Logger logger = Logger.getLogger(MSConvertImportTask.class.getName());
+
+  private final File rawFilePath;
+  private final ScanImportProcessorConfig config;
+  private final MZmineProject project;
+  private final Class<? extends MZmineModule> module;
+  private final ParameterSet parameters;
+  private MSDKmzMLImportTask msdkTask;
+  private Boolean convertToFile = ConfigService.getConfiguration().getPreferences()
+      .getValue(MZminePreferences.keepConvertedFile);
+
+  public MSConvertImportTask(@NotNull Instant moduleCallDate, File path,
+      ScanImportProcessorConfig config, MZmineProject project, Class<? extends MZmineModule> module,
+      ParameterSet parameters) {
+    super(moduleCallDate);
+    this.rawFilePath = path;
+    this.config = config;
+    this.project = project;
+    this.module = module;
+    this.parameters = parameters;
+  }
+
+  @Override
+  public String getTaskDescription() {
+    return msdkTask != null ? msdkTask.getTaskDescription()
+        : "Waiting for conversion/Importing MS data file %s".formatted(rawFilePath);
+  }
+
+  @Override
+  public double getFinishedPercentage() {
+    return msdkTask != null ? msdkTask.getFinishedPercentage() : 0;
+  }
+
+  @Override
+  public void run() {
+    setStatus(TaskStatus.PROCESSING);
+
+    final File msConvertPath = MSConvert.getMsConvertPath();
+    if (msConvertPath == null) {
+      setErrorMessage("MSConvert not found. Please install MSConvert.");
+      setStatus(TaskStatus.ERROR);
+    }
+    final File mzMLFile = getMzMLFileName(rawFilePath);
+
+    if (mzMLFile.exists()) {
+      logger.finest(
+          "Discovered mzml file for MS data file %s. Importing mzml file from %s.".formatted(
+              rawFilePath, mzMLFile));
+      importFromMzML(mzMLFile);
+      setStatus(TaskStatus.FINISHED);
+      return;
+    }
+
+    final List<String> cmdLine = buildCommandLine(rawFilePath, msConvertPath);
+
+    if (convertToFile) {
+      ProcessBuilder builder = new ProcessBuilder(cmdLine);
+      try {
+        final Process process = builder.start();
+        while (process.isAlive()) { // wait for conversion to finish
+          if (isCanceled()) {
+            process.destroy();
+          }
+          TimeUnit.MILLISECONDS.sleep(100);
+        }
+      } catch (IOException | InterruptedException e) {
+        logger.log(Level.WARNING, "Error while converting %s to mzML file.".formatted(rawFilePath),
+            e);
+        setStatus(TaskStatus.ERROR);
+        return;
+      }
+      importFromMzML(mzMLFile);
+    } else {
+      importFromStream(rawFilePath, cmdLine);
+    }
+
+//    logger.info(
+//        STR."Finished parsing \{fileToOpen}, parsed \{parsedScans} scans and after filtering remained \{convertedScans}");
+    setStatus(TaskStatus.FINISHED);
+  }
+
+  private @NotNull File getMzMLFileName(File filePath) {
+    final String fileName = filePath.getName();
+    final String extension = FileAndPathUtil.getExtension(fileName);
+    final String mzMLName = fileName.replace(extension, "mzML");
+    final File mzMLFile = new File(filePath.getParent(), mzMLName);
+    return mzMLFile;
+  }
+
+  private void importFromMzML(File mzMLFile) {
+    RawDataFile dataFile = null;
+    ParameterUtils.replaceRawFileName(parameters, rawFilePath, mzMLFile);
+    msdkTask = new MSDKmzMLImportTask(project, mzMLFile, config, module, parameters, moduleCallDate,
+        storage);
+
+    this.addTaskStatusListener((_, _, _) -> {
+      if (isCanceled()) {
+        msdkTask.cancel();
+      }
+    });
+    dataFile = msdkTask.importStreamOrFile();
+
+    if (dataFile == null || isCanceled()) {
+      return;
+    }
+
+    var totalScans = msdkTask.getTotalScansInMzML();
+    var parsedScans = msdkTask.getParsedMzMLScans();
+    var convertedScans = msdkTask.getConvertedScansAfterFilter();
+
+    if (parsedScans == 0) {
+      throw (new RuntimeException("No scans found"));
+    }
+
+    if (parsedScans != totalScans) {
+      throw (new RuntimeException(
+          "MSConvert process crashed before all scans were extracted (" + parsedScans + " out of "
+              + totalScans + ")"));
+    }
+    msdkTask.addAppliedMethodAndAddToProject(dataFile);
+  }
+
+  private void importFromStream(File rawFilePath, List<String> cmdLine) {
+    ProcessBuilder builder = new ProcessBuilder(cmdLine);
+    Process process = null;
+    try {
+      process = builder.start();
+
+      // Get the stdout of MSConvert process as InputStream
+      RawDataFile dataFile = null;
+      try (InputStream mzMLStream = process.getInputStream()) //
+      {
+        msdkTask = new MSDKmzMLImportTask(project, rawFilePath, mzMLStream, config, module,
+            parameters, moduleCallDate, storage);
+
+        this.addTaskStatusListener((_, _, _) -> {
+          if (isCanceled()) {
+            msdkTask.cancel();
+          }
+        });
+        dataFile = msdkTask.importStreamOrFile();
+      }
+
+      if (dataFile == null || isCanceled()) {
+        return;
+      }
+
+      var totalScans = msdkTask.getTotalScansInMzML();
+      var parsedScans = msdkTask.getParsedMzMLScans();
+      var convertedScans = msdkTask.getConvertedScansAfterFilter();
+
+      // Finish
+      process.destroy();
+
+      if (parsedScans == 0) {
+        throw (new RuntimeException("No scans found"));
+      }
+
+      if (parsedScans != totalScans) {
+        throw (new RuntimeException(
+            "ThermoRawFileParser process crashed before all scans were extracted (" + parsedScans
+                + " out of " + totalScans + ")"));
+      }
+
+      msdkTask.addAppliedMethodAndAddToProject(dataFile);
+
+    } catch (Throwable e) {
+      if (process != null) {
+        process.destroy();
+      }
+
+      if (getStatus() == TaskStatus.PROCESSING) {
+        logger.log(Level.SEVERE, "Error while parsing file %s".formatted(rawFilePath), e);
+        setErrorMessage(ExceptionUtils.exceptionToString(e));
+        setStatus(TaskStatus.ERROR);
+      }
+    }
+  }
+
+  private @NotNull List<String> buildCommandLine(File filePath, File msConvertPath) {
+
+    List<String> cmdLine = new ArrayList<>();
+    cmdLine.addAll(List.of("\"" + msConvertPath.toString() + "\"", // MSConvert path
+        "\"" + filePath.getAbsolutePath() + "\"", // raw file path
+        "-o", !convertToFile ? "-" /* to stdout */ : "\"" + filePath.getParent() + "\"" //
+    )); // vendor peak-picking
+
+    if (convertToFile) {
+      cmdLine.add("--zlib");
+    }
+
+    if (ConfigService.getPreferences().getValue(MZminePreferences.applyPeakPicking)) {
+      cmdLine.addAll(List.of("--filter", "\"peakPicking vendor msLevel=1-\""));
+    }
+
+    // deactivated, since waters files converted by MSConvert have poor quality.
+    /*final RawDataFileType fileType = RawDataFileTypeDetector.detectDataFileType(rawFilePath);
+    if (fileType == RawDataFileType.WATERS_RAW) {
+      final PolarityType polarity = getWatersPolarity(filePath);
+      if (polarity == PolarityType.POSITIVE) {
+        logger.finest(
+            "Determined polarity of file %s to be %s. Applying lockmass correction.".formatted(
+                rawFilePath, polarity));
+        cmdLine.addAll(List.of("--filter", "\"lockmassRefiner mz=556.276575 tol=0.1\""));
+      } else if (polarity == PolarityType.NEGATIVE) {
+        logger.finest(
+            "Determined polarity of file %s to be %s. Applying lockmass correction.".formatted(
+                rawFilePath, polarity));
+        cmdLine.addAll(List.of("--filter", "\"lockmassRefiner mz=554.262022 tol=0.1\""));
+      }
+    }*/
+
+    cmdLine.addAll(List.of("--filter",
+        "\"titleMaker <RunId>.<ScanNumber>.<ScanNumber>.<ChargeState> File:\"\"\"^<SourcePath^>\"\"\", NativeID:\"\"\"^<Id^>\"\"\"\""));
+
+    logger.finest("Running msconvert with command line: %s".formatted(cmdLine.toString()));
+    return cmdLine;
+  }
+
+  private PolarityType getWatersPolarity(File rawFilePath) {
+    final File file = new File(rawFilePath, "_extern.inf");
+    if (!file.exists() || !file.canRead()) {
+      return PolarityType.UNKNOWN;
+    }
+
+    final Pattern polarityPattern = Pattern.compile("(Polarity)(\\s+)([a-zA-Z]+)([+-])");
+
+    // somehow does not work with Files.newBufferedReader
+    try (var reader = new BufferedReader(new FileReader(file))) {
+      String line = reader.readLine();
+      while (line != null) {
+        final Matcher matcher = polarityPattern.matcher(line);
+        if (matcher.matches()) {
+          final PolarityType polarity = PolarityType.fromSingleChar(matcher.group(4));
+          return polarity;
+        }
+        line = reader.readLine();
+      }
+    } catch (IOException e) {
+      logger.log(Level.WARNING,
+          "Cannot determine raw data polarity for file %s. Cannot apply lockmass correction.".formatted(
+              rawFilePath), e);
+      return PolarityType.UNKNOWN;
+    }
+    return PolarityType.UNKNOWN;
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectsave/RawDataSavingUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectsave/RawDataSavingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -197,7 +197,7 @@ public class RawDataSavingUtils {
    * {@link RawDataFilesParameter} will be set to {@link RawDataFilesSelectionType#SPECIFIC_FILES}.
    *
    * @param parameterSet1 The first parameter set.
-   * @param parameterSet2 The second paramete set.
+   * @param parameterSet2 The second parameter set.
    * @return The merged parameter set.
    */
   @NotNull

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/dialogs/GroupedParameterSetupDialog.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/dialogs/GroupedParameterSetupDialog.java
@@ -108,7 +108,7 @@ public class GroupedParameterSetupDialog extends EmptyParameterSetupDialogBase {
     propertySheet.setTitleFilter(filter);
   }
 
-  public void addParameterGroup(String group, Parameter[] parameters) {
+  public void addParameterGroup(String group, Parameter... parameters) {
     for (Parameter p : parameters) {
       items.add(new ParameterItem(p, group));
     }

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/filenames/FileNameComponent.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/filenames/FileNameComponent.java
@@ -104,7 +104,7 @@ public class FileNameComponent extends HBox implements LastFilesComponent {
   }
 
 
-  private File openSelectDialog(final List<File> lastFiles, final FileSelectionType type,
+  public File openSelectDialog(final List<File> lastFiles, final FileSelectionType type,
       final List<ExtensionFilter> filters) {
     // Create chooser.
     FileChooser fileChooser = new FileChooser();

--- a/mzmine-community/src/main/java/io/github/mzmine/util/RawDataFileType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/RawDataFileType.java
@@ -25,23 +25,78 @@
 
 package io.github.mzmine.util;
 
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.util.files.ExtensionFilters;
+import io.github.mzmine.util.files.FileAndPathUtil;
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import javafx.stage.FileChooser.ExtensionFilter;
+
 /**
  * Enum of supported data file formats
  */
 public enum RawDataFileType {
 
-  MZML, //
-  IMZML, //
-  MZML_IMS, //
-  MZXML, //
-  MZDATA, //
-  NETCDF, //
-  THERMO_RAW, //
-//  WATERS_RAW, //
-  MZML_ZIP, //
-  MZML_GZIP, //
-  ICPMSMS_CSV, //
-  BRUKER_TDF, //
-  BRUKER_TSF, //
-  BRUKER_BAF, AIRD //
+  MZML(ExtensionFilters.MZML, false), //
+  IMZML(ExtensionFilters.IMZML, false), //
+  MZML_IMS(ExtensionFilters.MZML, false), //
+  MZXML(ExtensionFilters.MZXML, false), //
+  MZDATA(ExtensionFilters.MZDATA, false), //
+  NETCDF(ExtensionFilters.NETCDF, false), //
+  THERMO_RAW(ExtensionFilters.THERMO_RAW, false), //
+  //  WATERS_RAW(ExtensionFilters.WATERS_RAW, true), //
+  MZML_ZIP(ExtensionFilters.MZML_ZIP_GZIP, false), //
+  MZML_GZIP(ExtensionFilters.MZML_ZIP_GZIP, false), //
+  ICPMSMS_CSV(ExtensionFilters.CSV, false), //
+  BRUKER_TDF(ExtensionFilters.BRUKER_D, true), //
+  BRUKER_TSF(ExtensionFilters.BRUKER_D, true), //
+  BRUKER_BAF(ExtensionFilters.BRUKER_D, true), //
+  //  AIRD, //
+  SCIEX_WIFF(ExtensionFilters.WIFF, false), //
+  SCIEX_WIFF2(ExtensionFilters.WIFF2, false), //
+  AGILENT_D(ExtensionFilters.AGILENT_D, true);
+
+
+  private final ExtensionFilter extensionFilter;
+  private final boolean isFolder;
+
+  RawDataFileType(ExtensionFilter extensionFilter, boolean isFolder) {
+    this.extensionFilter = extensionFilter;
+    this.isFolder = isFolder;
+  }
+
+  public static List<RawDataFileType> getAllFolderTypes() {
+    return Arrays.stream(values()).filter(RawDataFileType::isFolder).toList();
+  }
+
+  public static List<RawDataFileType> getAllNonFolderTypes() {
+    return Arrays.stream(values()).filter(rawDataFileType -> !rawDataFileType.isFolder()).toList();
+  }
+
+  public static List<File> getAdditionalRequiredFiles(RawDataFile raw) {
+    final File file = raw.getAbsoluteFilePath();
+    final RawDataFileType type = RawDataFileTypeDetector.detectDataFileType(file);
+
+    return switch (type) {
+      case MZML, MZXML, MZML_IMS, MZDATA, NETCDF, THERMO_RAW, MZML_ZIP, MZML_GZIP, ICPMSMS_CSV,
+           BRUKER_TDF, BRUKER_TSF, BRUKER_BAF, AGILENT_D -> List.of();
+      case IMZML -> {
+        final String extension = FileAndPathUtil.getExtension(file.getName());
+        yield List.of(new File(file.getParent(), file.getName().replace(extension, "ibd")));
+      }
+      case SCIEX_WIFF, SCIEX_WIFF2 -> {
+        final String extension = FileAndPathUtil.getExtension(file.getName());
+        yield List.of(new File(file.getParent(), file.getName().replace(extension, "wiff.scan")));
+      }
+    };
+  }
+
+  public ExtensionFilter getExtensionFilter() {
+    return extensionFilter;
+  }
+
+  public boolean isFolder() {
+    return isFolder;
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/util/RawDataFileTypeDetector.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/RawDataFileTypeDetector.java
@@ -25,6 +25,7 @@
 
 package io.github.mzmine.util;
 
+import io.github.mzmine.gui.DesktopService;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -65,11 +66,14 @@ public class RawDataFileTypeDetector {
   private static final String TDF_BIN_SUFFIX = ".tdf_bin";
   private static final String TSF_BIN_SUFFIX = ".tsf_bin";
   private static final String TSF_SUFFIX = ".tsf_bin";
+  private static final String BAF_SUFFIX = ".baf";
   private static final String BRUKER_FOLDER_SUFFIX = ".d";
   private static final String AIRD_SUFFIX = ".aird";
   private static final String MZML_SUFFIX = ".mzml";
   private static final String IMZML_SUFFIX = ".imzml";
-  private static final String BAF_SUFFIX = ".baf";
+  private static final String SCIEX_WIFF_SUFFIX = ".wiff";
+  private static final String SCIEX_WIFF2_SUFFIX = ".wiff2";
+  private static final String AGILENT_ACQDATATA_FOLDER = "AcqData";
 
   private static final Logger logger = Logger.getLogger(RawDataFileTypeDetector.class.getName());
 
@@ -79,15 +83,16 @@ public class RawDataFileTypeDetector {
   public static RawDataFileType detectDataFileType(File fileName) {
 
     if (fileName.isDirectory()) {
-      /*if (fileName.getName().endsWith(BRUKER_FOLDER_SUFFIX)) {
-        return RawDataFileType.BRUKER_TDF;
-      }*/
-
       // To check for Waters .raw directory, we look for _FUNC[0-9]{3}.DAT
       for (File f : fileName.listFiles()) {
-        /*if (f.isFile() && f.getName().toUpperCase().matches("_FUNC[0-9]{3}.DAT")) {
-          return RawDataFileType.WATERS_RAW;
-        }*/
+        if (f.isFile() && f.getName().toUpperCase().matches("_FUNC[0-9]{3}.DAT")) {
+          DesktopService.getDesktop().displayMessage("Waters raw data detected",
+              "Waters raw data is currently not supported in mzmine. Please use their tool DataConnect to convert zo mzML (see documentation).",
+              "https://mzmine.github.io/mzmine_documentation/data_conversion.html#waters");
+          throw new RuntimeException(
+              "Waters raw data detected. Please download Waters DataConnect(R) and convert to mzML.");
+//          return RawDataFileType.WATERS_RAW;
+        }
         if (f.isFile() && (f.getName().contains(TDF_SUFFIX) || f.getName()
             .contains(TDF_BIN_SUFFIX))) {
           return RawDataFileType.BRUKER_TDF;
@@ -98,6 +103,9 @@ public class RawDataFileTypeDetector {
         }
         if (f.isFile() && (f.getName().contains(BAF_SUFFIX))) {
           return RawDataFileType.BRUKER_BAF;
+        }
+        if (f.isDirectory() && f.getName().equals(AGILENT_ACQDATATA_FOLDER)) {
+          return RawDataFileType.AGILENT_D;
         }
       }
       // We don't recognize any other directory type than Waters and Bruker
@@ -111,6 +119,12 @@ public class RawDataFileTypeDetector {
         }
         if (fileName.getName().toLowerCase().endsWith(IMZML_SUFFIX)) {
           return RawDataFileType.IMZML;
+        }
+        if (fileName.getName().toLowerCase().endsWith(SCIEX_WIFF_SUFFIX)) {
+          return RawDataFileType.SCIEX_WIFF;
+        }
+        if (fileName.getName().toLowerCase().endsWith(SCIEX_WIFF2_SUFFIX)) {
+          return RawDataFileType.SCIEX_WIFF2;
         }
         //the suffix is json and have a .aird file with same name
         /*if (fileName.getName().toLowerCase().endsWith(AIRD_SUFFIX)) {

--- a/mzmine-community/src/main/java/io/github/mzmine/util/StringUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/StringUtils.java
@@ -227,4 +227,8 @@ public class StringUtils {
   public static boolean isBlank(@Nullable String str) {
     return str == null || str.isBlank();
   }
+
+  public static String inQuotes(String str) {
+    return "\"" + str + "\"";
+  }
 }

--- a/utils/src/main/java/io/github/mzmine/util/files/ExtensionFilters.java
+++ b/utils/src/main/java/io/github/mzmine/util/files/ExtensionFilters.java
@@ -34,9 +34,11 @@ public class ExtensionFilters {
    * mzmine specific
    */
   public static final ExtensionFilter MZ_USER = new ExtensionFilter("mzmine user", "*.mzuser");
-  public static final ExtensionFilter MZ_CONFIG = new ExtensionFilter("mzmine config", "*.mzconfig");
+  public static final ExtensionFilter MZ_CONFIG = new ExtensionFilter("mzmine config",
+      "*.mzconfig");
   public static final ExtensionFilter MZ_BATCH = new ExtensionFilter("mzmine batch", "*.mzbatch");
-  public static final ExtensionFilter MZ_WIZARD = new ExtensionFilter("mzmine mzwizard", "*.mzmwizard");
+  public static final ExtensionFilter MZ_WIZARD = new ExtensionFilter("mzmine mzwizard",
+      "*.mzmwizard");
 
   /*
    * CSV and TSV import export
@@ -47,6 +49,11 @@ public class ExtensionFilters {
   public static final ExtensionFilter ALL_FILES = new ExtensionFilter("All files", "*.*");
   public static final ExtensionFilter CSV_OR_TSV = new ExtensionFilter("CSV or TSV data", "*.csv",
       "*.tsv");
+
+  /**
+   * Executables
+   */
+  public static final ExtensionFilter EXE = new ExtensionFilter("Executable", "*.exe");
 
   // LISTS
   public static final List<ExtensionFilter> CSV_TSV_IMPORT = List.of(CSV_OR_TSV, CSV, TSV,
@@ -63,36 +70,36 @@ public class ExtensionFilters {
   public static final ExtensionFilter MSP = new ExtensionFilter("msp mass spectra format (NIST)",
       "*.msp");
   public static final ExtensionFilter MGF = new ExtensionFilter("mgf mass spectra format", "*.mgf");
+  public static final ExtensionFilter JDCAMX = new ExtensionFilter("JCAM-DX files", "*.jdx");
+
   /**
    * MASS SPEC formats
    */
-  public static final ExtensionFilter ALL_MS_DATA_FILTER = new ExtensionFilter("MS data", "*.mzML",
-      "*.mzml", "*.mzXML", "*.mzxml", "*.imzML", "*.imzml", "*.d", "*.raw", "*.RAW", "*.mzData",
-      "*.netcdf", "*.mzdata", "*.aird");
-  private static final ExtensionFilter JDCAMX = new ExtensionFilter("JCAM-DX files", "*.jdx");
-  private static final ExtensionFilter ALL_SPECTRAL_LIBRARY_FILTER = new ExtensionFilter(
-      "All spectral libraries", "*.json", "*.msp", "*.mgf", "*.jdx");
-  // LISTS
-  public static final List<ExtensionFilter> ALL_LIBRARY = List.of(ALL_SPECTRAL_LIBRARY_FILTER,
-      JSON_LIBRARY, MGF, MSP, JDCAMX, ALL_FILES);
-  private static final ExtensionFilter MZML = new ExtensionFilter("mzML MS data", "*.mzML",
+  public static final ExtensionFilter MZML = new ExtensionFilter("mzML MS data", "*.mzML",
       "*.mzml");
-  private static final ExtensionFilter MZXML = new ExtensionFilter("mzXML MS data", "*.mzXML",
+  public static final ExtensionFilter MZXML = new ExtensionFilter("mzXML MS data", "*.mzXML",
       "*.mzxml");
-  private static final ExtensionFilter IMZML = new ExtensionFilter("imzML MS imaging data",
+  public static final ExtensionFilter IMZML = new ExtensionFilter("imzML MS imaging data",
       "*.imzML", "*.imzml");
-  private static final ExtensionFilter BRUKER_D = new ExtensionFilter("Bruker tdf files", "*.d");
-  private static final ExtensionFilter THERMO_RAW = new ExtensionFilter("Thermo RAW files", "*.raw",
+  public static final ExtensionFilter BRUKER_D = new ExtensionFilter("Bruker .d files", "*.d",
+      ".tsf", "*.tdf");
+  public static final ExtensionFilter AGILENT_D = new ExtensionFilter("Agilent .d files", "*.d");
+  public static final ExtensionFilter THERMO_RAW = new ExtensionFilter("Thermo RAW files", "*.raw",
       "*.RAW");
-//  private static final ExtensionFilter WATERS_RAW = new ExtensionFilter("Waters RAW folders",
-//      "*.raw", "*.RAW");
-  private static final ExtensionFilter MZDATA = new ExtensionFilter("mzData MS data", "*.mzData",
+  public static final ExtensionFilter WATERS_RAW = new ExtensionFilter("Waters RAW folders",
+      "*.raw", "*.RAW");
+  public static final ExtensionFilter MZDATA = new ExtensionFilter("mzData MS data", "*.mzData",
       "*.mzdata");
-  private static final ExtensionFilter AIRD = new ExtensionFilter("aird MS data", "*.aird",
-      "*.Aird", "*.AIRD");
-  private static final ExtensionFilter NETCDF = new ExtensionFilter("netCDF", "*.cdf", "*.CDF",
+  //  public static final ExtensionFilter AIRD = new ExtensionFilter("aird MS data", "*.aird",
+//      "*.Aird", "*.AIRD");
+  public static final ExtensionFilter NETCDF = new ExtensionFilter("netCDF", "*.cdf", "*.CDF",
       "*.netcdf", "*.NETCDF", "*.nc", "*.NC");
-  private static final ExtensionFilter MZML_ZIP_GZIP = new ExtensionFilter("zip", "*.zip", "*.gz");
+  public static final ExtensionFilter MZML_ZIP_GZIP = new ExtensionFilter("zip", "*.zip", "*.gz");
+  public static final ExtensionFilter WIFF = new ExtensionFilter("wiff", "*.wiff");
+  public static final ExtensionFilter WIFF2 = new ExtensionFilter("wiff2", "*.wiff2");
+  public static final ExtensionFilter ALL_MS_DATA_FILTER = new ExtensionFilter("MS data", "*.mzML",
+      "*.mzml", "*.mzXML", "*.mzxml", "*.imzML", "*.imzml", "*.d", "*.tdf", "*.tsf", "*.raw",
+      "*.RAW", "*.mzData", "*.netcdf", "*.mzdata", /*"*.aird",*/ "*.wiff", "*.wiff2");
   public static final List<ExtensionFilter> MS_RAW_DATA = List.of( //
       ALL_MS_DATA_FILTER, //
       MZML, //
@@ -100,12 +107,19 @@ public class ExtensionFilters {
       IMZML, //
       BRUKER_D, //
       THERMO_RAW, //
-//      WATERS_RAW, //
+      WATERS_RAW, //
       MZDATA, //
-      AIRD, //
+//      AIRD, //
       NETCDF, //
       MZML_ZIP_GZIP, //
+      WIFF, //
+      WIFF2, //
       ALL_FILES);
+  private static final ExtensionFilter ALL_SPECTRAL_LIBRARY_FILTER = new ExtensionFilter(
+      "All spectral libraries", "*.json", "*.msp", "*.mgf", "*.jdx");
+  // LISTS
+  public static final List<ExtensionFilter> ALL_LIBRARY = List.of(ALL_SPECTRAL_LIBRARY_FILTER,
+      JSON_LIBRARY, MGF, MSP, JDCAMX, ALL_FILES);
 
 
   public static String getExtensionName(ExtensionFilter filter) {

--- a/utils/src/main/java/io/github/mzmine/util/files/FileAndPathUtil.java
+++ b/utils/src/main/java/io/github/mzmine/util/files/FileAndPathUtil.java
@@ -527,39 +527,6 @@ public class FileAndPathUtil {
     }
   }
 
-  /**
-   * The Path of the Jar.
-   *
-   * @return jar path
-   */
-  @Nullable
-  public static File getPathOfJar() {
-    /*
-     * File f = new File(System.getProperty("java.class.path")); File dir =
-     * f.getAbsoluteFile().getParentFile(); return dir;
-     */
-    try {
-      File jar = new File(
-          FileAndPathUtil.class.getProtectionDomain().getCodeSource().getLocation().toURI()
-              .getPath());
-      return jar.getParentFile();
-    } catch (Exception ex) {
-      return null;
-    }
-  }
-
-  /**
-   * The main directory. Only tested on windows
-   *
-   * @return
-   */
-  @Nullable
-  public static File getSoftwareMainDirectory() {
-    File pathOfJar = FileAndPathUtil.getPathOfJar();
-    return pathOfJar == null ? null : pathOfJar.getParentFile();
-  }
-
-
   @Nullable
   public static File getMzmineDir() {
     return USER_MZMINE_DIR;
@@ -569,7 +536,6 @@ public class FileAndPathUtil {
   public static File resolveInMzmineDir(String name) {
     return new File(USER_MZMINE_DIR, name);
   }
-
 
   public static File getUniqueFilename(final File parent, final String fileName) {
     final File dir = parent.isDirectory() ? parent : parent.getParentFile();
@@ -689,5 +655,9 @@ public class FileAndPathUtil {
    */
   public static Path createTempDirectory(String name) throws IOException {
     return Files.createTempDirectory(MZMINE_TEMP_DIR.toPath(), name);
+  }
+
+  public static Path getWorkingDirectory() {
+    return Paths.get("").toAbsolutePath();
   }
 }


### PR DESCRIPTION
cherrypicked form other PR

- looks for MSConvert installation in user app data folder, program files, and program files (x86), otherwise shows a window to manually select
- options:
  - convert on the fly into stream or keep the mzml
  - mzml or raw file is put into the project,p ahts  are replaced
  - apply peak picking (default)
- does not work for waters data: scans not sorted and lockmass is incredibly slow
- import only works on windows
- tested for agilent and sciex