### PR TITLE
PCA contributions as labels + resize stats dashboard for smaller display

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/pca_new/PCAModel.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/pca_new/PCAModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -48,6 +48,7 @@ public class PCAModel {
       4);
   private final Property<Integer> domainPc = new SimpleIntegerProperty(1).asObject();
   private final Property<Integer> rangePc = new SimpleIntegerProperty(2).asObject();
+
   private final ObjectProperty<List<FeatureList>> flists = new SimpleObjectProperty<>();
   private final ObjectProperty<List<FeatureListRow>> selectedRows = new SimpleObjectProperty<>();
   private final ObjectProperty<AbundanceMeasure> abundance = new SimpleObjectProperty<>(

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/pca_new/PCAResult.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/pca_new/PCAResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -38,7 +38,6 @@ import org.jetbrains.annotations.NotNull;
  * transpose of V.
  * <p>
  * https://stats.stackexchange.com/questions/134282/relationship-between-svd-and-pca-how-to-use-svd-to-perform-pca
- *
  */
 public record PCAResult(SingularValueDecomposition svd) {
 
@@ -104,6 +103,30 @@ public record PCAResult(SingularValueDecomposition svd) {
   public RealMatrix getLoadingsMatrix() {
     final RealMatrix transpose = svd.getV().transpose();
     return transpose;
+  }
+
+  /**
+   * The contributions of the principle components
+   *
+   * @param components number of components
+   * @return length of returned array is limited by the components argument and the actual number of
+   * components available. PC1 will be first element [0].
+   */
+  public float[] getComponentContributions(int components) {
+    double[] singularValues = svd.getSingularValues();
+    // Calculate total variance - singularValues are related to standard deviation
+    double totalVariance = 0;
+    for (double value : singularValues) {
+      totalVariance += value * value;
+    }
+
+    components = Math.min(components, singularValues.length);
+    // Calculate variance explained by PC1 and PC2
+    float[] contributions = new float[components];
+    for (int i = 0; i < components; i++) {
+      contributions[i] = (float) ((singularValues[i] * singularValues[i]) / totalVariance);
+    }
+    return contributions;
   }
 
   public int componentCount() {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/pca_new/PCAViewBuilder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/pca_new/PCAViewBuilder.java
@@ -128,8 +128,8 @@ public class PCAViewBuilder extends FxViewBuilder<PCAModel> {
     accordion.setExpandedPane(controls);
     pane.setBottom(accordion);
 
-    scoresPlot.setMinSize(300, 300);
-    loadingsPlot.setMinSize(300, 300);
+    scoresPlot.setMinSize(200, 200);
+    loadingsPlot.setMinSize(200, 200);
 
     final GridPane plotPane = createPlotPane();
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/pca_new/PCAViewBuilder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/pca_new/PCAViewBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -37,6 +37,7 @@ import io.github.mzmine.javafx.components.factories.FxComboBox;
 import io.github.mzmine.javafx.components.factories.FxLabels;
 import io.github.mzmine.javafx.components.util.FxLayout;
 import io.github.mzmine.javafx.mvci.FxViewBuilder;
+import io.github.mzmine.main.ConfigService;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.dataanalysis.utils.imputation.ImputationFunctions;
 import io.github.mzmine.modules.dataanalysis.utils.scaling.ScalingFunctions;
@@ -110,16 +111,19 @@ public class PCAViewBuilder extends FxViewBuilder<PCAModel> {
         FXCollections.observableArrayList(SampleType.values()));
     sampleTypesBox.getCheckModel().clearChecks();
     sampleTypesBox.getCheckModel().check(SampleType.SAMPLE);
-    sampleTypesBox.getCheckModel().getCheckedItems().addListener(new ListChangeListener<SampleType>() {
-      @Override
-      public void onChanged(Change<? extends SampleType> c) {
-        model.setSampleTypeFilter(SampleTypeFilter.of((List<SampleType>) c.getList()));
-      }
-    });
-    final HBox sampleBox = FxLayout.newHBox(Insets.EMPTY, FxLabels.newLabel("Sample types"), sampleTypesBox);
+    sampleTypesBox.getCheckModel().getCheckedItems()
+        .addListener(new ListChangeListener<SampleType>() {
+          @Override
+          public void onChanged(Change<? extends SampleType> c) {
+            model.setSampleTypeFilter(SampleTypeFilter.of((List<SampleType>) c.getList()));
+          }
+        });
+    final HBox sampleBox = FxLayout.newHBox(Insets.EMPTY, FxLabels.newLabel("Sample types"),
+        sampleTypesBox);
 
     final TitledPane controls = new TitledPane("Controls",
-        new FlowPane(space, space, scaling, imputation, domain, range, coloring, abundance, sampleBox));
+        new FlowPane(space, space, scaling, imputation, domain, range, coloring, abundance,
+            sampleBox));
     final Accordion accordion = new Accordion(controls);
     accordion.setExpandedPane(controls);
     pane.setBottom(accordion);
@@ -186,9 +190,22 @@ public class PCAViewBuilder extends FxViewBuilder<PCAModel> {
       plot.addDataset(d.dataset(), d.renderer());
       collection.addAll(d.renderer().getLegendItems());
     });
+    int domainPc = model.getDomainPc();
+    int rangePc = model.getRangePc();
+    int maxPc = Math.max(domainPc, rangePc);
+
+    // show PC contribution on label - otherwise 0 before its calculated
+    PCARowsResult results = model.getPcaResult();
+    float[] contributions =
+        results == null ? new float[maxPc] : results.pcaResult().getComponentContributions(maxPc);
+
+    var percent = ConfigService.getGuiFormats().percentFormat();
+
     plot.getXYPlot().setFixedLegendItems(collection);
-    plot.setDomainAxisLabel(STR."PC\{model.getDomainPc()}");
-    plot.setRangeAxisLabel(STR."PC\{model.getRangePc()}");
+    plot.setDomainAxisLabel(
+        "PC%d (%s)".formatted(domainPc, percent.format(contributions[domainPc - 1])));
+    plot.setRangeAxisLabel(
+        "PC%d (%s)".formatted(rangePc, percent.format(contributions[rangePc - 1])));
   }
 
   private void initChartListeners() {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/rowsboxplot/RowsBoxplotViewBuilder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/rowsboxplot/RowsBoxplotViewBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -55,7 +55,7 @@ public class RowsBoxplotViewBuilder extends FxViewBuilder<RowsBoxplotModel> {
     ((NumberAxis) barChart.getCategoryPlot().getRangeAxis()).setNumberFormatOverride(
         formats.intensityFormat());
     final EChartViewer viewer = new EChartViewer(barChart);
-    viewer.setMinWidth(250);
+    viewer.setMinWidth(200);
     final BoxAndWhiskerRenderer boxAndWhiskerRenderer = new BoxAndWhiskerRenderer();
     boxAndWhiskerRenderer.setMeanVisible(false);
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/statsdashboard/StatsDashboardViewBuilder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/statsdashboard/StatsDashboardViewBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -63,6 +63,7 @@ public class StatsDashboardViewBuilder extends FxViewBuilder<StatsDashboardModel
   public Region build() {
     final SplitPane main = new SplitPane();
     main.setOrientation(Orientation.VERTICAL);
+    main.setDividerPositions(0.75);
     final SplitPane stats = buildStatsPane();
     main.getItems().addAll(stats, table);
 
@@ -105,8 +106,7 @@ public class StatsDashboardViewBuilder extends FxViewBuilder<StatsDashboardModel
         new Tab("Volcano Plot", volcanoPlotController.buildView()));
     stats.getItems().add(analysisTab);
     stats.getItems().add(boxplotController.buildView());
-    stats.setDividerPosition(0, 0.9d);
-    stats.setMinHeight(Region.USE_COMPUTED_SIZE);
+    stats.setDividerPositions(0.9);
     return stats;
   }
 }


### PR DESCRIPTION
Added PCA contributions to the labels. I was always wondering how much PC1 and PC2 contribute. 

Also resized the split panes to give more focus on the stats and less space for the feature table.

![image](https://github.com/user-attachments/assets/9ed15c53-3472-49b2-9708-b29601481453)
