### PR TITLE
Add method to extract a Scan Id String from a Scan

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/spectra/matchedlipid/LipidAnnotationMatchPane.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/spectra/matchedlipid/LipidAnnotationMatchPane.java
@@ -37,6 +37,7 @@ import io.github.mzmine.modules.dataprocessing.id_lipidid.common.lipids.LipidFra
 import io.github.mzmine.util.FormulaUtils;
 import io.github.mzmine.javafx.util.color.ColorScaleUtil;
 import io.github.mzmine.javafx.util.FxColorUtil;
+import io.github.mzmine.util.scans.ScanUtils;
 import java.text.DecimalFormat;
 import java.util.List;
 import javafx.geometry.HPos;
@@ -145,7 +146,8 @@ public class LipidAnnotationMatchPane extends AbstractFeatureListRowsPane {
       // put into main
       ColumnConstraints ccSpectrum = new ColumnConstraints(400, -1, Region.USE_COMPUTED_SIZE,
           Priority.ALWAYS, HPos.CENTER, true);
-      ColumnConstraints ccMetadata = new ColumnConstraints(META_WIDTH + 30, META_WIDTH + 30, Region.USE_COMPUTED_SIZE, Priority.NEVER, HPos.LEFT, false);
+      ColumnConstraints ccMetadata = new ColumnConstraints(META_WIDTH + 30, META_WIDTH + 30,
+          Region.USE_COMPUTED_SIZE, Priority.NEVER, HPos.LEFT, false);
 
       add(pnTitle, 0, 0, 2, 1);
       add(lipidSpectrumPlot, 0, 1);
@@ -167,8 +169,9 @@ public class LipidAnnotationMatchPane extends AbstractFeatureListRowsPane {
       Label lblMatchedLipid = createLabel(matchedLipid.getLipidAnnotation().getAnnotation(),
           "white-larger-label");
 
-      String simScoreTooltip = "Explained intensity [%] of all signals in MS/MS spectrum: " + MSMS_SCORE_FORM.format(
-          msMsScore);
+      String simScoreTooltip =
+          "Explained intensity [%] of all signals in MS/MS spectrum: " + MSMS_SCORE_FORM.format(
+              msMsScore);
       Label lblScore = createLabel(MSMS_SCORE_FORM.format(msMsScore), simScoreTooltip,
           "white-score-label");
 
@@ -249,23 +252,28 @@ public class LipidAnnotationMatchPane extends AbstractFeatureListRowsPane {
       panelOther.getChildren().addAll(formula);
 
       Label ion = new Label(
-          "Ion notation: " + matchedLipid.getIonizationType().getAdductName() + " " + MZmineCore.getConfiguration().getMZFormat().format(FormulaUtils.calculateMzRatio(
+          "Ion notation: " + matchedLipid.getIonizationType().getAdductName() + " "
+              + MZmineCore.getConfiguration().getMZFormat().format(FormulaUtils.calculateMzRatio(
               FormulaUtils.ionizeFormula(MolecularFormulaManipulator.getString(
-                  matchedLipid.getLipidAnnotation().getMolecularFormula()), matchedLipid.getIonizationType()))));
+                      matchedLipid.getLipidAnnotation().getMolecularFormula()),
+                  matchedLipid.getIonizationType()))));
       ion.setWrapText(true);
       panelOther.getChildren().addAll(ion);
 
-      Label lipidClass = new Label("Lipid class: " + matchedLipid.getLipidAnnotation().getLipidClass().getName());
+      Label lipidClass = new Label(
+          "Lipid class: " + matchedLipid.getLipidAnnotation().getLipidClass().getName());
       lipidClass.setWrapText(true);
       panelOther.getChildren().addAll(lipidClass);
 
       Label lipidMainClass = new Label(
-          "Lipid main class: " + matchedLipid.getLipidAnnotation().getLipidClass().getMainClass().getName());
+          "Lipid main class: " + matchedLipid.getLipidAnnotation().getLipidClass().getMainClass()
+              .getName());
       lipidMainClass.setWrapText(true);
       panelOther.getChildren().addAll(lipidMainClass);
 
       Label lipidCategory = new Label(
-          "Lipid category: " + matchedLipid.getLipidAnnotation().getLipidClass().getMainClass().getLipidCategory().getName());
+          "Lipid category: " + matchedLipid.getLipidAnnotation().getLipidClass().getMainClass()
+              .getLipidCategory().getName());
       lipidCategory.setWrapText(true);
       panelOther.getChildren().addAll(lipidCategory);
 
@@ -277,13 +285,17 @@ public class LipidAnnotationMatchPane extends AbstractFeatureListRowsPane {
       panelOther.getChildren().addAll(rawDataTitle);
 
       if (!matchedLipid.getMatchedFragments().isEmpty()) {
-        LipidFragment lipidFragment = matchedLipid.getMatchedFragments().stream().findFirst().orElse(null);
+        LipidFragment lipidFragment = matchedLipid.getMatchedFragments().stream().findFirst()
+            .orElse(null);
         if (lipidFragment != null) {
-          Label rawFile = new Label("Raw data file: " + lipidFragment.getMsMsScan().getDataFile().getName());
+          Label rawFile = new Label(
+              "Raw data file: " + lipidFragment.getMsMsScan().getDataFile().getName());
           rawFile.setWrapText(true);
           panelOther.getChildren().addAll(rawFile);
 
-          Label matchedScan = new Label("Matched Scan number: " + lipidFragment.getMsMsScan().getScanNumber());
+          Label matchedScan = new Label(
+              "Matched Scan number: " + ScanUtils.extractScanIdString(lipidFragment.getMsMsScan(),
+                  false));
           matchedScan.setWrapText(true);
           panelOther.getChildren().addAll(matchedScan);
         }


### PR DESCRIPTION
Extracts a scan id string in the form of:
`171103_PMA_TK_M1_01.mzML:2215;171103_PMA_TK_M1_06.mzML:2230;171103_PMA_TK_M1_02.mzML:2208;171103_PMA_TK_M1_04.mzML:2203;171103_PMA_TK_M1_05.mzML:2215;171103_PMA_TK_M1_03.mzML:2216,2239`
from merged spectra. Also works for mobility scans. 

Also adds this string to the Lipid match pane and the spectral db match pane.
For the spectral db match pane, also the sizing was fixed so the scroll pane works as intended and you can actually see all the information.

![grafik](https://github.com/user-attachments/assets/f5d33106-e3ca-43b4-a6b5-751a75039f6a)

@corinnabrungs The method `ScanUtils.extractIdStringForScansOfSingleFile` can be used to generate only the list of scan numbers, so that it can be reused to create USIs.
