### PR TITLE
BaselineDataBuffer clearing fix

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_baselinecorrection/BaselineDataBuffer.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_baselinecorrection/BaselineDataBuffer.java
@@ -79,8 +79,8 @@ public class BaselineDataBuffer {
     }
 
     ensureCapacity(numValues);
-    extractRtValues(timeSeries); // needs to happen after ensureCapacity
     clearRemovedPeaksBuffers();
+    extractRtValues(timeSeries); // needs to happen after ensureCapacity
 
     indicesOfInterest.clear();
     indicesOfInterest.add(0);


### PR DESCRIPTION
fix BaselineDataBuffer clearing xbuffer after extracting rts if no features were found