### PR TITLE
option use msconvert for thermo import

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/gui/preferences/MZminePreferences.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/preferences/MZminePreferences.java
@@ -57,8 +57,11 @@ import io.github.mzmine.util.web.Proxy;
 import io.github.mzmine.util.web.ProxyType;
 import io.github.mzmine.util.web.ProxyUtils;
 import io.mzio.users.gui.fx.UsersController;
+import io.mzio.users.service.UserType;
+import io.mzio.users.user.CurrentUserService;
 import java.io.File;
 import java.text.DecimalFormat;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import javafx.application.Platform;
@@ -495,5 +498,22 @@ public class MZminePreferences extends SimpleParameterSet {
     ProxyParameters params = pp.getEmbeddedParameters();
     params.setProxy(proxy);
     ProxyUtils.setSystemProxy(proxy);
+  }
+
+  @Override
+  public boolean checkParameterValues(Collection<String> errorMessages,
+      boolean skipRawDataAndFeatureListParameters) {
+    final boolean superCheck = super.checkParameterValues(errorMessages,
+        skipRawDataAndFeatureListParameters);
+
+    if (getValue(MZminePreferences.thermoImportChoice) == ThermoImportOptions.THERMO_RAW_FILE_PARSER
+        && CurrentUserService.getUser() != null
+        && CurrentUserService.getUser().getUserType() != UserType.ACADEMIC) {
+      errorMessages.add(
+          "Importing Thermo raw files via the Thermo raw file parser is only available for academic "
+              + "users. Please select and install MSConvert.");
+      return false;
+    }
+    return superCheck;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/preferences/MZminePreferences.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/preferences/MZminePreferences.java
@@ -74,7 +74,6 @@ public class MZminePreferences extends SimpleParameterSet {
   public static final HiddenParameter<String> username = new HiddenParameter<>(
       new StringParameter("username", "last active username", "", false, true));
 
-
   public static final NumberFormatParameter mzFormat = new NumberFormatParameter("m/z value format",
       "Format of m/z values", false, new DecimalFormat("0.0000"));
 
@@ -143,24 +142,24 @@ public class MZminePreferences extends SimpleParameterSet {
   public static final HiddenParameter<Map<String, Boolean>> imsModuleWarnings = new HiddenParameter<>(
       new OptOutParameter("Ion mobility compatibility warnings",
           "Shows a warning message when a module without explicit ion mobility support is "
-          + "used to process ion mobility data."));
+              + "used to process ion mobility data."));
 
   public static final DirectoryParameter tempDirectory = new DirectoryParameter(
       "Temporary file directory", "Directory where temporary files"
-                                  + " will be stored. Directory should be located on a drive with fast read and write "
-                                  + "(e.g., an SSD). Requires a restart of MZmine to take effect (the program argument --temp "
-                                  + "overrides this parameter, if set: --temp D:\\your_tmp_dir\\)",
+      + " will be stored. Directory should be located on a drive with fast read and write "
+      + "(e.g., an SSD). Requires a restart of MZmine to take effect (the program argument --temp "
+      + "overrides this parameter, if set: --temp D:\\your_tmp_dir\\)",
       System.getProperty("java.io.tmpdir"));
 
   public static final ComboParameter<KeepInMemory> memoryOption = new ComboParameter<>(
       "Keep in memory", String.format(
       "Specifies the objects that are kept in memory rather than memory mapping "
-      + "them into temp files in the temp directory. Parameter is overriden by the program "
-      + "argument --memory. Depending on the read/write speed of the temp directory,"
-      + " memory mapping is a fast and memory efficient way to handle data, therefore, the "
-      + "default is to memory map all spectral data and feature data with the option %s. On "
-      + "systems where memory (RAM) is no concern, viable options are %s and %s, to keep all in memory "
-      + "or to keep mass lists and feauture data in memory, respectively.", KeepInMemory.NONE,
+          + "them into temp files in the temp directory. Parameter is overriden by the program "
+          + "argument --memory. Depending on the read/write speed of the temp directory,"
+          + " memory mapping is a fast and memory efficient way to handle data, therefore, the "
+          + "default is to memory map all spectral data and feature data with the option %s. On "
+          + "systems where memory (RAM) is no concern, viable options are %s and %s, to keep all in memory "
+          + "or to keep mass lists and feauture data in memory, respectively.", KeepInMemory.NONE,
       KeepInMemory.ALL, KeepInMemory.MASSES_AND_FEATURES), KeepInMemory.values(),
       KeepInMemory.NONE);
 
@@ -182,19 +181,12 @@ public class MZminePreferences extends SimpleParameterSet {
   public static final ComboParameter<ImageNormalization> imageNormalization = new ComboParameter<ImageNormalization>(
       "Normalize images",
       "Specifies if displayed images shall be normalized to the average TIC or shown according to the raw data."
-      + "only applies to newly generated plots.", ImageNormalization.values(),
+          + "only applies to newly generated plots.", ImageNormalization.values(),
       ImageNormalization.NO_NORMALIZATION);
 
   public static final ComboParameter<PaintScaleTransform> imageTransformation = new ComboParameter<>(
       "Image paint scale transformation", "Transforms the paint scale for images.",
       PaintScaleTransform.values(), PaintScaleTransform.LINEAR);
-
-  private static final NumberFormats exportFormat = new NumberFormats(new DecimalFormat("0.#####"),
-      new DecimalFormat("0.####"), new DecimalFormat("0.####"), new DecimalFormat("0.##"),
-      new DecimalFormat("0.###E0"), new DecimalFormat("0.##"), new DecimalFormat("0.####"),
-      new DecimalFormat("0.###"), UnitFormat.DIVIDE);
-  private final BooleanProperty darkModeProperty = new SimpleBooleanProperty(false);
-  private NumberFormats guiFormat = exportFormat; // default value
 
   public static final FileNameParameter msConvertPath = new FileNameParameter("MSConvert path",
       "Set a path to MSConvert to automatically convert unknown vendor formats to mzML while importing.",
@@ -203,13 +195,27 @@ public class MZminePreferences extends SimpleParameterSet {
   public static final BooleanParameter keepConvertedFile = new BooleanParameter(
       "Keep files converted by MSConvert",
       "Store the files after conversion by MSConvert to an mzML file.\n"
-      + "This will reduce the import time when re-processing, but require more disc space.", false);
+          + "This will reduce the import time when re-processing, but require more disc space.",
+      false);
 
   public static final BooleanParameter applyPeakPicking = new BooleanParameter(
       "Apply peak picking (recommended)",
       "Apply vendor peak picking during import of native vendor files with MSConvert.\n"
-      + "Using the vendor peak picking during conversion usually leads to better results that using a generic algorithm.",
+          + "Using the vendor peak picking during conversion usually leads to better results that using a generic algorithm.",
       true);
+
+  public static final ComboParameter<ThermoImportOptions> thermoImportChoice = new ComboParameter<>(
+      "Thermo data import", """
+      Specify which path you want to use for Thermo raw data import. MSConvert allows import of
+      UV spectra and chromatograms and is therefore recommended, but only available on windows.
+      """, ThermoImportOptions.getOptionsForOs(), ThermoImportOptions.MSCONVERT);
+
+  private static final NumberFormats exportFormat = new NumberFormats(new DecimalFormat("0.#####"),
+      new DecimalFormat("0.####"), new DecimalFormat("0.####"), new DecimalFormat("0.##"),
+      new DecimalFormat("0.###E0"), new DecimalFormat("0.##"), new DecimalFormat("0.####"),
+      new DecimalFormat("0.###"), UnitFormat.DIVIDE);
+  private final BooleanProperty darkModeProperty = new SimpleBooleanProperty(false);
+  private NumberFormats guiFormat = exportFormat; // default value
 
   public MZminePreferences() {
     super(// start with performance
@@ -228,7 +234,7 @@ public class MZminePreferences extends SimpleParameterSet {
         // silent parameters without controls
         showTempFolderAlert, username,
         //
-        msConvertPath, keepConvertedFile, applyPeakPicking);
+        msConvertPath, keepConvertedFile, applyPeakPicking, thermoImportChoice);
 
     darkModeProperty.subscribe(state -> {
       var oldTheme = getValue(theme);
@@ -258,7 +264,8 @@ public class MZminePreferences extends SimpleParameterSet {
         intensityFormat, ppmFormat, scoreFormat, unitFormat);
     dialog.addParameterGroup("Visuals", defaultColorPalette, defaultPaintScale, chartParam, theme,
         presentationMode, showPrecursorWindow, imageTransformation, imageNormalization);
-    dialog.addParameterGroup("MS data import", msConvertPath, keepConvertedFile, applyPeakPicking);
+    dialog.addParameterGroup("MS data import", msConvertPath, keepConvertedFile, applyPeakPicking,
+        thermoImportChoice);
 //    dialog.addParameterGroup("Other", new Parameter[]{
     // imsModuleWarnings, showTempFolderAlert, windowSetttings  are hidden parameters
 //    });
@@ -332,8 +339,8 @@ public class MZminePreferences extends SimpleParameterSet {
 
       boolean changeColors = false;
       if (theme.isDark() && (ColorUtils.isDark(bgColor) || ColorUtils.isDark(axisFont.getColor())
-                             || ColorUtils.isDark(itemFont.getColor()) || ColorUtils.isDark(
-          titleFont.getColor()) || ColorUtils.isDark(subTitleFont.getColor()))) {
+          || ColorUtils.isDark(itemFont.getColor()) || ColorUtils.isDark(titleFont.getColor())
+          || ColorUtils.isDark(subTitleFont.getColor()))) {
         if (DialogLoggerUtil.showDialogYesNo("Change theme?", """
             MZmine detected that you changed the GUI theme.
             The current chart theme colors might not be readable.

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/preferences/ThermoImportOptions.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/preferences/ThermoImportOptions.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2004-2024 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.gui.preferences;
+
+import com.sun.jna.Platform;
+
+public enum ThermoImportOptions {
+  THERMO_RAW_FILE_PARSER, MSCONVERT;
+
+
+  public static ThermoImportOptions[] getOptionsForOs() {
+    if (Platform.isWindows()) {
+      return new ThermoImportOptions[]{THERMO_RAW_FILE_PARSER, MSCONVERT};
+    } else {
+      return new ThermoImportOptions[]{THERMO_RAW_FILE_PARSER};
+    }
+  }
+
+  @Override
+  public String toString() {
+    return switch (this) {
+      case THERMO_RAW_FILE_PARSER -> "Thermo raw file parser (academia only)";
+      case MSCONVERT -> "MSConvert";
+    };
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoRawImportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoRawImportTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -54,7 +54,6 @@ import java.util.zip.ZipInputStream;
 import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -66,7 +65,6 @@ public class ThermoRawImportTask extends AbstractTask {
   public static final String THERMO_RAW_PARSER_DIR = "mzmine_thermo_raw_parser";
 
   private static final Logger logger = Logger.getLogger(ThermoRawImportTask.class.getName());
-  private static final org.slf4j.Logger log = LoggerFactory.getLogger(ThermoRawImportTask.class);
 
   private final File fileToOpen;
   private final MZmineProject project;

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoRawImportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoRawImportTask.java
@@ -28,8 +28,13 @@ package io.github.mzmine.modules.io.import_rawdata_thermo_raw;
 import com.sun.jna.Platform;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.gui.preferences.MZminePreferences;
+import io.github.mzmine.gui.preferences.ThermoImportOptions;
+import io.github.mzmine.main.ConfigService;
 import io.github.mzmine.modules.MZmineModule;
 import io.github.mzmine.modules.io.import_rawdata_all.spectral_processor.ScanImportProcessorConfig;
+import io.github.mzmine.modules.io.import_rawdata_msconvert.MSConvert;
+import io.github.mzmine.modules.io.import_rawdata_msconvert.MSConvertImportTask;
 import io.github.mzmine.modules.io.import_rawdata_mzml.MSDKmzMLImportTask;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
@@ -37,14 +42,18 @@ import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.ZipUtils;
 import io.github.mzmine.util.exceptions.ExceptionUtils;
 import io.github.mzmine.util.files.FileAndPathUtil;
+import io.mzio.users.service.UserType;
+import io.mzio.users.user.CurrentUserService;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
+import java.util.List;
 import java.util.logging.Logger;
 import java.util.zip.ZipInputStream;
 import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 
 /**
@@ -53,6 +62,8 @@ import org.jetbrains.annotations.NotNull;
  */
 public class ThermoRawImportTask extends AbstractTask {
 
+  public static final String THERMO_RAW_PARSER_DIR = "mzmine_thermo_raw_parser";
+
   private static final Logger logger = Logger.getLogger(ThermoRawImportTask.class.getName());
 
   private final File fileToOpen;
@@ -60,16 +71,11 @@ public class ThermoRawImportTask extends AbstractTask {
   private final ParameterSet parameters;
   private final Class<? extends MZmineModule> module;
   private final ScanImportProcessorConfig scanProcessorConfig;
-
   private Process dumper = null;
-
   private String taskDescription;
   private int parsedScans = 0;
-
   private MSDKmzMLImportTask msdkTask;
   private int convertedScans;
-  public static final String THERMO_RAW_PARSER_DIR = "mzmine_thermo_raw_parser";
-
 
   public ThermoRawImportTask(MZmineProject project, File fileToOpen, RawDataFile newMZmineFile,
       @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters,
@@ -98,47 +104,23 @@ public class ThermoRawImportTask extends AbstractTask {
     setStatus(TaskStatus.PROCESSING);
     logger.info("Opening file " + fileToOpen);
 
-    // Unzip ThermoRawFileParser
-    try {
-      final File thermoRawFileParserDir = unzipThermoRawFileParser();
-      taskDescription = "Opening file " + fileToOpen;
-      String thermoRawFileParserCommand;
+    final boolean useMsConvertForThermo =
+        ConfigService.getPreferences().getValue(MZminePreferences.thermoImportChoice)
+            == ThermoImportOptions.MSCONVERT;
 
-      if (Platform.isWindows()) {
-        thermoRawFileParserCommand =
-            thermoRawFileParserDir + File.separator + "ThermoRawFileParser.exe";
-      } else if (Platform.isLinux()) {
-        thermoRawFileParserCommand =
-            thermoRawFileParserDir + File.separator + "ThermoRawFileParserLinux";
-      } else if (Platform.isMac()) {
-        thermoRawFileParserCommand =
-            thermoRawFileParserDir + File.separator + "ThermoRawFileParserMac";
-      } else {
-        setStatus(TaskStatus.ERROR);
-        setErrorMessage("Unsupported platform: JNA ID " + Platform.getOSType());
+    try {
+      final ProcessBuilder builder = useMsConvertForThermo ? createProcessFromMsConvert()
+          : createProcessFromThermoFileParser();
+      if (builder == null) {
         return;
       }
 
-      final String cmdLine[] = new String[]{ //
-          thermoRawFileParserCommand, // program to run
-          "-s", // output mzML to stdout
-          "-p", // no peak picking
-          "-z", // no zlib compression (higher speed)
-          "-f=1", // no index, https://github.com/compomics/ThermoRawFileParser/issues/118
-          "-i", // input RAW file name coming next
-          fileToOpen.getPath() // input RAW file name
-      };
-
-      // Create a separate process and execute ThermoRawFileParser.
-      // Use thermoRawFileParserDir as working directory; this is essential, otherwise the process will fail.
-      dumper = Runtime.getRuntime().exec(cmdLine, null, thermoRawFileParserDir);
+      dumper = builder.start();
 
       // Get the stdout of ThermoRawFileParser process as InputStream
       RawDataFile dataFile = null;
       try (InputStream mzMLStream = dumper.getInputStream()) //
-//          BufferedInputStream bufStream = new BufferedInputStream(mzMLStream))//
       {
-
         msdkTask = new MSDKmzMLImportTask(project, fileToOpen, mzMLStream, scanProcessorConfig,
             module, parameters, moduleCallDate, storage);
 
@@ -190,6 +172,59 @@ public class ThermoRawImportTask extends AbstractTask {
 
   }
 
+  private @Nullable ProcessBuilder createProcessFromMsConvert() {
+    final File msConvertPath = MSConvert.getMsConvertPath();
+    if (msConvertPath == null) {
+      error("MSConvert not found. Please install MSConvert to import thermo raw data files.");
+      return null;
+    }
+
+    final List<String> cmdLine = MSConvertImportTask.buildCommandLine(fileToOpen, msConvertPath,
+        false);
+    return new ProcessBuilder(cmdLine);
+  }
+
+  private @Nullable ProcessBuilder createProcessFromThermoFileParser() throws IOException {
+    if (CurrentUserService.getUser().getUserType() != UserType.ACADEMIC) {
+      error("Cannot use Thermo raw file parser import without an academic license.");
+      return null;
+    }
+
+    final File thermoRawFileParserDir = unzipThermoRawFileParser();
+    taskDescription = "Opening file " + fileToOpen;
+    String thermoRawFileParserCommand;
+
+    if (Platform.isWindows()) {
+      thermoRawFileParserCommand =
+          thermoRawFileParserDir + File.separator + "ThermoRawFileParser.exe";
+    } else if (Platform.isLinux()) {
+      thermoRawFileParserCommand =
+          thermoRawFileParserDir + File.separator + "ThermoRawFileParserLinux";
+    } else if (Platform.isMac()) {
+      thermoRawFileParserCommand =
+          thermoRawFileParserDir + File.separator + "ThermoRawFileParserMac";
+    } else {
+      setStatus(TaskStatus.ERROR);
+      setErrorMessage("Unsupported platform: JNA ID " + Platform.getOSType());
+      return null;
+    }
+
+    final String cmdLine[] = new String[]{ //
+        thermoRawFileParserCommand, // program to run
+        "-s", // output mzML to stdout
+        "-p", // no peak picking
+        "-z", // no zlib compression (higher speed)
+        "-f=1", // no index, https://github.com/compomics/ThermoRawFileParser/issues/118
+        "-i", // input RAW file name coming next
+        fileToOpen.getPath() // input RAW file name
+    };
+
+    // Create a separate process and execute ThermoRawFileParser.
+    // Use thermoRawFileParserDir as working directory; this is essential, otherwise the process will fail.
+    ProcessBuilder builder = new ProcessBuilder(cmdLine).directory(thermoRawFileParserDir);
+    return builder;
+  }
+
   @Override
   public String getTaskDescription() {
     return taskDescription;
@@ -197,7 +232,8 @@ public class ThermoRawImportTask extends AbstractTask {
 
   private File unzipThermoRawFileParser() throws IOException {
 
-    File thermoRawFileParserFolder = FileAndPathUtil.createTempDirectory(THERMO_RAW_PARSER_DIR).toFile();
+    File thermoRawFileParserFolder = FileAndPathUtil.createTempDirectory(THERMO_RAW_PARSER_DIR)
+        .toFile();
     final File thermoRawFileParserExe = new File(thermoRawFileParserFolder,
         "ThermoRawFileParser.exe");
 
@@ -228,7 +264,8 @@ public class ThermoRawImportTask extends AbstractTask {
     ZipInputStream zipInputStream = new ZipInputStream(zipStream);
     ZipUtils.unzipStream(zipInputStream, thermoRawFileParserFolder);
     zipInputStream.close();
-    logger.finest(STR."Finished unpacking ThermoRawFileParser to folder \{thermoRawFileParserFolder}");
+    logger.finest(
+        STR."Finished unpacking ThermoRawFileParser to folder \{thermoRawFileParserFolder}");
 
     // Delete the temporary folder on application exit
     FileUtils.forceDeleteOnExit(thermoRawFileParserFolder);


### PR DESCRIPTION
- add option to use msconvert for thermo import
- allows import of uv traces and spectra
- checks if it's an academic license (then allows usage of thermo raw file parser and looks for msconvert otherwise)