### PR TITLE
Fix old projects not savable with mzmine 4.3

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/SimpleFeatureListAppliedMethod.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/SimpleFeatureListAppliedMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -28,6 +28,8 @@ package io.github.mzmine.datamodel.features;
 import io.github.mzmine.datamodel.features.FeatureList.FeatureListAppliedMethod;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineModule;
+import io.github.mzmine.modules.tools.PlaceholderModule;
+import io.github.mzmine.modules.tools.PlaceholderModuleParameters;
 import io.github.mzmine.parameters.ParameterSet;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
@@ -43,8 +45,8 @@ import org.w3c.dom.Element;
  */
 public class SimpleFeatureListAppliedMethod implements FeatureListAppliedMethod {
 
-  private static final Logger logger = Logger
-      .getLogger(SimpleFeatureListAppliedMethod.class.getName());
+  private static final Logger logger = Logger.getLogger(
+      SimpleFeatureListAppliedMethod.class.getName());
 
   private final String description;
   private final Instant moduleCallDate;
@@ -52,8 +54,8 @@ public class SimpleFeatureListAppliedMethod implements FeatureListAppliedMethod 
   private final MZmineModule module;
 
   /**
-   * @param parameters The parameter set used to create this feature list. A clone of the parameter
-   *                   set is created in the constructor and saved in this class.
+   * @param parameters     The parameter set used to create this feature list. A clone of the
+   *                       parameter set is created in the constructor and saved in this class.
    * @param moduleCallDate
    */
   public SimpleFeatureListAppliedMethod(MZmineModule module, ParameterSet parameters,
@@ -91,7 +93,7 @@ public class SimpleFeatureListAppliedMethod implements FeatureListAppliedMethod 
   }
 
   public String toString() {
-    return description;
+    return module.getName();
   }
 
   public @NotNull ParameterSet getParameters() {
@@ -99,6 +101,11 @@ public class SimpleFeatureListAppliedMethod implements FeatureListAppliedMethod 
     return parameters.cloneParameterSet(true);
   }
 
+  /**
+   * The module of this applied method. If the feature list was created with an old version of
+   * mzmine and the module does not exist anymore, this method will return
+   * {@link PlaceholderModule}.
+   */
   @Override
   public MZmineModule getModule() {
     return module;
@@ -137,8 +144,8 @@ public class SimpleFeatureListAppliedMethod implements FeatureListAppliedMethod 
     final Element descriptionElement = (Element) element.getElementsByTagName("description")
         .item(0);
 
-    Class<? extends MZmineModule> moduleClass;
-    ParameterSet moduleParameters;
+    Class<? extends MZmineModule> moduleClass = null;
+    ParameterSet moduleParameters = null;
 
     try {
       moduleClass = (Class<? extends MZmineModule>) Class.forName(moduleClassName);
@@ -147,7 +154,8 @@ public class SimpleFeatureListAppliedMethod implements FeatureListAppliedMethod 
       moduleParameters.loadValuesFromXML(parametersElement);
     } catch (Exception | NoClassDefFoundError e) {
       logger.log(Level.SEVERE, "Cannot parse module parameters", e);
-      return null;
+      moduleClass = PlaceholderModule.class;
+      moduleParameters = PlaceholderModuleParameters.forElement(moduleClassName, parametersElement);
     }
 
     final Instant date;

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/SimpleFeatureListAppliedMethod.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/SimpleFeatureListAppliedMethod.java
@@ -34,7 +34,6 @@ import io.github.mzmine.parameters.ParameterSet;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Document;
@@ -153,7 +152,7 @@ public class SimpleFeatureListAppliedMethod implements FeatureListAppliedMethod 
           .cloneParameterSet();
       moduleParameters.loadValuesFromXML(parametersElement);
     } catch (Exception | NoClassDefFoundError e) {
-      logger.log(Level.SEVERE, "Cannot parse module parameters", e);
+      logger.info("Cannot parse module parameters for class %s".formatted(moduleClassName));
       moduleClass = PlaceholderModule.class;
       moduleParameters = PlaceholderModuleParameters.forElement(moduleClassName, parametersElement);
     }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/identities/iontype/IonModification.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/identities/iontype/IonModification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -33,6 +33,7 @@ import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.io.projectload.version_3_0.CONST;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.util.FormulaUtils;
+import io.github.mzmine.util.ParsingUtils;
 import io.github.mzmine.util.StringMapParser;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -222,7 +223,7 @@ public class IonModification extends NeutralMolecule implements Comparable<IonMo
     }
 
     String name = reader.getAttributeValue(null, "name");
-    String formula = reader.getAttributeValue(null, "formula");
+    String formula = ParsingUtils.readNullableString(reader.getAttributeValue(null, "formula"));
     String massDiff = reader.getAttributeValue(null, "massdifference");
     String type = reader.getAttributeValue(null, "type");
     String charge = reader.getAttributeValue(null, "charge");

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchQueue.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -282,5 +282,10 @@ public class BatchQueue extends ArrayObservableList<MZmineProcessingStep<MZmineP
 
     ChangeOutputFilesUtils.applyTo(this, baseFile);
     logger.info("Done changing output file paths.");
+  }
+
+  @Override
+  public void add(int index, MZmineProcessingStep<MZmineProcessingModule> element) {
+    super.add(index, element);
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchQueue.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchQueue.java
@@ -283,9 +283,5 @@ public class BatchQueue extends ArrayObservableList<MZmineProcessingStep<MZmineP
     ChangeOutputFilesUtils.applyTo(this, baseFile);
     logger.info("Done changing output file paths.");
   }
-
-  @Override
-  public void add(int index, MZmineProcessingStep<MZmineProcessingModule> element) {
-    super.add(index, element);
-  }
 }
+

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectsave/FeatureListSaveTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectsave/FeatureListSaveTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -57,6 +57,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import javafx.collections.ObservableList;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -176,10 +177,18 @@ public class FeatureListSaveTask extends AbstractTask {
 
     // write applied methods
     appliedMethodsList.setAttribute(CONST.XML_FLIST_NAME_ATTR, flist.getName());
-    for (FeatureListAppliedMethod appliedMethod : flist.getAppliedMethods()) {
-      Element methodElement = document.createElement(CONST.XML_FLIST_APPLIED_METHOD_ELEMENT);
-      appliedMethod.saveValueToXML(methodElement);
-      appliedMethodsList.appendChild(methodElement);
+    ObservableList<FeatureListAppliedMethod> appliedMethods = flist.getAppliedMethods();
+    for (int i = 0; i < appliedMethods.size(); i++) {
+      FeatureListAppliedMethod appliedMethod = appliedMethods.get(i);
+      if (appliedMethod != null) {
+        Element methodElement = document.createElement(CONST.XML_FLIST_APPLIED_METHOD_ELEMENT);
+        appliedMethod.saveValueToXML(methodElement);
+        appliedMethodsList.appendChild(methodElement);
+      } else {
+        logger.severe(
+            "Cannot save applied %d method of feature list %s because it is null.".formatted(i,
+                flist.getName()));
+      }
     }
 
     // write selected files

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/PlaceholderModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/PlaceholderModule.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2004-2024 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.tools;
+
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.modules.MZmineModuleCategory;
+import io.github.mzmine.modules.impl.AbstractRunnableModule;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.taskcontrol.Task;
+import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
+
+public final class PlaceholderModule extends AbstractRunnableModule {
+
+  /**
+   * @param name              name of the module in the menu and quick access
+   * @param parameterSetClass the class of the parameters
+   * @param moduleCategory    module category for quick access and batch mode
+   * @param description       the description of the task
+   */
+  public PlaceholderModule() {
+    super("PLACEHOLDER - OLD MODULE", PlaceholderModuleParameters.class, MZmineModuleCategory.TOOLS,
+        "Placeholder for a module that does not exist anymore.");
+  }
+
+  @Override
+  public @NotNull ExitCode runModule(@NotNull MZmineProject project,
+      @NotNull ParameterSet parameters, @NotNull Collection<Task> tasks,
+      @NotNull Instant moduleCallDate) {
+    return ExitCode.OK;
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/PlaceholderModuleParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/PlaceholderModuleParameters.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2004-2024 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.tools;
+
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.StringParameter;
+import io.github.mzmine.util.XMLUtils;
+import org.w3c.dom.Element;
+
+public final class PlaceholderModuleParameters extends SimpleParameterSet {
+
+  public static final StringParameter oldModuleName = new StringParameter("Old module name",
+      "The name of the old module.");
+
+  public PlaceholderModuleParameters() {
+    super(oldModuleName);
+  }
+
+  public static ParameterSet forElement(String moduleName, Element parametersElement) {
+    final ParameterSet param = new PlaceholderModuleParameters().cloneParameterSet();
+
+    StringBuilder b = new StringBuilder();
+    b.append(moduleName).append("\n\n");
+    b.append(XMLUtils.nodeToString(parametersElement));
+    param.setParameter(oldModuleName, b.toString());
+
+    return param;
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/util/XMLUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/XMLUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -29,6 +29,7 @@ import com.google.common.collect.Range;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.util.Objects;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -41,6 +42,7 @@ import javax.xml.transform.stream.StreamResult;
 import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
@@ -206,6 +208,32 @@ public class XMLUtils {
       return null;
     } else {
       return items.item(0).getTextContent();
+    }
+  }
+
+  public static String nodeToString(Node node) {
+    try {
+      // Create a TransformerFactory instance
+      TransformerFactory transformerFactory = TransformerFactory.newInstance();
+
+      // Create a Transformer
+      Transformer transformer = transformerFactory.newTransformer();
+
+      // Set output properties to make it pretty
+      transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+      transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+      transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+
+      // Create a StringWriter to hold the XML as a string
+      StringWriter writer = new StringWriter();
+
+      // Transform the DOM Node into a string
+      transformer.transform(new DOMSource(node), new StreamResult(writer));
+
+      return writer.toString();
+    } catch (TransformerException e) {
+      e.printStackTrace();
+      return null;
     }
   }
 }


### PR DESCRIPTION
in case a module was renamed and an old project was opened with a new mzmine version, the project cout not be saved anymore. this replaces missing modules with a placeholder and a xml string covering all the parameter settings