### PR TITLE
Improve memory mapping in data import

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/MainWindowController.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/MainWindowController.java
@@ -910,6 +910,19 @@ public class MainWindowController {
       new Thread(() -> {
         logger.info("Freeing unused memory");
         System.gc();
+        // temporary logs
+//        var raws = ProjectService.getProject().getCurrentRawDataFiles();
+//        var total = raws.stream().map(RawDataFile::getScans).flatMap(Collection::stream)
+//            .mapToLong(MassSpectrum::getNumberOfDataPoints).sum();
+//        var masses = raws.stream().map(RawDataFile::getScans).flatMap(Collection::stream)
+//            .map(Scan::getMassList).filter(Objects::nonNull)
+//            .mapToLong(MassSpectrum::getNumberOfDataPoints).sum();
+//        long totalMb = (total * 2 * 8) / 1024 / 1024;
+//        long massesMb = (masses * 2 * 8) / 1024 / 1024;
+//        logger.info("""
+//            Total data points:   %d (%d MB)
+//            Total in mass lists: %d (%d MB)
+//            """.formatted(total, totalMb, masses, massesMb));
       }).start();
     });
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_imzml/ImzMLImportModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_imzml/ImzMLImportModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -118,11 +118,11 @@ public class ImzMLImportModule implements MZmineProcessingModule {
       logger.finest("File " + fileNames[i] + " type detected as " + fileType);
 
       try {
-        ImagingRawDataFile newMZmineFile = MZmineCore
-            .createNewImagingFile(newName, fileNames[i].getAbsolutePath(), storage);
+        ImagingRawDataFile newMZmineFile = MZmineCore.createNewImagingFile(newName,
+            fileNames[i].getAbsolutePath(), storage);
         Task newTask = new ImzMLImportTask(project, fileNames[i],
-            ScanImportProcessorConfig.createDefault(), newMZmineFile,
-            ImzMLImportModule.class, parameters, moduleCallDate);
+            ScanImportProcessorConfig.createDefault(), newMZmineFile, ImzMLImportModule.class,
+            parameters, moduleCallDate, storage);
         tasks.add(newTask);
 
       } catch (IOException e) {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_imzml/ImzMLImportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_imzml/ImzMLImportTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -53,6 +53,7 @@ import io.github.mzmine.modules.io.import_rawdata_all.spectral_processor.SimpleS
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.exceptions.ExceptionUtils;
 import io.github.mzmine.util.scans.ScanUtils;
 import java.io.File;
@@ -65,6 +66,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * This class reads mzML 1.0 and 1.1.0 files (http://www.psidev.info/index.php?q=node/257) using the
@@ -99,8 +101,9 @@ public class ImzMLImportTask extends AbstractTask {
   public ImzMLImportTask(MZmineProject project, File fileToOpen,
       final @NotNull ScanImportProcessorConfig scanProcessorConfig,
       ImagingRawDataFile newMZmineFile, @NotNull final Class<? extends MZmineModule> module,
-      @NotNull final ParameterSet parameters, @NotNull Instant moduleCallDate) {
-    super(null, moduleCallDate); // storage in raw data file
+      @NotNull final ParameterSet parameters, @NotNull Instant moduleCallDate,
+      final @Nullable MemoryMapStorage storage) {
+    super(storage, moduleCallDate); // storage also set in raw data file
     this.project = project;
     this.file = fileToOpen;
     this.scanProcessorConfig = scanProcessorConfig;

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvertImportModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvertImportModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -32,6 +32,7 @@ import io.github.mzmine.modules.io.import_rawdata_all.spectral_processor.ScanImp
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import io.github.mzmine.util.MemoryMapStorage;
 import java.io.File;
 import java.time.Instant;
 import java.util.Collection;
@@ -40,7 +41,8 @@ import org.jetbrains.annotations.NotNull;
 public class MSConvertImportModule extends AbstractProcessingModule {
 
   public MSConvertImportModule() {
-    super("Raw data import (MSConvert)", MSConvertImportParameters.class, MZmineModuleCategory.RAWDATAIMPORT,
+    super("Raw data import (MSConvert)", MSConvertImportParameters.class,
+        MZmineModuleCategory.RAWDATAIMPORT,
         "Import native raw data using MSConvert as an intermediate step.");
   }
 
@@ -55,9 +57,10 @@ public class MSConvertImportModule extends AbstractProcessingModule {
       return ExitCode.ERROR;
     }
 
+    var storage = MemoryMapStorage.forRawDataFile();
     for (File file : files) {
-      tasks.add(new MSConvertImportTask(moduleCallDate, file, ScanImportProcessorConfig.createDefault(), project, this.getClass(),
-          parameters));
+      tasks.add(new MSConvertImportTask(storage, moduleCallDate, file,
+          ScanImportProcessorConfig.createDefault(), project, this.getClass(), parameters));
     }
 
     return ExitCode.OK;

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvertImportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvertImportTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -40,6 +40,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.ParameterUtils;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.RawDataFileType;
 import io.github.mzmine.util.RawDataFileTypeDetector;
 import io.github.mzmine.util.RawDataFileTypeDetector.WatersAcquisitionType;
@@ -59,6 +60,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class MSConvertImportTask extends AbstractTask {
 
@@ -73,10 +75,10 @@ public class MSConvertImportTask extends AbstractTask {
   private Boolean convertToFile = ConfigService.getConfiguration().getPreferences()
       .getValue(MZminePreferences.keepConvertedFile);
 
-  public MSConvertImportTask(@NotNull Instant moduleCallDate, File path,
-      ScanImportProcessorConfig config, MZmineProject project, Class<? extends MZmineModule> module,
-      ParameterSet parameters) {
-    super(moduleCallDate);
+  public MSConvertImportTask(final @Nullable MemoryMapStorage storage,
+      @NotNull Instant moduleCallDate, File path, ScanImportProcessorConfig config,
+      MZmineProject project, Class<? extends MZmineModule> module, ParameterSet parameters) {
+    super(storage, moduleCallDate);
     this.rawFilePath = path;
     this.config = config;
     this.project = project;
@@ -286,7 +288,7 @@ public class MSConvertImportTask extends AbstractTask {
     if (parsedScans != totalScans) {
       throw (new RuntimeException(
           "MSConvert process crashed before all scans were extracted (" + parsedScans + " out of "
-              + totalScans + ")"));
+          + totalScans + ")"));
     }
     msdkTask.addAppliedMethodAndAddToProject(dataFile);
   }
@@ -330,7 +332,7 @@ public class MSConvertImportTask extends AbstractTask {
       if (parsedScans != totalScans) {
         throw (new RuntimeException(
             "ThermoRawFileParser process crashed before all scans were extracted (" + parsedScans
-                + " out of " + totalScans + ")"));
+            + " out of " + totalScans + ")"));
       }
 
       msdkTask.addAppliedMethodAndAddToProject(dataFile);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzxml/MzXMLImportModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzxml/MzXMLImportModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -117,7 +117,7 @@ public class MzXMLImportModule implements MZmineProcessingModule {
             fileNames[i].getAbsolutePath(), storage);
         Task newTask = new MzXMLImportTask(project, fileNames[i], newMZmineFile,
             ScanImportProcessorConfig.createDefault(), MzXMLImportModule.class, parameters,
-            moduleCallDate);
+            moduleCallDate, storage);
         tasks.add(newTask);
       } catch (IOException e) {
         e.printStackTrace();

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzxml/MzXMLImportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzxml/MzXMLImportTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -41,6 +41,7 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.CompressionUtils;
+import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.exceptions.ExceptionUtils;
 import io.github.mzmine.util.scans.ScanUtils;
 import java.io.ByteArrayInputStream;
@@ -60,6 +61,7 @@ import javax.xml.datatype.Duration;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
@@ -110,8 +112,8 @@ public class MzXMLImportTask extends AbstractTask {
   public MzXMLImportTask(MZmineProject project, File fileToOpen, RawDataFile newMZmineFile,
       @NotNull ScanImportProcessorConfig scanProcessorConfig,
       @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters,
-      @NotNull Instant moduleCallDate) {
-    super(null, moduleCallDate); // storage in raw data file
+      @NotNull Instant moduleCallDate, final @Nullable MemoryMapStorage storage) {
+    super(storage, moduleCallDate); // storage also set in raw data file
     this.scanProcessorConfig = scanProcessorConfig;
     this.parameters = parameters;
     this.module = module;

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoImportTaskDelegator.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoImportTaskDelegator.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2004-2024 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.mzmine.modules.io.import_rawdata_thermo_raw;
 
 import io.github.mzmine.datamodel.MZmineProject;
@@ -12,9 +37,7 @@ import io.github.mzmine.modules.io.import_rawdata_msconvert.MSConvertImportTask;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.AbstractSimpleTask;
 import io.github.mzmine.taskcontrol.AbstractTask;
-import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import io.github.mzmine.taskcontrol.TaskStatusListener;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.io.File;
 import java.time.Instant;
@@ -23,26 +46,26 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Handles if thermo files are imported via msconvert or the raw file parser. launches the correct task.
+ * Handles if thermo files are imported via msconvert or the raw file parser. launches the correct
+ * task.
  */
 public class ThermoImportTaskDelegator extends AbstractSimpleTask {
 
   private AbstractTask actualTask;
 
   public ThermoImportTaskDelegator(@Nullable MemoryMapStorage storage,
-      @NotNull Instant moduleCallDate, File file,
-      ScanImportProcessorConfig processorConfig, MZmineProject project,
-      @NotNull ParameterSet parameters, @NotNull Class<? extends MZmineModule> moduleClass) {
+      @NotNull Instant moduleCallDate, File file, ScanImportProcessorConfig processorConfig,
+      MZmineProject project, @NotNull ParameterSet parameters,
+      @NotNull Class<? extends MZmineModule> moduleClass) {
 
     super(storage, moduleCallDate, parameters, moduleClass);
 
     final ThermoImportOptions importChoice = ConfigService.getPreference(
         MZminePreferences.thermoImportChoice);
-    actualTask =
-        importChoice == ThermoImportOptions.MSCONVERT ? new MSConvertImportTask(moduleCallDate,
-            file, processorConfig, project, moduleClass, parameters)
-            : new ThermoRawImportTask(project, file, moduleClass, parameters,
-                moduleCallDate, processorConfig);
+    actualTask = importChoice == ThermoImportOptions.MSCONVERT ? new MSConvertImportTask(storage,
+        moduleCallDate, file, processorConfig, project, moduleClass, parameters)
+        : new ThermoRawImportTask(storage, project, file, moduleClass, parameters, moduleCallDate,
+            processorConfig);
 
     // cancel the underlying task if this task is canceled
     this.addTaskStatusListener((_, newStatus, _) -> actualTask.setStatus(newStatus));
@@ -51,8 +74,8 @@ public class ThermoImportTaskDelegator extends AbstractSimpleTask {
   @Override
   protected void process() {
     actualTask.run();
-    if(actualTask.getStatus() != TaskStatus.FINISHED) {
-      if(actualTask.getErrorMessage() != null) {
+    if (actualTask.getStatus() != TaskStatus.FINISHED) {
+      if (actualTask.getErrorMessage() != null) {
         setErrorMessage(actualTask.getErrorMessage());
       }
       setStatus(actualTask.getStatus());

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoRawImportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_thermo_raw/ThermoRawImportTask.java
@@ -30,40 +30,29 @@ import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.gui.DesktopService;
 import io.github.mzmine.gui.preferences.MZminePreferences;
-import io.github.mzmine.gui.preferences.ThermoImportOptions;
 import io.github.mzmine.javafx.concurrent.threading.FxThread;
 import io.github.mzmine.javafx.dialogs.DialogLoggerUtil;
 import io.github.mzmine.main.ConfigService;
-import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineModule;
 import io.github.mzmine.modules.io.download.ExternalAsset;
-import io.github.mzmine.modules.io.import_rawdata_all.AllSpectralDataImportModule;
 import io.github.mzmine.modules.io.import_rawdata_all.spectral_processor.ScanImportProcessorConfig;
-import io.github.mzmine.modules.io.import_rawdata_msconvert.MSConvert;
-import io.github.mzmine.modules.io.import_rawdata_msconvert.MSConvertImportTask;
 import io.github.mzmine.modules.io.import_rawdata_mzml.MSDKmzMLImportTask;
 import io.github.mzmine.parameters.ParameterSet;
-import io.github.mzmine.parameters.ParameterUtils;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.ExitCode;
+import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.StringUtils;
 import io.github.mzmine.util.ZipUtils;
 import io.github.mzmine.util.concurrent.CloseableReentrantReadWriteLock;
 import io.github.mzmine.util.exceptions.ExceptionUtils;
 import io.github.mzmine.util.files.FileAndPathUtil;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.StandardOpenOption;
 import java.time.Instant;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
-import java.util.zip.ZipInputStream;
-import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -92,10 +81,11 @@ public class ThermoRawImportTask extends AbstractTask {
   private MSDKmzMLImportTask msdkTask;
   private int convertedScans;
 
-  protected ThermoRawImportTask(MZmineProject project, File fileToOpen,
-      @NotNull final Class<? extends MZmineModule> module, @NotNull final ParameterSet parameters,
-      @NotNull Instant moduleCallDate, @NotNull ScanImportProcessorConfig scanProcessorConfig) {
-    super(null, moduleCallDate); // storage in raw data file
+  protected ThermoRawImportTask(final @Nullable MemoryMapStorage storage, MZmineProject project,
+      File fileToOpen, @NotNull final Class<? extends MZmineModule> module,
+      @NotNull final ParameterSet parameters, @NotNull Instant moduleCallDate,
+      @NotNull ScanImportProcessorConfig scanProcessorConfig) {
+    super(storage, moduleCallDate); // storage in raw data file
     this.project = project;
     this.fileToOpen = fileToOpen;
     taskDescription = "Opening file " + fileToOpen;
@@ -160,7 +150,7 @@ public class ThermoRawImportTask extends AbstractTask {
       if (parsedScans != totalScans) {
         throw (new RuntimeException(
             "ThermoRawFileParser process crashed before all scans were extracted (" + parsedScans
-                + " out of " + totalScans + ")"));
+            + " out of " + totalScans + ")"));
       }
       msdkTask.addAppliedMethodAndAddToProject(dataFile);
     } catch (Throwable e) {
@@ -358,7 +348,7 @@ public class ThermoRawImportTask extends AbstractTask {
    */
   private boolean isValidParserPathForOs(File path) {
     if (path != null && path.exists() && (path.toPath().endsWith(getParserNameForOs())
-        || path.toPath().endsWith("ThermoRawFileParser.zip"))) {
+                                          || path.toPath().endsWith("ThermoRawFileParser.zip"))) {
       return true;
     }
     return false;

--- a/mzmine-community/src/main/java/io/github/mzmine/util/RawDataFileUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/RawDataFileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -42,7 +42,6 @@ import io.github.mzmine.modules.io.import_rawdata_mzml.MSDKmzMLImportTask;
 import io.github.mzmine.modules.io.import_rawdata_mzxml.MzXMLImportTask;
 import io.github.mzmine.modules.io.import_rawdata_netcdf.NetCDFImportTask;
 import io.github.mzmine.modules.io.import_rawdata_thermo_raw.ThermoImportTaskDelegator;
-import io.github.mzmine.modules.io.import_rawdata_thermo_raw.ThermoRawImportTask;
 import io.github.mzmine.modules.io.import_rawdata_zip.ZipImportTask;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
@@ -109,13 +108,13 @@ public class RawDataFileUtils {
           newMZmineFile = MZmineCore.createNewImagingFile(fileName.getName(),
               fileName.getAbsolutePath(), storage);
           newTask = new ImzMLImportTask(project, fileName, scanProcessorConfig,
-              (ImagingRawDataFile) newMZmineFile, module, parameters, moduleCallDate);
+              (ImagingRawDataFile) newMZmineFile, module, parameters, moduleCallDate, storage);
           break;
         case MZXML:
           newMZmineFile = MZmineCore.createNewFile(fileName.getName(), fileName.getAbsolutePath(),
               storage);
           newTask = new MzXMLImportTask(project, fileName, newMZmineFile, scanProcessorConfig,
-              module, parameters, moduleCallDate);
+              module, parameters, moduleCallDate, storage);
           break;
         case NETCDF:
           newMZmineFile = MZmineCore.createNewFile(fileName.getName(), fileName.getAbsolutePath(),
@@ -124,8 +123,8 @@ public class RawDataFileUtils {
               moduleCallDate);
           break;
         case THERMO_RAW:
-          newTask = new ThermoImportTaskDelegator(storage, moduleCallDate, fileName, scanProcessorConfig, project,
-              parameters, module);
+          newTask = new ThermoImportTaskDelegator(storage, moduleCallDate, fileName,
+              scanProcessorConfig, project, parameters, module);
           break;
 /*        case WATERS_RAW:
           newMZmineFile = MZmineCore.createNewFile(fileName.getName(), fileName.getAbsolutePath(),


### PR DESCRIPTION
Adds memory maps directly to tasks.
Also present in RawDataFile but this way task can decide where to get the map from