### PR TITLE
Show MS2Deepscore edges in network visualizer by default

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/networking/visual/FeatureNetworkGenerator.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/networking/visual/FeatureNetworkGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -335,7 +335,7 @@ public class FeatureNetworkGenerator {
     setEdgeWeightQuadraticScore(edge, score);
 
     switch (type) {
-      case MS2_MODIFIED_COSINE, GNPS_MODIFIED_COSINE ->
+      case MS2_MODIFIED_COSINE, GNPS_MODIFIED_COSINE, MS2Deepscore ->
           edge.setAttribute("ui.size", (float) Math.max(1, Math.min(5, 5 * score * score)));
       case FEATURE_SHAPE_CORRELATION ->
           edge.setAttribute("ui.size", (float) Math.max(1, Math.min(5, 5 * score * score)));

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/networking/visual/FeatureNetworkPane.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/networking/visual/FeatureNetworkPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -371,7 +371,7 @@ public class FeatureNetworkPane extends NetworkPane {
       if (type != null) {
         switch (type) {
           case ION_IDENTITY -> setVisible(edge, !collapse);
-          case MS2_MODIFIED_COSINE, NETWORK_RELATIONS -> setVisible(edge, true);
+          case MS2_MODIFIED_COSINE, NETWORK_RELATIONS, MS2Deepscore -> setVisible(edge, true);
           default -> {
           }
         }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/networking/visual/enums/EdgeType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/networking/visual/enums/EdgeType.java
@@ -74,7 +74,7 @@ public enum EdgeType implements ElementType {
 
   public static List<EdgeType> getDefaultVisibleColumns() {
     return List.of(ION_IDENTITY, NETWORK_RELATIONS, MS2_MODIFIED_COSINE, GNPS_MODIFIED_COSINE,
-        OTHER);
+        MS2Deepscore, OTHER);
   }
 
   @Override


### PR DESCRIPTION
Kind of confusing for many if those edges are missing. So maybe better to show them by default if people run it