### PR TITLE
Enable thermo import via self-downloaded parser

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/gui/preferences/MZminePreferences.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/preferences/MZminePreferences.java
@@ -25,6 +25,8 @@
 
 package io.github.mzmine.gui.preferences;
 
+import static io.github.mzmine.util.files.ExtensionFilters.MSCONVERT;
+
 import io.github.mzmine.gui.chartbasics.chartthemes.ChartThemeParameters;
 import io.github.mzmine.gui.chartbasics.chartutils.paintscales.PaintScaleTransform;
 import io.github.mzmine.javafx.dialogs.DialogLoggerUtil;
@@ -69,6 +71,7 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.FXCollections;
 import javafx.scene.paint.Color;
+import javafx.stage.FileChooser.ExtensionFilter;
 import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Element;
 
@@ -145,24 +148,24 @@ public class MZminePreferences extends SimpleParameterSet {
   public static final HiddenParameter<Map<String, Boolean>> imsModuleWarnings = new HiddenParameter<>(
       new OptOutParameter("Ion mobility compatibility warnings",
           "Shows a warning message when a module without explicit ion mobility support is "
-          + "used to process ion mobility data."));
+              + "used to process ion mobility data."));
 
   public static final DirectoryParameter tempDirectory = new DirectoryParameter(
       "Temporary file directory", "Directory where temporary files"
-                                  + " will be stored. Directory should be located on a drive with fast read and write "
-                                  + "(e.g., an SSD). Requires a restart of MZmine to take effect (the program argument --temp "
-                                  + "overrides this parameter, if set: --temp D:\\your_tmp_dir\\)",
+      + " will be stored. Directory should be located on a drive with fast read and write "
+      + "(e.g., an SSD). Requires a restart of MZmine to take effect (the program argument --temp "
+      + "overrides this parameter, if set: --temp D:\\your_tmp_dir\\)",
       System.getProperty("java.io.tmpdir"));
 
   public static final ComboParameter<KeepInMemory> memoryOption = new ComboParameter<>(
       "Keep in memory", String.format(
       "Specifies the objects that are kept in memory rather than memory mapping "
-      + "them into temp files in the temp directory. Parameter is overriden by the program "
-      + "argument --memory. Depending on the read/write speed of the temp directory,"
-      + " memory mapping is a fast and memory efficient way to handle data, therefore, the "
-      + "default is to memory map all spectral data and feature data with the option %s. On "
-      + "systems where memory (RAM) is no concern, viable options are %s and %s, to keep all in memory "
-      + "or to keep mass lists and feauture data in memory, respectively.", KeepInMemory.NONE,
+          + "them into temp files in the temp directory. Parameter is overriden by the program "
+          + "argument --memory. Depending on the read/write speed of the temp directory,"
+          + " memory mapping is a fast and memory efficient way to handle data, therefore, the "
+          + "default is to memory map all spectral data and feature data with the option %s. On "
+          + "systems where memory (RAM) is no concern, viable options are %s and %s, to keep all in memory "
+          + "or to keep mass lists and feauture data in memory, respectively.", KeepInMemory.NONE,
       KeepInMemory.ALL, KeepInMemory.MASSES_AND_FEATURES), KeepInMemory.values(),
       KeepInMemory.NONE);
 
@@ -184,7 +187,7 @@ public class MZminePreferences extends SimpleParameterSet {
   public static final ComboParameter<ImageNormalization> imageNormalization = new ComboParameter<ImageNormalization>(
       "Normalize images",
       "Specifies if displayed images shall be normalized to the average TIC or shown according to the raw data."
-      + "only applies to newly generated plots.", ImageNormalization.values(),
+          + "only applies to newly generated plots.", ImageNormalization.values(),
       ImageNormalization.NO_NORMALIZATION);
 
   public static final ComboParameter<PaintScaleTransform> imageTransformation = new ComboParameter<>(
@@ -201,24 +204,35 @@ public class MZminePreferences extends SimpleParameterSet {
   public static final FileNameParameter msConvertPath = new FileNameWithDownloadParameter(
       "MSConvert path",
       "Set a path to MSConvert to automatically convert unknown vendor formats to mzML while importing.",
-      List.of(ExtensionFilters.EXE, ExtensionFilters.ALL_FILES), ExternalAsset.MSCONVERT);
+      List.of(MSCONVERT), ExternalAsset.MSCONVERT);
 
   public static final BooleanParameter keepConvertedFile = new BooleanParameter(
       "Keep files converted by MSConvert",
       "Store the files after conversion by MSConvert to an mzML file.\n"
-      + "This will reduce the import time when re-processing, but require more disc space.", false);
+          + "This will reduce the import time when re-processing, but require more disc space.",
+      false);
 
   public static final BooleanParameter applyPeakPicking = new BooleanParameter(
       "Apply peak picking (recommended)",
       "Apply vendor peak picking during import of native vendor files with MSConvert.\n"
-      + "Using the vendor peak picking during conversion usually leads to better results that using a generic algorithm.",
+          + "Using the vendor peak picking during conversion usually leads to better results that using a generic algorithm.",
       true);
 
-//  public static final ComboParameter<ThermoImportOptions> thermoImportChoice = new ComboParameter<>(
-//      "Thermo data import", """
-//      Specify which path you want to use for Thermo raw data import. MSConvert allows import of
-//      UV spectra and chromatograms and is therefore recommended, but only available on windows.
-//      """, ThermoImportOptions.getOptionsForOs(), ThermoImportOptions.MSCONVERT);
+  public static final ComboParameter<ThermoImportOptions> thermoImportChoice = new ComboParameter<>(
+      "Thermo data import", """
+      Specify which path you want to use for Thermo raw data import. MSConvert allows import of
+      UV spectra and chromatograms and is therefore recommended, but only available on windows.
+      """, ThermoImportOptions.getOptionsForOs(), ThermoImportOptions.MSCONVERT);
+
+  public static final FileNameWithDownloadParameter thermoRawFileParserPath = new FileNameWithDownloadParameter(
+      "Thermo raw file parser location", "The file path to the thermo raw file parser.", List.of(
+      new ExtensionFilter("Executable or zip", "ThermoRawFileParser.exe",
+          "ThermoRawFileParserLinux", "ThermoRawFileParserMac", "ThermoRawFileParser.zip"),
+      new ExtensionFilter("zip", "ThermoRawFileParser.zip"),
+      new ExtensionFilter("Windows executable", "ThermoRawFileParser.exe"),
+      new ExtensionFilter("Linux executable", "ThermoRawFileParserLinux"),
+      new ExtensionFilter("Mac executable", "ThermoRawFileParserMac")),
+      ExternalAsset.ThermoRawFileParser);
 
   public static final OptionalParameter<ParameterSetParameter<WatersLockmassParameters>> watersLockmass = new OptionalParameter<>(
       new ParameterSetParameter<>("Apply lockmass on import (Waters)",
@@ -242,7 +256,8 @@ public class MZminePreferences extends SimpleParameterSet {
         // silent parameters without controls
         showTempFolderAlert, username,
         //
-        msConvertPath, keepConvertedFile, applyPeakPicking, /*thermoImportChoice,*/ watersLockmass);
+        msConvertPath, keepConvertedFile, applyPeakPicking, watersLockmass, thermoRawFileParserPath,
+        thermoImportChoice);
 
     darkModeProperty.subscribe(state -> {
       var oldTheme = getValue(theme);
@@ -273,7 +288,7 @@ public class MZminePreferences extends SimpleParameterSet {
     dialog.addParameterGroup("Visuals", defaultColorPalette, defaultPaintScale, chartParam, theme,
         presentationMode, showPrecursorWindow, imageTransformation, imageNormalization);
     dialog.addParameterGroup("MS data import", msConvertPath, keepConvertedFile, applyPeakPicking,
-        /*thermoImportChoice,*/ watersLockmass);
+        watersLockmass, thermoRawFileParserPath, thermoImportChoice);
 //    dialog.addParameterGroup("Other", new Parameter[]{
     // imsModuleWarnings, showTempFolderAlert, windowSetttings  are hidden parameters
 //    });
@@ -347,8 +362,8 @@ public class MZminePreferences extends SimpleParameterSet {
 
       boolean changeColors = false;
       if (theme.isDark() && (ColorUtils.isDark(bgColor) || ColorUtils.isDark(axisFont.getColor())
-                             || ColorUtils.isDark(itemFont.getColor()) || ColorUtils.isDark(
-          titleFont.getColor()) || ColorUtils.isDark(subTitleFont.getColor()))) {
+          || ColorUtils.isDark(itemFont.getColor()) || ColorUtils.isDark(titleFont.getColor())
+          || ColorUtils.isDark(subTitleFont.getColor()))) {
         if (DialogLoggerUtil.showDialogYesNo("Change theme?", """
             MZmine detected that you changed the GUI theme.
             The current chart theme colors might not be readable.

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/preferences/ThermoImportOptions.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/preferences/ThermoImportOptions.java
@@ -42,7 +42,7 @@ public enum ThermoImportOptions {
   @Override
   public String toString() {
     return switch (this) {
-      case THERMO_RAW_FILE_PARSER -> "Thermo raw file parser (academia only)";
+      case THERMO_RAW_FILE_PARSER -> "Thermo raw file parser";
       case MSCONVERT -> "MSConvert";
     };
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/download/ExternalAsset.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/download/ExternalAsset.java
@@ -70,7 +70,7 @@ public enum ExternalAsset {
   public String getDownloadInfoPage() {
     return switch (this) {
       case ThermoRawFileParser ->
-          "https://github.com/compomics/ThermoRawFileParser/releases/latest";
+          "https://github.com/pluskal-lab/ThermoRawFileParserMacLinux/releases";
       case MSCONVERT -> "https://proteowizard.sourceforge.io/download.html";
       // libraries
       case MSnLib -> "https://zenodo.org/records/11163381";

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_all/AllSpectralDataImportModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_all/AllSpectralDataImportModule.java
@@ -49,6 +49,7 @@ import io.github.mzmine.modules.io.import_rawdata_mzdata.MzDataImportTask;
 import io.github.mzmine.modules.io.import_rawdata_mzml.MSDKmzMLImportTask;
 import io.github.mzmine.modules.io.import_rawdata_mzxml.MzXMLImportTask;
 import io.github.mzmine.modules.io.import_rawdata_netcdf.NetCDFImportTask;
+import io.github.mzmine.modules.io.import_rawdata_thermo_raw.ThermoImportTaskDelegator;
 import io.github.mzmine.modules.io.import_rawdata_thermo_raw.ThermoRawImportTask;
 import io.github.mzmine.modules.io.import_rawdata_zip.ZipImportTask;
 import io.github.mzmine.modules.io.import_spectral_library.SpectralLibraryImportParameters;
@@ -369,8 +370,8 @@ public class AllSpectralDataImportModule implements MZmineProcessingModule {
       case NETCDF ->
           new NetCDFImportTask(project, file, newMZmineFile, module, parameters, moduleCallDate);
       case THERMO_RAW ->
-          new ThermoRawImportTask(project, file, newMZmineFile, module, parameters, moduleCallDate,
-              scanProcessorConfig);
+          new ThermoImportTaskDelegator(storage, moduleCallDate, file, scanProcessorConfig, project,
+              parameters, module);
       case ICPMSMS_CSV ->
           new IcpMsCVSImportTask(project, file, newMZmineFile, module, parameters, moduleCallDate);
       case MZML_GZIP, MZML_ZIP ->
@@ -413,8 +414,10 @@ public class AllSpectralDataImportModule implements MZmineProcessingModule {
           new TDFImportTask(project, file, storage, scanProcessorConfig, module, parameters,
               moduleCallDate);
       case THERMO_RAW ->
-          new ThermoRawImportTask(project, file, newMZmineFile, module, parameters, moduleCallDate,
-              scanProcessorConfig);
+          new ThermoImportTaskDelegator(storage, moduleCallDate, file, scanProcessorConfig, project,
+              parameters, module);
+//          new ThermoRawImportTask(project, file, module, parameters, moduleCallDate,
+//              scanProcessorConfig);
       case BRUKER_TSF ->
           new TSFImportTask(project, file, storage, module, parameters, moduleCallDate,
               scanProcessorConfig);
@@ -448,13 +451,13 @@ public class AllSpectralDataImportModule implements MZmineProcessingModule {
   private RawDataFile createDataFile(RawDataFileType fileType, String absPath, String newName,
       MemoryMapStorage storage) throws IOException {
     return switch (fileType) {
-      case MZXML, MZDATA, THERMO_RAW, /*WATERS_RAW,*/ NETCDF, ICPMSMS_CSV ->
+      case MZXML, MZDATA, /*WATERS_RAW,*/ NETCDF, ICPMSMS_CSV ->
           MZmineCore.createNewFile(newName, absPath, storage);
       case MZML, MZML_IMS, MZML_ZIP, MZML_GZIP -> null; // created in Mzml import task
       case IMZML -> MZmineCore.createNewImagingFile(newName, absPath, storage);
       case BRUKER_TSF, BRUKER_BAF, BRUKER_TDF ->
           null; // TSF can be anything: Single shot maldi, imaging, or LC-MS (non ims)
-      case WATERS_RAW, SCIEX_WIFF, SCIEX_WIFF2, AGILENT_D -> null;
+      case WATERS_RAW, SCIEX_WIFF, SCIEX_WIFF2, AGILENT_D, THERMO_RAW -> null;
     };
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvert.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvert.java
@@ -25,6 +25,8 @@
 
 package io.github.mzmine.modules.io.import_rawdata_msconvert;
 
+import static io.github.mzmine.util.files.ExtensionFilters.MSCONVERT;
+
 import com.vdurmont.semver4j.Semver;
 import io.github.mzmine.javafx.concurrent.threading.FxThread;
 import io.github.mzmine.javafx.util.FxFileChooser;
@@ -81,9 +83,8 @@ public class MSConvert {
           () -> "Cannot find MSConvert in the regular install directories. Please set the MSConvert path in the config before launching in headless mode.");
     } else {
       FxThread.runOnFxThreadAndWait(() -> {
-        final ExtensionFilter filter = new ExtensionFilter("MSConvert", "msconvert.exe");
         selected.set(
-            FxFileChooser.openSelectDialog(FxFileChooser.FileSelectionType.OPEN, List.of(filter),
+            FxFileChooser.openSelectDialog(FxFileChooser.FileSelectionType.OPEN, List.of(MSCONVERT),
                 null, "Please select the MSConvert path."));
       });
     }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvertImportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvertImportTask.java
@@ -242,7 +242,7 @@ public class MSConvertImportTask extends AbstractTask {
     }
   }
 
-  private @NotNull File getMzMLFileName(File filePath) {
+  public static @NotNull File getMzMLFileName(File filePath) {
     final String fileName = filePath.getName();
     final String extension = FileAndPathUtil.getExtension(fileName);
     final String mzMLName = fileName.replace(extension, "mzML");

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoImportTaskDelegator.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoImportTaskDelegator.java
@@ -1,0 +1,83 @@
+package io.github.mzmine.modules.io.import_rawdata_thermo_raw;
+
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.features.FeatureList;
+import io.github.mzmine.gui.preferences.MZminePreferences;
+import io.github.mzmine.gui.preferences.ThermoImportOptions;
+import io.github.mzmine.main.ConfigService;
+import io.github.mzmine.modules.MZmineModule;
+import io.github.mzmine.modules.io.import_rawdata_all.spectral_processor.ScanImportProcessorConfig;
+import io.github.mzmine.modules.io.import_rawdata_msconvert.MSConvertImportTask;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.taskcontrol.AbstractSimpleTask;
+import io.github.mzmine.taskcontrol.AbstractTask;
+import io.github.mzmine.taskcontrol.Task;
+import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.taskcontrol.TaskStatusListener;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.io.File;
+import java.time.Instant;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Handles if thermo files are imported via msconvert or the raw file parser. launches the correct task.
+ */
+public class ThermoImportTaskDelegator extends AbstractSimpleTask {
+
+  private AbstractTask actualTask;
+
+  public ThermoImportTaskDelegator(@Nullable MemoryMapStorage storage,
+      @NotNull Instant moduleCallDate, File file,
+      ScanImportProcessorConfig processorConfig, MZmineProject project,
+      @NotNull ParameterSet parameters, @NotNull Class<? extends MZmineModule> moduleClass) {
+
+    super(storage, moduleCallDate, parameters, moduleClass);
+
+    final ThermoImportOptions importChoice = ConfigService.getPreference(
+        MZminePreferences.thermoImportChoice);
+    actualTask =
+        importChoice == ThermoImportOptions.MSCONVERT ? new MSConvertImportTask(moduleCallDate,
+            file, processorConfig, project, moduleClass, parameters)
+            : new ThermoRawImportTask(project, file, moduleClass, parameters,
+                moduleCallDate, processorConfig);
+
+    // cancel the underlying task if this task is canceled
+    this.addTaskStatusListener((_, newStatus, _) -> actualTask.setStatus(newStatus));
+  }
+
+  @Override
+  protected void process() {
+    actualTask.run();
+    if(actualTask.getStatus() != TaskStatus.FINISHED) {
+      if(actualTask.getErrorMessage() != null) {
+        setErrorMessage(actualTask.getErrorMessage());
+      }
+      setStatus(actualTask.getStatus());
+    }
+  }
+
+  @Override
+  protected @NotNull List<FeatureList> getProcessedFeatureLists() {
+    // applied method added by actual task
+    return List.of();
+  }
+
+  @Override
+  protected @NotNull List<RawDataFile> getProcessedDataFiles() {
+    // applied method added by actual task
+    return List.of();
+  }
+
+  @Override
+  public String getTaskDescription() {
+    return actualTask.getTaskDescription();
+  }
+
+  @Override
+  public double getFinishedPercentage() {
+    return actualTask.getFinishedPercentage();
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoRawImportModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoRawImportModule.java
@@ -116,8 +116,8 @@ public class ThermoRawImportModule implements MZmineProcessingModule {
       try {
         RawDataFile newMZmineFile = MZmineCore.createNewFile(newName,
             fileNames[i].getAbsolutePath(), storage);
-        Task newTask = new ThermoRawImportTask(project, fileNames[i], newMZmineFile,
-            ThermoRawImportModule.class, parameters, moduleCallDate, scanImportProcessorConfig);
+        Task newTask = new ThermoImportTaskDelegator(storage, moduleCallDate, fileNames[i],
+            scanImportProcessorConfig, project, parameters, ThermoRawImportModule.class);
         tasks.add(newTask);
 
       } catch (IOException e) {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoRawImportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoRawImportTask.java
@@ -28,6 +28,7 @@ package io.github.mzmine.modules.io.import_rawdata_thermo_raw;
 import com.sun.jna.Platform;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.gui.DesktopService;
 import io.github.mzmine.gui.preferences.MZminePreferences;
 import io.github.mzmine.gui.preferences.ThermoImportOptions;
 import io.github.mzmine.javafx.concurrent.threading.FxThread;
@@ -35,6 +36,7 @@ import io.github.mzmine.javafx.dialogs.DialogLoggerUtil;
 import io.github.mzmine.main.ConfigService;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineModule;
+import io.github.mzmine.modules.io.download.ExternalAsset;
 import io.github.mzmine.modules.io.import_rawdata_all.spectral_processor.ScanImportProcessorConfig;
 import io.github.mzmine.modules.io.import_rawdata_msconvert.MSConvert;
 import io.github.mzmine.modules.io.import_rawdata_msconvert.MSConvertImportTask;
@@ -43,6 +45,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.ExitCode;
+import io.github.mzmine.util.StringUtils;
 import io.github.mzmine.util.ZipUtils;
 import io.github.mzmine.util.concurrent.CloseableReentrantReadWriteLock;
 import io.github.mzmine.util.exceptions.ExceptionUtils;
@@ -268,6 +271,16 @@ public class ThermoRawImportTask extends AbstractTask {
           ConfigService.getPreferences()
               .setParameter(MZminePreferences.thermoRawFileParserPath, defaultLocation);
           return true;
+        }
+
+        // instructions for headless mode.
+        if (DesktopService.isHeadLess()) {
+          logger.severe(
+              "Cannot find thermo raw file parser. Download the parser from %s and unzip the content into %s or edit the mzmine config file (parameter %s).".formatted(
+                  StringUtils.inQuotes(ExternalAsset.ThermoRawFileParser.getDownloadInfoPage()),
+                  StringUtils.inQuotes(DEFAULT_PARSER_DIR.toString()),
+                  StringUtils.inQuotes(MZminePreferences.thermoRawFileParserPath.getName())));
+          return false;
         }
 
         logger.fine(

--- a/mzmine-community/src/main/java/io/github/mzmine/util/RawDataFileUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/RawDataFileUtils.java
@@ -41,6 +41,7 @@ import io.github.mzmine.modules.io.import_rawdata_mzdata.MzDataImportTask;
 import io.github.mzmine.modules.io.import_rawdata_mzml.MSDKmzMLImportTask;
 import io.github.mzmine.modules.io.import_rawdata_mzxml.MzXMLImportTask;
 import io.github.mzmine.modules.io.import_rawdata_netcdf.NetCDFImportTask;
+import io.github.mzmine.modules.io.import_rawdata_thermo_raw.ThermoImportTaskDelegator;
 import io.github.mzmine.modules.io.import_rawdata_thermo_raw.ThermoRawImportTask;
 import io.github.mzmine.modules.io.import_rawdata_zip.ZipImportTask;
 import io.github.mzmine.parameters.ParameterSet;
@@ -123,10 +124,8 @@ public class RawDataFileUtils {
               moduleCallDate);
           break;
         case THERMO_RAW:
-          newMZmineFile = MZmineCore.createNewFile(fileName.getName(), fileName.getAbsolutePath(),
-              storage);
-          newTask = new ThermoRawImportTask(project, fileName, newMZmineFile, module, parameters,
-              moduleCallDate, scanProcessorConfig);
+          newTask = new ThermoImportTaskDelegator(storage, moduleCallDate, fileName, scanProcessorConfig, project,
+              parameters, module);
           break;
 /*        case WATERS_RAW:
           newMZmineFile = MZmineCore.createNewFile(fileName.getName(), fileName.getAbsolutePath(),

--- a/utils/src/main/java/io/github/mzmine/util/files/ExtensionFilters.java
+++ b/utils/src/main/java/io/github/mzmine/util/files/ExtensionFilters.java
@@ -128,6 +128,8 @@ public class ExtensionFilters {
   public static final List<ExtensionFilter> ALL_LIBRARY = List.of(ALL_SPECTRAL_LIBRARY_FILTER,
       JSON_LIBRARY, MGF, MSP, JDCAMX, ALL_FILES);
 
+  public static final ExtensionFilter MSCONVERT = new ExtensionFilter("MSConvert", "msconvert.exe");
+
 
   public static String getExtensionName(ExtensionFilter filter) {
     return filter.getExtensions().stream().findFirst().map(ext -> {


### PR DESCRIPTION
- Add parameter to settings for raw file parser location
- Add parameter for thermo import option (msconvert or raw file parser)
- Thread-blocking check if the dir is set correctly, show an error message and open preferences otherwise
- If a zip is selected, unzip to external_resources folder
- also check external_resources folder for already-unzipped parsers if the current path is invalid (auto discover if the config was broken)