### PR TITLE
Add UniqueIdSupplier for stable ID for IO

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/DataType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/DataType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -46,6 +46,7 @@ import io.github.mzmine.datamodel.features.types.modifiers.NullColumnType;
 import io.github.mzmine.datamodel.features.types.modifiers.StringParser;
 import io.github.mzmine.datamodel.features.types.modifiers.SubColumnsFactory;
 import io.github.mzmine.datamodel.features.types.numbers.abstr.ListDataType;
+import io.github.mzmine.datamodel.utils.UniqueIdSupplier;
 import io.github.mzmine.modules.visualization.featurelisttable_modular.FeatureTableFX;
 import java.util.ArrayList;
 import java.util.List;
@@ -67,7 +68,7 @@ import org.jetbrains.annotations.Nullable;
  * @param <T>
  * @author Robin Schmid (robinschmid@uni-muenster.de)
  */
-public abstract class DataType<T> implements Comparable<DataType> {
+public abstract class DataType<T> implements Comparable<DataType>, UniqueIdSupplier {
 
   private static final Logger logger = Logger.getLogger(DataType.class.getName());
 
@@ -155,6 +156,7 @@ public abstract class DataType<T> implements Comparable<DataType> {
    *
    * @return a unique identifier
    */
+  @Override
   @NotNull
   public abstract String getUniqueID();
 
@@ -355,9 +357,9 @@ public abstract class DataType<T> implements Comparable<DataType> {
    * modified.
    */
   @Nullable
-  public Runnable getDoubleClickAction(final @Nullable FeatureTableFX table, @NotNull ModularFeatureListRow row,
-      @NotNull List<RawDataFile> file, @Nullable DataType<?> superType,
-      @Nullable final Object value) {
+  public Runnable getDoubleClickAction(final @Nullable FeatureTableFX table,
+      @NotNull ModularFeatureListRow row, @NotNull List<RawDataFile> file,
+      @Nullable DataType<?> superType, @Nullable final Object value) {
     return null;
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/utils/UniqueIdSupplier.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/utils/UniqueIdSupplier.java
@@ -23,38 +23,18 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.mzmine.modules.io.spectraldbsubmit.batch;
+package io.github.mzmine.datamodel.utils;
 
-import io.github.mzmine.datamodel.utils.UniqueIdSupplier;
 import org.jetbrains.annotations.NotNull;
 
-public enum SpectralLibraryExportFormats implements UniqueIdSupplier {
-  json_mzmine, msp, mgf;
+public interface UniqueIdSupplier {
 
-  @Override
-  public String toString() {
-    return switch (this) {
-      case json_mzmine -> "mzmine json (recommended)";
-      case msp -> "NIST msp";
-      case mgf -> "mgf";
-    };
-  }
+  /**
+   * This value should not change throughout versions
+   *
+   * @return a stable unique ID that may be used in save and load
+   */
+  @NotNull
+  String getUniqueID();
 
-  public String getExtension() {
-    return switch (this) {
-      case json_mzmine -> "json";
-      case msp -> "msp";
-      case mgf -> "mgf";
-    };
-  }
-
-  @Override
-  public @NotNull String getUniqueID() {
-    // do not change these values are used for import export
-    return switch (this) {
-      case json_mzmine -> "MZmine json (recommended)"; // this was the initial name
-      case msp -> "msp";
-      case mgf -> "mgf";
-    };
-  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/batch/LibraryBatchGenerationParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/batch/LibraryBatchGenerationParameters.java
@@ -68,7 +68,7 @@ public class LibraryBatchGenerationParameters extends SimpleParameterSet {
 
   public static final ComboParameter<SpectralLibraryExportFormats> exportFormat = new ComboParameter<>(
       "Export format", "format to export", SpectralLibraryExportFormats.values(),
-      SpectralLibraryExportFormats.json);
+      SpectralLibraryExportFormats.json_mzmine);
 
   public static final ParameterSetParameter<LibraryBatchMetadataParameters> metadata = new ParameterSetParameter<>(
       "Metadata", "Metadata for all entries", new LibraryBatchMetadataParameters());

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/batch/LibraryBatchGenerationTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/batch/LibraryBatchGenerationTask.java
@@ -377,7 +377,7 @@ public class LibraryBatchGenerationTask extends AbstractTask {
     // if intensity is 0 after formatting
     String stringEntry = switch (format) {
       case msp -> MSPEntryGenerator.createMSPEntry(entry, normalizer);
-      case json -> MZmineJsonGenerator.generateJSON(entry, normalizer);
+      case json_mzmine -> MZmineJsonGenerator.generateJSON(entry, normalizer);
       case mgf -> MGFEntryGenerator.createMGFEntry(entry, normalizer).spectrum();
     };
     writer.append(stringEntry).append("\n");

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/WizardPart.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/WizardPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -90,7 +90,7 @@ public enum WizardPart {
    * @return the WizardParameterFactory that matches the uniqueID
    */
   public Optional<WizardParameterFactory> getParameterFactory(final String uniqeId) {
-    return Arrays.stream(getDefaultPresets()).filter(p -> p.getUniqueId().equals(uniqeId))
+    return Arrays.stream(getDefaultPresets()).filter(p -> p.getUniqueID().equals(uniqeId))
         .findFirst();
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/BaseWizardBatchBuilder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/BaseWizardBatchBuilder.java
@@ -731,7 +731,7 @@ public abstract class BaseWizardBatchBuilder extends WizardBatchBuilder {
     final ParameterSet param = MZmineCore.getConfiguration()
         .getModuleParameters(LibraryBatchGenerationModule.class).cloneParameterSet();
 
-    var exportFormat = SpectralLibraryExportFormats.json;
+    var exportFormat = SpectralLibraryExportFormats.json_mzmine;
     File fileName = FileAndPathUtil.eraseFormat(exportPath);
     fileName = new File(fileName.getParentFile(),
         fileName.getName() + "_lib." + exportFormat.getExtension());

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/WizardStepParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/WizardStepParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -117,7 +117,7 @@ public abstract sealed class WizardStepParameters extends ComposedParameterSet i
    */
   @NotNull
   public String getUniquePresetId() {
-    return factory.getUniqueId();
+    return factory.getUniqueID();
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/AnnotationWizardParameterFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/AnnotationWizardParameterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -27,6 +27,7 @@ package io.github.mzmine.modules.tools.batchwizard.subparameters.factories;
 
 import io.github.mzmine.modules.tools.batchwizard.subparameters.AnnotationWizardParameters;
 import io.github.mzmine.modules.tools.batchwizard.subparameters.WizardStepParameters;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * the defaults should not change the name of enum values. if strings are needed, override the
@@ -42,7 +43,7 @@ public enum AnnotationWizardParameterFactory implements WizardParameterFactory {
   }
 
   @Override
-  public String getUniqueId() {
+  public @NotNull String getUniqueID() {
     return name();
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/DataImportWizardParameterFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/DataImportWizardParameterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -27,6 +27,7 @@ package io.github.mzmine.modules.tools.batchwizard.subparameters.factories;
 
 import io.github.mzmine.modules.tools.batchwizard.subparameters.DataImportWizardParameters;
 import io.github.mzmine.modules.tools.batchwizard.subparameters.WizardStepParameters;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * the defaults should not change the name of enum values. if strings are needed, override the
@@ -42,7 +43,7 @@ public enum DataImportWizardParameterFactory implements WizardParameterFactory {
   }
 
   @Override
-  public String getUniqueId() {
+  public @NotNull String getUniqueID() {
     return name();
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/FilterWizardParameterFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/FilterWizardParameterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -27,6 +27,7 @@ package io.github.mzmine.modules.tools.batchwizard.subparameters.factories;
 
 import io.github.mzmine.modules.tools.batchwizard.subparameters.FilterWizardParameters;
 import io.github.mzmine.modules.tools.batchwizard.subparameters.WizardStepParameters;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * the defaults should not change the name of enum values. if strings are needed, override the
@@ -42,7 +43,7 @@ public enum FilterWizardParameterFactory implements WizardParameterFactory {
   }
 
   @Override
-  public String getUniqueId() {
+  public @NotNull String getUniqueID() {
     return name();
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/IonInterfaceWizardParameterFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/IonInterfaceWizardParameterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -33,6 +33,7 @@ import io.github.mzmine.modules.tools.batchwizard.subparameters.IonInterfaceImag
 import io.github.mzmine.modules.tools.batchwizard.subparameters.WizardStepParameters;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance;
 import io.github.mzmine.parameters.parametertypes.tolerances.RTTolerance.Unit;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * the defaults should not change the name of enum values. if strings are needed, override the
@@ -77,7 +78,7 @@ public enum IonInterfaceWizardParameterFactory implements WizardParameterFactory
   }
 
   @Override
-  public String getUniqueId() {
+  public @NotNull String getUniqueID() {
     return name();
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/IonMobilityWizardParameterFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/IonMobilityWizardParameterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -28,6 +28,7 @@ package io.github.mzmine.modules.tools.batchwizard.subparameters.factories;
 import io.github.mzmine.datamodel.MobilityType;
 import io.github.mzmine.modules.tools.batchwizard.subparameters.IonMobilityWizardParameters;
 import io.github.mzmine.modules.tools.batchwizard.subparameters.WizardStepParameters;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * the defaults should not change the name of enum values. if strings are needed, override the
@@ -68,7 +69,7 @@ public enum IonMobilityWizardParameterFactory implements WizardParameterFactory 
   }
 
   @Override
-  public String getUniqueId() {
+  public @NotNull String getUniqueID() {
     return name();
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/MassSpectrometerWizardParameterFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/MassSpectrometerWizardParameterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -29,6 +29,7 @@ import io.github.mzmine.modules.tools.batchwizard.subparameters.MassDetectorWiza
 import io.github.mzmine.modules.tools.batchwizard.subparameters.MassSpectrometerWizardParameters;
 import io.github.mzmine.modules.tools.batchwizard.subparameters.WizardStepParameters;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * the defaults should not change the name of enum values. if strings are needed, override the
@@ -61,7 +62,7 @@ public enum MassSpectrometerWizardParameterFactory implements WizardParameterFac
   }
 
   @Override
-  public String getUniqueId() {
+  public @NotNull String getUniqueID() {
     return name();
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/WizardParameterFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/WizardParameterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,12 +25,13 @@
 
 package io.github.mzmine.modules.tools.batchwizard.subparameters.factories;
 
+import io.github.mzmine.datamodel.utils.UniqueIdSupplier;
 import io.github.mzmine.modules.tools.batchwizard.subparameters.WizardStepParameters;
 
 /**
  * implemented by preset enums of parts with multiple preset options
  */
-public interface WizardParameterFactory {
+public interface WizardParameterFactory extends UniqueIdSupplier {
 
   /**
    * @return the default parameters for this preset

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/WizardParameterFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/WizardParameterFactory.java
@@ -27,6 +27,7 @@ package io.github.mzmine.modules.tools.batchwizard.subparameters.factories;
 
 import io.github.mzmine.datamodel.utils.UniqueIdSupplier;
 import io.github.mzmine.modules.tools.batchwizard.subparameters.WizardStepParameters;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * implemented by preset enums of parts with multiple preset options
@@ -43,5 +44,7 @@ public interface WizardParameterFactory extends UniqueIdSupplier {
    *
    * @return {@link Enum#name()}
    */
-  String getUniqueId();
+  @Override
+  @NotNull
+  String getUniqueID();
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/WorkflowWizardParameterFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/WorkflowWizardParameterFactory.java
@@ -33,6 +33,7 @@ import io.github.mzmine.modules.tools.batchwizard.subparameters.WorkflowImagingW
 import io.github.mzmine.modules.tools.batchwizard.subparameters.WorkflowLibraryGenerationWizardParameters;
 import io.github.mzmine.modules.tools.batchwizard.subparameters.WorkflowTargetPlateWizardParameters;
 import io.github.mzmine.modules.tools.batchwizard.subparameters.WorkflowWizardParameters;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * the defaults should not change the name of enum values. if strings are needed, override the
@@ -77,7 +78,7 @@ public enum WorkflowWizardParameterFactory implements WizardParameterFactory {
   }
 
   @Override
-  public String getUniqueId() {
+  public @NotNull String getUniqueID() {
     return name();
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/ComboParameter.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/ComboParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,6 +25,7 @@
 
 package io.github.mzmine.parameters.parametertypes;
 
+import io.github.mzmine.datamodel.utils.UniqueIdSupplier;
 import io.github.mzmine.parameters.PropertyParameter;
 import java.util.Collection;
 import java.util.List;
@@ -124,13 +125,14 @@ public class ComboParameter<ValueType> implements
   @Override
   public void loadValueFromXML(Element xmlElement) {
     String elementString = xmlElement.getTextContent();
-    if (elementString.length() == 0) {
+    if (elementString.isEmpty()) {
       return;
     }
     for (ValueType option : choices) {
-      if (option.toString().equals(elementString)) {
+      if ((value instanceof UniqueIdSupplier uis && uis.getUniqueID().equals(elementString))
+          || option.toString().equals(elementString)) {
         value = option;
-        break;
+        return;
       }
     }
   }
@@ -140,7 +142,11 @@ public class ComboParameter<ValueType> implements
     if (value == null) {
       return;
     }
-    xmlElement.setTextContent(value.toString());
+    if (value instanceof UniqueIdSupplier uis) {
+      xmlElement.setTextContent(uis.getUniqueID());
+    } else {
+      xmlElement.setTextContent(value.toString());
+    }
   }
 
   @Override


### PR DESCRIPTION
Need to change the toString of the export format enum. Therefore added a UniqueIdSupplier where enums, DataType and other classes can provide a unique ID like we already do for DataType. Parameters can then check for this type and use it instead of the toString method that may be subject to change. 