### PR TITLE
save relative paths in projects

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/MZmineProject.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/MZmineProject.java
@@ -33,6 +33,7 @@ import io.github.mzmine.project.impl.ProjectChangeEvent.Type;
 import io.github.mzmine.project.impl.ProjectChangeListener;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibrary;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Hashtable;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
@@ -128,14 +129,16 @@ public interface MZmineProject {
    *
    * @return copy of the current feature lists
    */
-  @NotNull List<FeatureList> getCurrentFeatureLists();
+  @NotNull
+  List<FeatureList> getCurrentFeatureLists();
 
   /**
    * Unmodifiable copy of current list
    *
    * @return copy of current raw data files
    */
-  @NotNull List<RawDataFile> getCurrentRawDataFiles();
+  @NotNull
+  List<RawDataFile> getCurrentRawDataFiles();
 
   void addProjectListener(ProjectChangeListener newListener);
 
@@ -159,9 +162,11 @@ public interface MZmineProject {
    * @param name the exact name of the feature list
    * @return the last feature list with that name or null
    */
-  @Nullable FeatureList getFeatureList(String name);
+  @Nullable
+  FeatureList getFeatureList(String name);
 
-  @Nullable Boolean isStandalone();
+  @Nullable
+  Boolean isStandalone();
 
   void setStandalone(Boolean standalone);
 
@@ -189,7 +194,8 @@ public interface MZmineProject {
    *
    * @return current list of preloaded libraries
    */
-  @NotNull List<SpectralLibrary> getCurrentSpectralLibraries();
+  @NotNull
+  List<SpectralLibrary> getCurrentSpectralLibraries();
 
   /**
    * Remove preloaded spectral library
@@ -219,7 +225,8 @@ public interface MZmineProject {
 
   int getNumberOfDataFiles();
 
-  @NotNull MetadataTable getProjectMetadata();
+  @NotNull
+  MetadataTable getProjectMetadata();
 
   /**
    * find data file by name. Acquires read lock on files for synchronization.
@@ -227,5 +234,19 @@ public interface MZmineProject {
    * @param name name of the file, compared with ignore case
    * @return the RawDataFile or null if the name was null or no such file exists
    */
-  @Nullable RawDataFile getDataFileByName(@Nullable String name);
+  @Nullable
+  RawDataFile getDataFileByName(@Nullable String name);
+
+  /**
+   * @return The relative path of the file/folder with regard to the project file. Null if the path
+   * or the project file are null.
+   */
+  @Nullable
+  Path getRelativePath(@Nullable Path path);
+
+  /**
+   * @return A
+   */
+  @Nullable
+  File resolveRelativePathToFile(@Nullable String path);
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectsave/ProjectSaveAsParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectsave/ProjectSaveAsParameters.java
@@ -58,11 +58,16 @@ public class ProjectSaveAsParameters extends SimpleParameterSet {
       new ExtensionFilter("All files", "*.*") //
   );
   public static final ComboParameter<ProjectSaveOption> option = new ComboParameter<>(
-      "Project type",
-      "Referencing projects point to the original directory of raw data files (with those projects "
-      + "files should not be moved or renamed). Standalone copies the raw data files into the project, "
-      + "creating a large but flexible project that can be shared.", ProjectSaveOption.values(),
-      ProjectSaveOption.REFERENCING);
+      "Project type", """
+      Referencing projects point to the original directory of raw data files as absolute and 
+      relative paths.  Projects can be shared if the raw files are located in exactly the same absolute 
+      path (e.g. starting with C:\\\\...) or the same path relative to the project file (e.g. saving the
+      project in the same folder as the raw files will achieve a portable project - requires mzmine 4.3 or higher). 
+            
+      Standalone copies the raw data files into the project, 
+      creating a larger, but flexible project that can be shared without any additional requirements.""",
+      ProjectSaveOption.values(), ProjectSaveOption.REFERENCING);
+
   public static final FileNameSuffixExportParameter projectFile = new FileNameSuffixExportParameter(
       "Project file", "File name of project to be saved", extensions, null);
   private static final Logger logger = Logger.getLogger(ProjectSaveAsParameters.class.getName());
@@ -80,7 +85,9 @@ public class ProjectSaveAsParameters extends SimpleParameterSet {
         boldText("Standalone: "),
         text("Adds the raw data files into a project (large but flexible)"), linebreak(),
         boldText("Referencing: "), text(
-            "The project will point to the current files used. Any rename, move, or remove of a file from their current directory might lead to incompatibility of the project."),
+            "The project will point to the currently used files. Renaming, moving, or removing"
+                + " a file from its current directory might lead to incompatibility of the project. "
+                + "The project will keep absolute and relative (from mzmine 4.4) paths the the raw files."),
         linebreak(), boldText("WARNING: "),
         text("If this is an existing project, it is recommended to save it in the same way."));
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectsave/ProjectSavingTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectsave/ProjectSavingTask.java
@@ -151,6 +151,11 @@ public class ProjectSavingTask extends AbstractTask {
         case REFERENCING -> savedProject.setStandalone(false);
       }
 
+      // Update the location of the project
+      // set the location before starting the save process, so we can also determine relative
+      // paths for this project.
+      savedProject.setProjectFile(saveFile);
+
       // Prepare a temporary ZIP file. We create this file in the same
       // directory as the final saveFile to avoid moving between
       // filesystems in the last stage (renameTo)
@@ -229,9 +234,6 @@ public class ProjectSavingTask extends AbstractTask {
             "Could not move the temporary file " + tempFile + " to the final location " + saveFile);
       }
 
-      // Update the location of the project
-      savedProject.setProjectFile(saveFile);
-
       // Update the window title to reflect the new name of the project
       // if (MZmineCore.getDesktop() instanceof MainWindow) {
       // MainWindow mainWindow = (MainWindow) MZmineCore.getDesktop();
@@ -254,7 +256,7 @@ public class ProjectSavingTask extends AbstractTask {
       } else {
         setErrorMessage(
             "Failed saving the project. Error while saving " + currentSavedObjectName + ": "
-            + ExceptionUtils.exceptionToString(e));
+                + ExceptionUtils.exceptionToString(e));
       }
 
     }

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/filenames/FileNameParameter.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/filenames/FileNameParameter.java
@@ -25,11 +25,15 @@
 
 package io.github.mzmine.parameters.parametertypes.filenames;
 
+import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.parameters.UserParameter;
+import io.github.mzmine.project.ProjectService;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Pattern;
 import javafx.stage.FileChooser.ExtensionFilter;
 import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Document;
@@ -41,6 +45,10 @@ import org.w3c.dom.NodeList;
  * Simple Parameter implementation
  */
 public class FileNameParameter implements UserParameter<File, FileNameComponent> {
+
+  public static final Pattern FILE_PATH_PATTERN = Pattern.compile(
+      "^(?:[a-zA-Z]:\\\\|\\/)?(?:[^<>:\"/\\\\|?*\\x00-\\x1F]+[\\/\\\\]?)*$");
+  public static final String SPLIT_CHARACTER = "||";
 
   protected static final String CURRENT_FILE_ELEMENT = "current_file";
   protected static final String LAST_FILE_ELEMENT = "last_file";
@@ -170,8 +178,21 @@ public class FileNameParameter implements UserParameter<File, FileNameComponent>
   @Override
   public void loadValueFromXML(Element xmlElement) {
     NodeList current = xmlElement.getElementsByTagName(CURRENT_FILE_ELEMENT);
+    final File projectFile = ProjectService.getProject().getProjectFile();
+
     if (current.getLength() == 1) {
-      setValue(new File(current.item(0).getTextContent()));
+      final File absFile = new File(current.item(0).getTextContent());
+
+      final String relPathValue = ((Element) current.item(0)).getAttribute(
+          FileNamesParameter.XML_RELATIVE_PATH_ATTRIBUTE);
+      final File relFile = relPathValue.isBlank() ? null : new File(relPathValue);
+
+      if (!absFile.exists() && relFile != null && projectFile != null && projectFile.toPath()
+          .resolve(relFile.toPath()).toFile().exists()) {
+        setValue(projectFile.toPath().resolve(relFile.toPath()).toFile());
+      } else {
+        setValue(absFile);
+      }
     }
     // add all still existing files
     lastFiles = new ArrayList<>();
@@ -180,9 +201,17 @@ public class FileNameParameter implements UserParameter<File, FileNameComponent>
     for (int i = 0; i < last.getLength(); i++) {
       Node n = last.item(i);
       if (n.getTextContent() != null) {
-        File f = new File(n.getTextContent());
-        if (f.exists()) {
-          lastFiles.add(f);
+        File absFile = new File(n.getTextContent());
+
+        final String relPathAttr = ((Element) n).getAttribute(
+            FileNamesParameter.XML_RELATIVE_PATH_ATTRIBUTE);
+        final File relFile = !relPathAttr.isBlank() ? new File(relPathAttr) : null;
+
+        if (absFile.exists()) {
+          lastFiles.add(absFile);
+        } else if (!absFile.exists() && (relFile != null && projectFile != null
+            && projectFile.toPath().resolve(relFile.toPath()).toFile().exists())) {
+          lastFiles.add(projectFile.toPath().resolve(relFile.toPath()).toFile());
         }
       }
     }
@@ -193,9 +222,17 @@ public class FileNameParameter implements UserParameter<File, FileNameComponent>
   public void saveValueToXML(Element xmlElement) {
     // add new element for each file
     Document parentDocument = xmlElement.getOwnerDocument();
+    final MZmineProject project = ProjectService.getProject();
+
     if (value != null) {
       Element paramElement = parentDocument.createElement(CURRENT_FILE_ELEMENT);
       paramElement.setTextContent(value.getAbsolutePath());
+
+      final Path relativePath = project.getRelativePath(value.toPath());
+      if (relativePath != null) {
+        paramElement.setAttribute(FileNamesParameter.XML_RELATIVE_PATH_ATTRIBUTE,
+            relativePath.toString());
+      }
       xmlElement.appendChild(paramElement);
     }
 
@@ -203,6 +240,12 @@ public class FileNameParameter implements UserParameter<File, FileNameComponent>
       for (File f : lastFiles) {
         Element paramElement = parentDocument.createElement(LAST_FILE_ELEMENT);
         paramElement.setTextContent(f.getAbsolutePath());
+
+        final Path relativePath = project.getRelativePath(f.toPath());
+        if (relativePath != null && relativePath.toFile().exists()) {
+          paramElement.setAttribute(FileNamesParameter.XML_RELATIVE_PATH_ATTRIBUTE,
+              relativePath.toString());
+        }
         xmlElement.appendChild(paramElement);
       }
     }

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/filenames/FileNameParameter.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/filenames/FileNameParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -33,7 +33,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.regex.Pattern;
 import javafx.stage.FileChooser.ExtensionFilter;
 import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Document;
@@ -45,10 +44,6 @@ import org.w3c.dom.NodeList;
  * Simple Parameter implementation
  */
 public class FileNameParameter implements UserParameter<File, FileNameComponent> {
-
-  public static final Pattern FILE_PATH_PATTERN = Pattern.compile(
-      "^(?:[a-zA-Z]:\\\\|\\/)?(?:[^<>:\"/\\\\|?*\\x00-\\x1F]+[\\/\\\\]?)*$");
-  public static final String SPLIT_CHARACTER = "||";
 
   protected static final String CURRENT_FILE_ELEMENT = "current_file";
   protected static final String LAST_FILE_ELEMENT = "last_file";

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/filenames/FileNamesParameter.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/filenames/FileNamesParameter.java
@@ -26,8 +26,11 @@
 package io.github.mzmine.parameters.parametertypes.filenames;
 
 import com.google.common.collect.ImmutableList;
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.modules.io.projectsave.RawDataFileSaveHandler;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.UserParameter;
+import io.github.mzmine.project.ProjectService;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -44,6 +47,8 @@ import org.w3c.dom.NodeList;
  *
  */
 public class FileNamesParameter implements UserParameter<File[], FileNamesComponent> {
+
+  public static final String XML_RELATIVE_PATH_ATTRIBUTE = "relative_path";
 
   private final String name;
   private final String description;
@@ -120,9 +125,20 @@ public class FileNamesParameter implements UserParameter<File[], FileNamesCompon
   public void loadValueFromXML(Element xmlElement) {
     NodeList list = xmlElement.getElementsByTagName("file");
     File[] newFiles = new File[list.getLength()];
+    final MZmineProject project = ProjectService.getProject();
+
     for (int i = 0; i < list.getLength(); i++) {
       Element nextElement = (Element) list.item(i);
-      newFiles[i] = new File(nextElement.getTextContent());
+
+      final File absFile = new File(nextElement.getTextContent());
+      final String relPathAttr = nextElement.getAttribute(XML_RELATIVE_PATH_ATTRIBUTE);
+      final File relFile = project.resolveRelativePathToFile(relPathAttr);
+
+      if (!absFile.exists() && (relFile != null && relFile.exists())) {
+        newFiles[i] = relFile;
+      } else {
+        newFiles[i] = absFile;
+      }
     }
     this.value = newFiles;
   }
@@ -133,9 +149,18 @@ public class FileNamesParameter implements UserParameter<File[], FileNamesCompon
       return;
     }
     Document parentDocument = xmlElement.getOwnerDocument();
+    final MZmineProject project = ProjectService.getProject();
+
     for (File f : value) {
       Element newElement = parentDocument.createElement("file");
       newElement.setTextContent(f.getPath());
+
+      if (!f.toString().contains(RawDataFileSaveHandler.DATA_FILES_PREFIX)) {
+        final Path relativePath = project.getRelativePath(f.toPath());
+        if (relativePath != null) {
+          newElement.setAttribute(XML_RELATIVE_PATH_ATTRIBUTE, relativePath.toString());
+        }
+      }
       xmlElement.appendChild(newElement);
     }
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/RawDataFilePlaceholder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/RawDataFilePlaceholder.java
@@ -38,6 +38,7 @@ import io.github.mzmine.project.ProjectService;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.awt.Color;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 import javafx.beans.property.ObjectProperty;
@@ -303,6 +304,9 @@ public class RawDataFilePlaceholder implements RawDataFile {
 
   @Override
   public List<OtherDataFile> getOtherDataFiles() {
+    if (getMatchingFile() != null) {
+      return getMatchingFile().getOtherDataFiles();
+    }
     return List.of();
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/RawDataFilesParameter.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/RawDataFilesParameter.java
@@ -26,9 +26,13 @@
 package io.github.mzmine.parameters.parametertypes.selectors;
 
 import com.google.common.base.Strings;
+import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.parameters.UserParameter;
+import io.github.mzmine.parameters.parametertypes.filenames.FileNamesParameter;
 import io.github.mzmine.project.ProjectService;
+import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -165,10 +169,21 @@ public class RawDataFilesParameter implements
 
     NodeList items = xmlElement.getElementsByTagName("specific_file");
     for (int i = 0; i < items.getLength(); i++) {
-      String itemString = items.item(i).getTextContent();
+      String fileName = items.item(i).getTextContent();
       String path = ((Element) items.item(i)).getAttribute(PATH_ATTRIBUTE);
       path = path.isEmpty() ? null : path;
-      newValues.add(new RawDataFilePlaceholder(itemString, path));
+
+      final String relPathValue = ((Element) items.item(i)).getAttribute(
+          FileNamesParameter.XML_RELATIVE_PATH_ATTRIBUTE);
+      // try if we can find this file in a relative path
+      if (path != null && !new File(path).exists() && !relPathValue.isBlank()) {
+        final File relPath = ProjectService.getProject().resolveRelativePathToFile(relPathValue);
+        if (relPath != null && relPath.exists()) {
+          path = relPath.getAbsolutePath();
+        }
+      }
+
+      newValues.add(new RawDataFilePlaceholder(fileName, path));
     }
     RawDataFilePlaceholder[] specificFiles = newValues.toArray(new RawDataFilePlaceholder[0]);
 
@@ -194,12 +209,20 @@ public class RawDataFilesParameter implements
 
     if (value.getSelectionType() == RawDataFilesSelectionType.SPECIFIC_FILES
         && value.getSpecificFiles() != null) {
+      final MZmineProject project = ProjectService.getProject();
       for (RawDataFile item : value.getSpecificFilesPlaceholders()) {
         assert item != null;
         Element newElement = parentDocument.createElement("specific_file");
         String fileName = item.getName();
         newElement.setTextContent(fileName);
         newElement.setAttribute(PATH_ATTRIBUTE, item.getAbsolutePath());
+
+        final Path relPath = project.getRelativePath(item.getAbsoluteFilePath().toPath());
+        if (relPath != null && project.resolveRelativePathToFile(relPath.toString()).exists()) {
+          newElement.setAttribute(FileNamesParameter.XML_RELATIVE_PATH_ATTRIBUTE,
+              relPath.toString());
+        }
+
         xmlElement.appendChild(newElement);
       }
     }
@@ -223,7 +246,8 @@ public class RawDataFilesParameter implements
   }
 
   @Override
-  public void setValueToComponent(RawDataFilesComponent component, @Nullable RawDataFilesSelection newValue) {
+  public void setValueToComponent(RawDataFilesComponent component,
+      @Nullable RawDataFilesSelection newValue) {
     component.setValue(newValue);
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/RawDataFilesSelection.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/RawDataFilesSelection.java
@@ -54,6 +54,7 @@ public class RawDataFilesSelection implements Cloneable {
   public RawDataFilesSelection(RawDataFilesSelectionType selectionType) {
     this.selectionType = selectionType;
   }
+
   public RawDataFilesSelection(RawDataFile[] specificDataFiles) {
     this.selectionType = RawDataFilesSelectionType.SPECIFIC_FILES;
     setSpecificFiles(specificDataFiles);
@@ -87,8 +88,8 @@ public class RawDataFilesSelection implements Cloneable {
     final RawDataFile[] matchingFiles;
     switch (selectionType) {
       case GUI_SELECTED_FILES -> matchingFiles = MZmineCore.getDesktop().getSelectedDataFiles();
-      case ALL_FILES -> matchingFiles = ProjectService.getProjectManager().getCurrentProject()
-          .getDataFiles();
+      case ALL_FILES ->
+          matchingFiles = ProjectService.getProjectManager().getCurrentProject().getDataFiles();
       case SPECIFIC_FILES -> matchingFiles = getSpecificFiles();
       case NAME_PATTERN -> {
         if (Strings.isNullOrEmpty(namePattern)) {
@@ -115,8 +116,8 @@ public class RawDataFilesSelection implements Cloneable {
         }
         matchingFiles = matchingDataFiles.toArray(new RawDataFile[0]);
       }
-      case BATCH_LAST_FILES -> matchingFiles = Objects.requireNonNullElseGet(batchLastFiles,
-          () -> new RawDataFile[0]);
+      case BATCH_LAST_FILES ->
+          matchingFiles = Objects.requireNonNullElseGet(batchLastFiles, () -> new RawDataFile[0]);
       default -> throw new IllegalStateException("Unexpected value: " + selectionType);
     }
 
@@ -141,8 +142,9 @@ public class RawDataFilesSelection implements Cloneable {
 
   public void resetSelection() {
     if (evaluatedSelection != null) {
-      logger.finest(() -> "Resetting file selection. Previously evaluated files: " + Arrays
-          .toString(evaluatedSelection));
+      logger.finest(
+          () -> "Resetting file selection. Previously evaluated files: " + Arrays.toString(
+              evaluatedSelection));
     }
     evaluatedSelection = null;
   }
@@ -161,10 +163,8 @@ public class RawDataFilesSelection implements Cloneable {
       for (RawDataFile file : ProjectService.getProjectManager().getCurrentProject()
           .getCurrentRawDataFiles()) {
         if (file.getName().equals(specificFile.getName()) && (file.getAbsolutePath() == null
-                                                              || specificFile.getAbsolutePath()
-                                                                 == null || file.getAbsolutePath()
-                                                                  .equals(
-                                                                      specificFile.getAbsolutePath()))) {
+            || specificFile.getAbsolutePath() == null || file.getAbsolutePath()
+            .equals(specificFile.getAbsolutePath()))) {
           c.accept(file);
           break;
         }
@@ -247,8 +247,8 @@ public class RawDataFilesSelection implements Cloneable {
     }
     RawDataFilesSelection that = (RawDataFilesSelection) o;
 
-    if (getSelectionType() != that.getSelectionType() || !Objects
-        .equals(getNamePattern(), that.getNamePattern())) {
+    if (getSelectionType() != that.getSelectionType() || !Objects.equals(getNamePattern(),
+        that.getNamePattern())) {
       return false;
     }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/project/impl/MZmineProjectImpl.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/project/impl/MZmineProjectImpl.java
@@ -39,6 +39,8 @@ import io.github.mzmine.project.impl.ProjectChangeEvent.Type;
 import io.github.mzmine.util.files.FileAndPathUtil;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibrary;
 import java.io.File;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,6 +49,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -508,4 +511,37 @@ public class MZmineProjectImpl implements MZmineProject {
     }
   }
 
+  public @Nullable Path getRelativePath(@Nullable Path path) {
+    if (path == null) {
+      return null;
+    }
+    final File projectFile = getProjectFile();
+
+    if (projectFile == null) {
+      return null;
+    }
+
+    try {
+      return projectFile.toPath().relativize(path).normalize();
+    } catch (IllegalArgumentException e) {
+      logger.warning(
+          () -> "Cannot relativize path %s to project file %s. Files may be located on a different drive.".formatted(
+              path.toFile().getAbsolutePath(), projectFile.getAbsolutePath()));
+      return null;
+    }
+  }
+
+  @Override
+  public @Nullable File resolveRelativePathToFile(@Nullable String path) {
+    if (path == null || path.isBlank() || getProjectFile() == null) {
+      return null;
+    }
+
+    try {
+      return projectFile.toPath().resolve(path).normalize().toFile();
+    } catch (InvalidPathException e) {
+      logger.log(Level.SEVERE, "Cannot resolve file path relative to project.", e);
+      return null;
+    }
+  }
 }


### PR DESCRIPTION
Allows projects that are saved with recent mzmine versions to be opened with relative paths. e.g. if the project is saved in the same folder as the raw files, just copy the whole folder and it is also portable without saving as a standalone project.

changes FileNamesParameter, FileNameParameter, RawDataFilesParameter