### PR TITLE
fix frame merging using mobility scans for frame spectrum

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/util/scans/SpectraMerging.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/scans/SpectraMerging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -558,7 +558,7 @@ public class SpectraMerging {
 
     frame.setMobilityScans(buildingMobilityScans, true);
     frame.setMobilities(mobilities);
-    double[][] mergedSpectrum = calculatedMergedMzsAndIntensities(buildingMobilityScans, tolerance,
+    double[][] mergedSpectrum = calculatedMergedMzsAndIntensities(frames, tolerance,
         intensityMergingType, cf, null, null, null);
     frame.setDataPoints(mergedSpectrum[0], mergedSpectrum[1]);
     return frame;


### PR DESCRIPTION
the intensity n the merged frames in the raw data overview was calculated from the most intense mobility scan, not the most intense frame.