### PR TITLE
change return types of subSeries and copyAndReplace

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/data_access/FeatureDataAccess.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/data_access/FeatureDataAccess.java
@@ -264,15 +264,15 @@ public abstract class FeatureDataAccess implements IonTimeSeries<Scan> {
    * @return
    */
   @Override
-  public IonSpectrumSeries<Scan> copyAndReplace(@Nullable MemoryMapStorage storage,
+  public IonTimeSeries<Scan> copyAndReplace(@Nullable MemoryMapStorage storage,
       @NotNull double[] newIntensityValues) {
     return copyAndReplace(storage, getMzValuesCopy(), newIntensityValues);
   }
 
   @Override
-  public IonSpectrumSeries<Scan> copyAndReplace(@Nullable MemoryMapStorage storage,
+  public IonTimeSeries<Scan> copyAndReplace(@Nullable MemoryMapStorage storage,
       @NotNull double[] newMzValues, @NotNull double[] newIntensityValues) {
-    IonSpectrumSeries<Scan> oldData = (IonSpectrumSeries<Scan>) getFeature().getFeatureData();
+    IonTimeSeries<Scan> oldData = (IonTimeSeries<Scan>) getFeature().getFeatureData();
     int numValues = oldData.getNumberOfValues();
     if (numValues < newIntensityValues.length) {
       // need to transfer data points to actual scans with detections.
@@ -296,9 +296,9 @@ public abstract class FeatureDataAccess implements IonTimeSeries<Scan> {
         actualIntensities[i] = newIntensityValues[newDataIndex];
       }
 
-      return oldData.copyAndReplace(storage, actualMzs, actualIntensities);
+      return (IonTimeSeries<Scan>) oldData.copyAndReplace(storage, actualMzs, actualIntensities);
     } else {
-      return oldData.copyAndReplace(storage, newMzValues, newIntensityValues);
+      return (IonTimeSeries<Scan>) oldData.copyAndReplace(storage, newMzValues, newIntensityValues);
     }
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/IonMobilogramTimeSeries.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/IonMobilogramTimeSeries.java
@@ -94,6 +94,14 @@ public interface IonMobilogramTimeSeries extends IonTimeSeries<Frame>, Modifiabl
   IonMobilogramTimeSeries copyAndReplace(@Nullable MemoryMapStorage storage,
       @NotNull SummedIntensityMobilitySeries summedMobilogram);
 
+  @Override
+  IonMobilogramTimeSeries copyAndReplace(@Nullable MemoryMapStorage storage,
+      @NotNull double[] newIntensityValues);
+
+  @Override
+  IonMobilogramTimeSeries copyAndReplace(@Nullable MemoryMapStorage storage,
+      @NotNull double[] newMzValues, @NotNull double[] newIntensityValues);
+
   /**
    * @param scan
    * @return The intensity value for the given scan or 0 if the no intensity was measured at that

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/IonTimeSeries.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/IonTimeSeries.java
@@ -77,20 +77,28 @@ public interface IonTimeSeries<T extends Scan> extends IonSpectrumSeries<T>, Int
   }
 
   @Override
-  default IntensityTimeSeries subSeries(MemoryMapStorage storage, float start, float end) {
+  default IonTimeSeries<T> subSeries(MemoryMapStorage storage, float start, float end) {
     final IndexRange indexRange = BinarySearch.indexRange(Range.closed(start, end), getSpectra(),
         Scan::getRetentionTime);
     return subSeries(storage, indexRange.min(), indexRange.maxExclusive());
   }
 
   @Override
-  default IntensityTimeSeries subSeries(MemoryMapStorage storage, int startIndexInclusive,
+  default IonTimeSeries<T> subSeries(MemoryMapStorage storage, int startIndexInclusive,
       int endIndexExclusive) {
     return subSeries(storage, getSpectra().subList(startIndexInclusive, endIndexExclusive));
   }
 
   @Override
   IonTimeSeries<T> subSeries(@Nullable MemoryMapStorage storage, @NotNull List<T> subset);
+
+  @Override
+  IonTimeSeries<T> copyAndReplace(@Nullable MemoryMapStorage storage,
+      @NotNull double[] newIntensityValues);
+
+  @Override
+  IonTimeSeries<T> copyAndReplace(@Nullable MemoryMapStorage storage, @NotNull double[] newMzValues,
+      @NotNull double[] newIntensityValues);
 
   /**
    * Saves this time series to xml. The implementing class is responsible for creating the xml

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonTimeSeries.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonTimeSeries.java
@@ -31,7 +31,6 @@ import com.google.common.collect.Comparators;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.featuredata.IntensitySeries;
-import io.github.mzmine.datamodel.featuredata.IntensityTimeSeries;
 import io.github.mzmine.datamodel.featuredata.IonSpectrumSeries;
 import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
 import io.github.mzmine.datamodel.featuredata.MzSeries;
@@ -184,7 +183,7 @@ public class SimpleIonTimeSeries implements IonTimeSeries<Scan> {
   }
 
   @Override
-  public IntensityTimeSeries subSeries(MemoryMapStorage storage, int startIndexInclusive,
+  public IonTimeSeries<Scan> subSeries(MemoryMapStorage storage, int startIndexInclusive,
       int endIndexExclusive) {
 
     return new SimpleIonTimeSeries(
@@ -222,7 +221,7 @@ public class SimpleIonTimeSeries implements IonTimeSeries<Scan> {
   }
 
   @Override
-  public IonSpectrumSeries<Scan> copyAndReplace(@Nullable final MemoryMapStorage storage,
+  public IonTimeSeries<Scan> copyAndReplace(@Nullable final MemoryMapStorage storage,
       @NotNull final double[] newIntensityValues) {
     var intensities = StorageUtils.storeValuesToDoubleBuffer(storage, newIntensityValues);
     // reuse mz memory segment


### PR DESCRIPTION
changed to some more specific return types in the downstream interfaces of IonSpectrumSeries. Makes it easer to deal with the returned values 