### PR TITLE
MenuBuilder example

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/MainMenuEntries.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/MainMenuEntries.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2004-2024 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.gui.mainwindow.mainmenu;
+
+public enum MainMenuEntries {
+  PROJECT, RAW_DATA_METHODS, FEATURE_DETECTION, FEATURE_LIST_METHODS, VISUALISATION, TOOLS, MZWIZARD, WINDOWS, USERS, HELP;
+
+
+  @Override
+  public String toString() {
+    return switch (this) {
+      case PROJECT -> "Project";
+      case RAW_DATA_METHODS -> "Raw data methods";
+      case FEATURE_DETECTION -> "Feature detection";
+      case FEATURE_LIST_METHODS -> "Feature list methods";
+      case VISUALISATION -> "Visualisation";
+      case TOOLS -> "Tools";
+      case MZWIZARD -> "mzwizard";
+      case WINDOWS -> "Windows";
+      case USERS -> "Users";
+      case HELP -> "Help";
+    };
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/MenuBuilder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/MenuBuilder.java
@@ -25,14 +25,60 @@
 
 package io.github.mzmine.gui.mainwindow.mainmenu;
 
+import io.github.mzmine.gui.mainwindow.mainmenu.impl.ProjectMenuBuilder;
+import java.util.ArrayList;
+import java.util.List;
 import javafx.scene.control.Menu;
+import javafx.scene.control.MenuItem;
 
 public abstract class MenuBuilder {
 
   public static MenuBuilder forCategory(final MainMenuEntries category) {
-    return null;
+    return switch (category) {
+      case PROJECT -> new ProjectMenuBuilder();
+      case RAW_DATA_METHODS -> null;
+      case FEATURE_DETECTION -> null;
+      case FEATURE_LIST_METHODS -> null;
+      case VISUALISATION -> null;
+      case TOOLS -> null;
+      case MZWIZARD -> null;
+      case WINDOWS -> null;
+      case USERS -> null;
+      case HELP -> null;
+    };
   }
 
   public abstract Menu build(Workspace workspace);
 
+  /**
+   * Removes all {@link WorkspaceMenuItem}s that do not belong in the given workspace. It's the
+   * implementing classes' responsibility to call this method, as some menus may be more specific
+   * than just filtering.
+   *
+   * @param menu      the menu to filter. this instance is mutated.
+   * @param workspace the workspace to filter for.
+   * @return the filtered menu. the same instance as the parameter.
+   */
+  public static Menu filterMenu(final Menu menu, Workspace workspace) {
+
+    List<MenuItem> itemsToRemove = new ArrayList<>();
+    for (MenuItem item : menu.getItems()) {
+      if (item instanceof WorkspaceMenuItem wi) {
+        if (!wi.contains(workspace)) {
+          itemsToRemove.add(item);
+        }
+      }
+
+      // check sub menus recursively
+      if (item instanceof Menu m) {
+        filterMenu(m, workspace);
+        if (m.getItems().isEmpty()) {
+          // remove empty sub menus
+          menu.getItems().remove(m);
+        }
+      }
+    }
+
+    menu.getItems().removeAll(itemsToRemove);
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/MenuBuilder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/MenuBuilder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2004-2024 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.gui.mainwindow.mainmenu;
+
+import javafx.scene.control.Menu;
+
+public abstract class MenuBuilder {
+
+  public static MenuBuilder forCategory(final MainMenuEntries category) {
+    return null;
+  }
+
+  public abstract Menu build(Workspace workspace);
+
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/ModuleMenuItem.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/ModuleMenuItem.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2004-2024 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.gui.mainwindow.mainmenu;
+
+import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.MZmineRunnableModule;
+import javafx.scene.Node;
+import javafx.scene.control.MenuItem;
+import javafx.scene.input.KeyCodeCombination;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class ModuleMenuItem extends MenuItem {
+
+  private final Class<? extends MZmineRunnableModule> moduleClass;
+
+  public ModuleMenuItem(String text, Node icon, @NotNull Class<? extends MZmineRunnableModule> moduleClass,
+      @Nullable KeyCodeCombination accelerator) {
+    super(text, icon);
+    this.moduleClass = moduleClass;
+    setOnAction(_ -> MZmineCore.setupAndRunModule(moduleClass));
+
+    if (accelerator != null) {
+      setAccelerator(accelerator);
+    }
+  }
+
+  public Class<? extends MZmineRunnableModule> getModuleClass() {
+    return moduleClass;
+  }
+
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/ModuleMenuItem.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/ModuleMenuItem.java
@@ -27,19 +27,21 @@ package io.github.mzmine.gui.mainwindow.mainmenu;
 
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineRunnableModule;
+import java.util.Collection;
 import javafx.scene.Node;
-import javafx.scene.control.MenuItem;
 import javafx.scene.input.KeyCodeCombination;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class ModuleMenuItem extends MenuItem {
+public class ModuleMenuItem extends WorkspaceMenuItem {
 
   private final Class<? extends MZmineRunnableModule> moduleClass;
 
-  public ModuleMenuItem(String text, Node icon, @NotNull Class<? extends MZmineRunnableModule> moduleClass,
-      @Nullable KeyCodeCombination accelerator) {
-    super(text, icon);
+  public ModuleMenuItem(String text, Node icon,
+      @NotNull Class<? extends MZmineRunnableModule> moduleClass,
+      @Nullable KeyCodeCombination accelerator,
+      @NotNull Collection<@NotNull Workspace> workspaces) {
+    super(text, icon, workspaces);
     this.moduleClass = moduleClass;
     setOnAction(_ -> MZmineCore.setupAndRunModule(moduleClass));
 

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/Workspace.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/Workspace.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2004-2024 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.gui.mainwindow.mainmenu;
+
+public enum Workspace {
+  ACADEMIC, PRO_FULL, LC_MS, IMS, MALDI_MS;
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/WorkspaceMenuItem.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/WorkspaceMenuItem.java
@@ -25,15 +25,30 @@
 
 package io.github.mzmine.gui.mainwindow.mainmenu;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.Collection;
+import java.util.EnumSet;
+import javafx.scene.Node;
+import javafx.scene.control.MenuItem;
+import org.jetbrains.annotations.NotNull;
 
-public enum Workspace {
-  ACADEMIC, PRO_FULL, LIBRARY, LC_MS, IMS, MALDI_MS;
+public class WorkspaceMenuItem extends MenuItem {
 
-  private static final List<Workspace> all = Arrays.asList(Workspace.values());
+  private final EnumSet<Workspace> workspaces;
 
-  public static List<Workspace> all() {
-    return all;
+  public WorkspaceMenuItem(String text, Collection<@NotNull Workspace> workspaces) {
+    this(text, null, workspaces);
+  }
+
+  public WorkspaceMenuItem(String text, Node graphic, Collection<@NotNull Workspace> workspaces) {
+    super(text, graphic);
+    this.workspaces = EnumSet.copyOf(workspaces);
+  }
+
+  public EnumSet<Workspace> getWorkspaces() {
+    return workspaces;
+  }
+
+  public boolean contains(Workspace workspace) {
+    return workspaces.contains(workspace);
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/impl/ProjectMenuBuilder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/impl/ProjectMenuBuilder.java
@@ -87,7 +87,7 @@ public class ProjectMenuBuilder extends MenuBuilder {
     return menu;
   }
 
-  private void fillRecentProjects(Menu recentProjectsMenu) {
+  private static void fillRecentProjects(Menu recentProjectsMenu) {
     recentProjectsMenu.getItems().clear();
 
     var recentProjects = MZmineCore.getConfiguration().getLastProjectsParameter().getValue();

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/impl/ProjectMenuBuilder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/impl/ProjectMenuBuilder.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2004-2024 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.gui.mainwindow.mainmenu.impl;
+
+import static io.github.mzmine.util.javafx.FxMenuUtil.addMenuItem;
+import static io.github.mzmine.util.javafx.FxMenuUtil.addSeparator;
+
+import io.github.mzmine.gui.MZmineGUI;
+import io.github.mzmine.gui.mainwindow.mainmenu.MainMenuEntries;
+import io.github.mzmine.gui.mainwindow.mainmenu.MenuBuilder;
+import io.github.mzmine.gui.mainwindow.mainmenu.Workspace;
+import io.github.mzmine.main.ConfigService;
+import io.github.mzmine.main.MZmineConfiguration;
+import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.batchmode.BatchModeModule;
+import io.github.mzmine.modules.io.projectload.ProjectLoadModule;
+import io.github.mzmine.modules.io.projectload.ProjectOpeningTask;
+import io.github.mzmine.modules.io.projectsave.ProjectSaveAsModule;
+import io.github.mzmine.modules.io.projectsave.ProjectSaveModule;
+import io.github.mzmine.modules.visualization.projectmetadata.ProjectMetadataTab;
+import io.github.mzmine.util.files.FileAndPathUtil;
+import java.io.File;
+import java.time.Instant;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuItem;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCombination;
+import javafx.stage.FileChooser;
+
+public class ProjectMenuBuilder extends MenuBuilder {
+
+  private static final Logger logger = Logger.getLogger(ProjectMenuBuilder.class.getName());
+
+  @Override
+  public Menu build(Workspace workspace) {
+    final Menu menu = new Menu(MainMenuEntries.PROJECT.toString());
+    final Menu recentProjects = new Menu("Recent projects");
+
+    menu.setOnShowing(_ -> fillRecentProjects(recentProjects));
+
+    addMenuItem(menu, "Open project", ProjectLoadModule.class, KeyCode.O,
+        KeyCombination.SHORTCUT_DOWN);
+    addMenuItem(menu, "Save project", ProjectSaveModule.class, KeyCode.S,
+        KeyCombination.SHORTCUT_DOWN);
+    addMenuItem(menu, "Save project as", ProjectSaveAsModule.class, KeyCode.S,
+        KeyCombination.SHORTCUT_DOWN, KeyCombination.SHIFT_DOWN);
+    addMenuItem(menu, "Close project", MZmineGUI::requestCloseProject, KeyCode.Q,
+        KeyCombination.SHORTCUT_DOWN);
+    addSeparator(menu);
+    addMenuItem(menu, "Batch mode", BatchModeModule.class, KeyCode.B, KeyCombination.SHORTCUT_DOWN);
+    addSeparator(menu);
+    addMenuItem(menu, "Sample metadata",
+        () -> MZmineCore.getDesktop().addTab(new ProjectMetadataTab()), KeyCode.M,
+        KeyCombination.SHORTCUT_DOWN);
+    addSeparator(menu);
+    addMenuItem(menu, "Set preferences",
+        () -> MZmineCore.getConfiguration().getPreferences().showSetupDialog(true), KeyCode.P,
+        KeyCombination.SHORTCUT_DOWN);
+    addMenuItem(menu, "Save configuration", ProjectMenuBuilder::saveConfiguration, null);
+    addMenuItem(menu, "Load configuration", ProjectMenuBuilder::loadConfiguration, null);
+
+    return menu;
+  }
+
+  private void fillRecentProjects(Menu recentProjectsMenu) {
+    recentProjectsMenu.getItems().clear();
+
+    var recentProjects = MZmineCore.getConfiguration().getLastProjectsParameter().getValue();
+
+    if ((recentProjects == null) || (recentProjects.isEmpty())) {
+      recentProjectsMenu.setDisable(true);
+      return;
+    }
+
+    recentProjectsMenu.setDisable(false);
+
+    // add items to load last used projects directly
+    final MenuItem[] items = recentProjects.stream().map(File::getAbsolutePath).map(name -> {
+      MenuItem item = new MenuItem(name);
+
+      item.setOnAction(e -> {
+        MenuItem c = (MenuItem) e.getSource();
+        if (c == null) {
+          return;
+        }
+        File f = new File(c.getText());
+        if (f.exists()) {
+          // load file
+          ProjectOpeningTask newTask = new ProjectOpeningTask(f, Instant.now());
+          MZmineCore.getTaskController().addTask(newTask);
+        }
+      });
+      return item;
+    }).toArray(MenuItem[]::new);
+    recentProjectsMenu.getItems().addAll(items);
+  }
+
+  public static void saveConfiguration() {
+    try {
+      var chooser = new FileChooser();
+      chooser.setInitialDirectory(MZmineConfiguration.CONFIG_FILE.getParentFile());
+      File file = chooser.showSaveDialog(null);
+      if (file == null) {
+        return;
+      }
+      file = FileAndPathUtil.getRealFilePath(file, MZmineConfiguration.CONFIG_EXTENSION);
+      ConfigService.getConfiguration().saveConfiguration(file);
+    } catch (Exception ex) {
+      logger.log(Level.WARNING, "Cannot save config", ex);
+    }
+  }
+
+  public static void loadConfiguration() {
+    try {
+      var chooser = new FileChooser();
+      chooser.setInitialDirectory(MZmineConfiguration.CONFIG_FILE.getParentFile());
+      File file = chooser.showOpenDialog(null);
+      if (file == null) {
+        return;
+      }
+      ConfigService.getConfiguration().loadConfiguration(file, true);
+      ConfigService.getPreferences().applyConfig();
+
+    } catch (Exception ex) {
+      logger.log(Level.WARNING, "Cannot save config", ex);
+    }
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/impl/RawDataMenuBuilder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/mainmenu/impl/RawDataMenuBuilder.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2004-2024 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.gui.mainwindow.mainmenu.impl;
+
+import static io.github.mzmine.util.javafx.FxMenuUtil.addMenuItem;
+import static io.github.mzmine.util.javafx.FxMenuUtil.addSeparator;
+
+import io.github.mzmine.gui.mainwindow.mainmenu.MenuBuilder;
+import io.github.mzmine.gui.mainwindow.mainmenu.Workspace;
+import io.github.mzmine.modules.dataprocessing.featdet_denormalize_by_inject_time.DenormalizeScansMultiplyByInjectTimeModule;
+import io.github.mzmine.modules.dataprocessing.featdet_masscalibration.MassCalibrationModule;
+import io.github.mzmine.modules.dataprocessing.featdet_massdetection.MassDetectionModule;
+import io.github.mzmine.modules.dataprocessing.featdet_mobilityscanmerger.MobilityScanMergerModule;
+import io.github.mzmine.modules.dataprocessing.featdet_shoulderpeaksfilter.ShoulderPeaksFilterModule;
+import io.github.mzmine.modules.dataprocessing.filter_alignscans.AlignScansModule;
+import io.github.mzmine.modules.dataprocessing.filter_cropfilter.CropFilterModule;
+import io.github.mzmine.modules.dataprocessing.filter_maldipseudofilegenerator.MaldiPseudoFileGeneratorModule;
+import io.github.mzmine.modules.dataprocessing.filter_merge.RawFileMergeModule;
+import io.github.mzmine.modules.dataprocessing.filter_scan_signals.ScanSignalRemovalModule;
+import io.github.mzmine.modules.dataprocessing.filter_scanfilters.ScanFiltersModule;
+import io.github.mzmine.modules.dataprocessing.filter_scansmoothing.ScanSmoothingModule;
+import io.github.mzmine.modules.dataprocessing.id_spectral_library_match.library_to_featurelist.SpectralLibraryToFeatureListModule;
+import io.github.mzmine.modules.io.export_msn_tree.MSnTreeExportModule;
+import io.github.mzmine.modules.io.export_scans.ExportScansFromRawFilesModule;
+import io.github.mzmine.modules.io.import_rawdata_all.AllSpectralDataImportModule;
+import io.github.mzmine.modules.io.import_spectral_library.SpectralLibraryImportModule;
+import java.util.List;
+import javafx.scene.control.Menu;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCombination;
+
+public class RawDataMenuBuilder extends MenuBuilder {
+
+  public RawDataMenuBuilder() {
+  }
+
+  @Override
+  public Menu build(Workspace workspace) {
+
+    final Menu menu = new Menu("Raw data methods");
+
+    addMenuItem(menu, "Import MS data", AllSpectralDataImportModule.class, KeyCode.I,
+        KeyCombination.SHORTCUT_DOWN);
+
+    final Menu spectraProcessing = new Menu("Spectra processing");
+    menu.getItems().add(spectraProcessing);
+    addMenuItem(spectraProcessing, "Mass detection", MassDetectionModule.class, null);
+    addMenuItem(spectraProcessing, "Mobility scan merging", MobilityScanMergerModule.class, null);
+    addMenuItem(spectraProcessing, "FTMS shoulder peak filter", ShoulderPeaksFilterModule.class,
+        null);
+    addMenuItem(spectraProcessing, "Scan signal removal", ScanSignalRemovalModule.class, null);
+    addMenuItem(spectraProcessing, "Mass calibration", MassCalibrationModule.class, null);
+
+    final Menu filtering = new Menu("Raw data filtering");
+    menu.getItems().add(filtering);
+    addMenuItem(filtering, "Scan by scan filtering", ScanFiltersModule.class,
+        List.of(Workspace.ACADEMIC, Workspace.PRO_FULL), null);
+    addMenuItem(filtering, "Crop filter", CropFilterModule.class,
+        List.of(Workspace.ACADEMIC, Workspace.PRO_FULL), null);
+    addMenuItem(filtering, "Align scans (MS1)", AlignScansModule.class,
+        List.of(Workspace.ACADEMIC, Workspace.PRO_FULL), null);
+    addMenuItem(filtering, "Scan smoothing (MS1)", ScanSmoothingModule.class,
+        List.of(Workspace.ACADEMIC, Workspace.PRO_FULL), null);
+    addMenuItem(filtering, "Denormalize scans (multiply by inject time)",
+        DenormalizeScansMultiplyByInjectTimeModule.class,
+        List.of(Workspace.ACADEMIC, Workspace.PRO_FULL), null);
+    addMenuItem(filtering, "Split MALDI spots to raw data files",
+        MaldiPseudoFileGeneratorModule.class,
+        List.of(Workspace.ACADEMIC, Workspace.PRO_FULL, Workspace.MALDI_MS), null);
+
+    addSeparator(menu);
+
+    addMenuItem(menu, "Raw data file merging", RawFileMergeModule.class,
+        List.of(Workspace.ACADEMIC, Workspace.PRO_FULL), null);
+
+    addSeparator(menu);
+
+    final Menu export = new Menu("Raw data export");
+    menu.getItems().add(export);
+    addMenuItem(export, "Export scans", ExportScansFromRawFilesModule.class,
+        List.of(Workspace.ACADEMIC, Workspace.PRO_FULL), null);
+    addMenuItem(export, "Export MSn trees", MSnTreeExportModule.class,
+        List.of(Workspace.ACADEMIC, Workspace.PRO_FULL), null);
+
+    addSeparator(menu);
+
+    final Menu specLibs = new Menu("Spectral libraries");
+    menu.getItems().add(specLibs);
+    addMenuItem(specLibs, "Spectral library import", SpectralLibraryImportModule.class, null);
+    addMenuItem(specLibs, "Spectral library to feature list",
+        SpectralLibraryToFeatureListModule.class, null);
+
+    return filterMenu(menu, workspace);
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/MZmineModuleCategory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/MZmineModuleCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -73,9 +73,8 @@ public enum MZmineModuleCategory {
       case RAWDATAIMPORT, RAWDATAEXPORT, RAWDATA, RAWDATAFILTERING -> MainCategory.SPECTRAL_DATA;
       case EIC_DETECTION, FEATURE_RESOLVING, GAPFILLING, ALIGNMENT, FEATURELIST ->
           MainCategory.FEATURE_DETECTION;
-      case ISOTOPES, SPECTRALDECONVOLUTION, FEATURELISTFILTERING -> MainCategory.FEATURE_FILTERING;
-      case NORMALIZATION, ANNOTATION, DATAANALYSIS, FEATURE_GROUPING, ION_IDENTITY_NETWORKS ->
-          MainCategory.FEATURE_PROCESSING;
+      case ISOTOPES, SPECTRALDECONVOLUTION, FEATURELISTFILTERING, NORMALIZATION, ANNOTATION,
+           DATAANALYSIS, FEATURE_GROUPING, ION_IDENTITY_NETWORKS -> MainCategory.FEATURE_PROCESSING;
       case FEATURELISTEXPORT, FEATURELISTIMPORT -> MainCategory.FEATURE_IO;
       case VISUALIZATIONRAWDATA, VISUALIZATIONFEATURELIST, VISUALIZATION_RAW_AND_FEATURE ->
           MainCategory.VISUALIZATION;
@@ -88,11 +87,10 @@ public enum MZmineModuleCategory {
 
   public enum MainCategory {
     PROJECT("Project"), //
-    SPECTRAL_DATA("Spectral data"), //
-    SPECTRAL_LIBRARY("Spectral library"), //
+    SPECTRAL_DATA("Raw data methods"), //
     FEATURE_DETECTION("Feature detection"), //
-    FEATURE_FILTERING("Feature filtering"), //
     FEATURE_PROCESSING("Feature processing"), //
+    SPECTRAL_LIBRARY("Spectral library"), //
     FEATURE_IO("Feature IO"), //
     VISUALIZATION("Visualization"), OTHER("Other");
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/MZmineRunnableModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/MZmineRunnableModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,15 +25,13 @@
 
 package io.github.mzmine.modules;
 
-import java.time.Instant;
-import java.util.Collection;
-
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Interface representing a module that can be executed from the GUI through a menu item. This can

--- a/mzmine-community/src/main/java/io/github/mzmine/util/javafx/FxMenuUtil.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/javafx/FxMenuUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,18 +25,73 @@
 
 package io.github.mzmine.util.javafx;
 
-import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
+import io.github.mzmine.gui.mainwindow.mainmenu.ModuleMenuItem;
+import io.github.mzmine.modules.MZmineRunnableModule;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.SeparatorMenuItem;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination.Modifier;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class FxMenuUtil {
 
-  public static MenuItem addMenuItem(Menu menu, String text, EventHandler<ActionEvent> action) {
-    MenuItem newItem = new MenuItem(text);
-    menu.getItems().add(newItem);
-    newItem.setOnAction(action);
-    return newItem;
+  public static MenuItem menuItem(@NotNull String text, @Nullable Runnable onClick,
+      @Nullable KeyCodeCombination accelerator) {
+    MenuItem menuItem = new MenuItem(text);
+    if (onClick != null) {
+      menuItem.setOnAction(_ -> onClick.run());
+    }
+    menuItem.setAccelerator(accelerator);
+    return menuItem;
   }
 
+  public static MenuItem addMenuItem(Menu menu, @NotNull String text, @NotNull Runnable onClick,
+      @Nullable KeyCodeCombination accelerator) {
+    final MenuItem item = menuItem(text, onClick, accelerator);
+    menu.getItems().add(item);
+    return item;
+  }
+
+  public static MenuItem addMenuItem(Menu menu, @NotNull String text, @NotNull Runnable onClick,
+      KeyCode mainKey, Modifier... modifers) {
+    final MenuItem item = menuItem(text, onClick, new KeyCodeCombination(mainKey, modifers));
+    menu.getItems().add(item);
+    return item;
+  }
+
+  public static ModuleMenuItem menuItem(@NotNull String text,
+      @NotNull Class<? extends MZmineRunnableModule> module,
+      @Nullable KeyCodeCombination accelerator) {
+    final ModuleMenuItem item = new ModuleMenuItem(text, null, module, accelerator);
+    return item;
+  }
+
+  public static ModuleMenuItem menuItem(@NotNull String text,
+      @NotNull Class<? extends MZmineRunnableModule> module, KeyCode mainKey,
+      Modifier... modifers) {
+    return menuItem(text, module, new KeyCodeCombination(mainKey, modifers));
+  }
+
+  public static ModuleMenuItem addMenuItem(Menu menu, @NotNull String text,
+      @NotNull Class<? extends MZmineRunnableModule> module,
+      @Nullable KeyCodeCombination accelerator) {
+    final ModuleMenuItem item = menuItem(text, module, accelerator);
+    menu.getItems().add(item);
+    return item;
+  }
+
+  public static ModuleMenuItem addMenuItem(Menu menu, @NotNull String text,
+      @NotNull Class<? extends MZmineRunnableModule> module, KeyCode mainKey,
+      Modifier... modifers) {
+    final ModuleMenuItem item = menuItem(text, module, mainKey, modifers);
+    menu.getItems().add(item);
+    return item;
+  }
+
+  public static void addSeparator(Menu menu) {
+    menu.getItems().add(new SeparatorMenuItem());
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/util/javafx/FxMenuUtil.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/javafx/FxMenuUtil.java
@@ -26,7 +26,10 @@
 package io.github.mzmine.util.javafx;
 
 import io.github.mzmine.gui.mainwindow.mainmenu.ModuleMenuItem;
+import io.github.mzmine.gui.mainwindow.mainmenu.Workspace;
+import io.github.mzmine.gui.mainwindow.mainmenu.WorkspaceMenuItem;
 import io.github.mzmine.modules.MZmineRunnableModule;
+import java.util.Collection;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.SeparatorMenuItem;
@@ -48,45 +51,59 @@ public class FxMenuUtil {
     return menuItem;
   }
 
-  public static MenuItem addMenuItem(Menu menu, @NotNull String text, @NotNull Runnable onClick,
-      @Nullable KeyCodeCombination accelerator) {
-    final MenuItem item = menuItem(text, onClick, accelerator);
+  public static MenuItem addMenuItem(Menu menu, @NotNull String text, @Nullable Runnable onClick,
+      @Nullable KeyCode mainKey, @Nullable Modifier... modifers) {
+    final MenuItem item = menuItem(text, onClick, null);
+
+    if (mainKey != null && modifers != null) {
+      item.setAccelerator(new KeyCodeCombination(mainKey, modifers));
+    } else if (mainKey != null) {
+      item.setAccelerator(new KeyCodeCombination(mainKey));
+    }
+
     menu.getItems().add(item);
     return item;
   }
 
-  public static MenuItem addMenuItem(Menu menu, @NotNull String text, @NotNull Runnable onClick,
+  public static MenuItem addWorkspaceMenuItem(Menu menu, @NotNull String text,
+      @Nullable Runnable onClick, @NotNull Collection<@NotNull Workspace> workspaces,
+      @Nullable KeyCode mainKey, @Nullable Modifier... modifers) {
+    final MenuItem item = new WorkspaceMenuItem(text, workspaces);
+
+    if (mainKey != null && modifers != null) {
+      item.setAccelerator(new KeyCodeCombination(mainKey, modifers));
+    } else if (mainKey != null) {
+      item.setAccelerator(new KeyCodeCombination(mainKey));
+    }
+
+    if (onClick != null) {
+      item.setOnAction(_ -> onClick.run());
+    }
+
+    menu.getItems().add(item);
+    return item;
+  }
+
+
+  public static ModuleMenuItem addMenuItem(Menu menu, @NotNull String text,
+      @NotNull Class<? extends MZmineRunnableModule> module, @Nullable KeyCode mainKey,
+      @Nullable Modifier... modifers) {
+    return addMenuItem(menu, text, module, Workspace.all(), mainKey, modifers);
+  }
+
+  public static ModuleMenuItem addMenuItem(Menu menu, @NotNull String text,
+      @NotNull Class<? extends MZmineRunnableModule> module, Collection<Workspace> workspaces,
       KeyCode mainKey, Modifier... modifers) {
-    final MenuItem item = menuItem(text, onClick, new KeyCodeCombination(mainKey, modifers));
-    menu.getItems().add(item);
-    return item;
-  }
+    KeyCodeCombination accelerator;
+    if (mainKey != null && modifers != null) {
+      accelerator = new KeyCodeCombination(mainKey, modifers);
+    } else if (mainKey != null && modifers == null) {
+      accelerator = new KeyCodeCombination(mainKey);
+    } else {
+      accelerator = null;
+    }
 
-  public static ModuleMenuItem menuItem(@NotNull String text,
-      @NotNull Class<? extends MZmineRunnableModule> module,
-      @Nullable KeyCodeCombination accelerator) {
-    final ModuleMenuItem item = new ModuleMenuItem(text, null, module, accelerator);
-    return item;
-  }
-
-  public static ModuleMenuItem menuItem(@NotNull String text,
-      @NotNull Class<? extends MZmineRunnableModule> module, KeyCode mainKey,
-      Modifier... modifers) {
-    return menuItem(text, module, new KeyCodeCombination(mainKey, modifers));
-  }
-
-  public static ModuleMenuItem addMenuItem(Menu menu, @NotNull String text,
-      @NotNull Class<? extends MZmineRunnableModule> module,
-      @Nullable KeyCodeCombination accelerator) {
-    final ModuleMenuItem item = menuItem(text, module, accelerator);
-    menu.getItems().add(item);
-    return item;
-  }
-
-  public static ModuleMenuItem addMenuItem(Menu menu, @NotNull String text,
-      @NotNull Class<? extends MZmineRunnableModule> module, KeyCode mainKey,
-      Modifier... modifers) {
-    final ModuleMenuItem item = menuItem(text, module, mainKey, modifers);
+    final ModuleMenuItem item = new ModuleMenuItem(text, null, module, accelerator, workspaces);
     menu.getItems().add(item);
     return item;
   }

--- a/utils/src/main/java/io/github/mzmine/util/collections/CollectionUtils.java
+++ b/utils/src/main/java/io/github/mzmine/util/collections/CollectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -198,5 +198,13 @@ public class CollectionUtils {
     T[] copy = ((Object) newType == (Object) Object[].class) ? (T[]) new Object[newLength]
         : (T[]) Array.newInstance(newType.getComponentType(), newLength);
     return copy;
+  }
+
+  public static <T> List<T> combine(List<? extends T>... lists) {
+    final List<T> value = new ArrayList<>();
+    for (List<? extends T> list : lists) {
+      value.addAll(list);
+    }
+    return value;
   }
 }


### PR DESCRIPTION
Example implementation of a menu builder. 

A menu can either be build for a workspace specifically or items can be filtered out of a default structure depending on the workspace selection.