### PR TITLE
Compact USI format as advanced parameter in library gen

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/batch/AdvancedLibraryBatchGenerationParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/batch/AdvancedLibraryBatchGenerationParameters.java
@@ -32,10 +32,9 @@ public class AdvancedLibraryBatchGenerationParameters extends SimpleParameterSet
 
   public static BooleanParameter compactUSI = new BooleanParameter(
       "Compact USI (limited compatibility)", """
-      Universal Spectrum Identifier allow traceability to the source scans in a format: mzspec:DATASET:DATAFILE:SCAN_NUMBER. \
-      The regular format allows for a single (optional) scan number. If this parameter is checked, \
-      one USI is generated per source file with scan numbers as ranges, e.g., 1-5,9 for all scans from \
-      1 to 5 and 9. This reduces the file size.
+      Universal Spectrum Identifier allow traceability to the source scans in a format: mzspec:DATASET:DATAFILE:SCAN_NUMBER.
+      The regular format allows for a single (optional) scan number. If this parameter is checked, one USI is generated
+      per source file with scan numbers as ranges, e.g., 1-5,9 for all scans from 1 to 5 and 9. This reduces the file size.
       Many tools do not parse this USI format.""", false);
 
   public AdvancedLibraryBatchGenerationParameters() {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/batch/AdvancedLibraryBatchGenerationParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/batch/AdvancedLibraryBatchGenerationParameters.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2004-2024 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.io.spectraldbsubmit.batch;
+
+import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.BooleanParameter;
+
+public class AdvancedLibraryBatchGenerationParameters extends SimpleParameterSet {
+
+  public static BooleanParameter compactUSI = new BooleanParameter(
+      "Compact USI (limited compatibility)", """
+      Universal Spectrum Identifier allow traceability to the source scans in a format: mzspec:DATASET:DATAFILE:SCAN_NUMBER. \
+      The regular format allows for a single (optional) scan number. If this parameter is checked, \
+      one USI is generated per source file with scan numbers as ranges, e.g., 1-5,9 for all scans from \
+      1 to 5 and 9. This reduces the file size.
+      Many tools do not parse this USI format.""", false);
+
+  public AdvancedLibraryBatchGenerationParameters() {
+    super(compactUSI);
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/batch/LibraryBatchGenerationParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/batch/LibraryBatchGenerationParameters.java
@@ -40,6 +40,7 @@ package io.github.mzmine.modules.io.spectraldbsubmit.batch;
 import io.github.mzmine.modules.dataanalysis.spec_chimeric_precursor.HandleChimericMsMsParameters;
 import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.AdvancedParametersParameter;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
 import io.github.mzmine.parameters.parametertypes.IntensityNormalizerComboParameter;
 import io.github.mzmine.parameters.parametertypes.OptionalParameter;
@@ -89,9 +90,12 @@ public class LibraryBatchGenerationParameters extends SimpleParameterSet {
       "Quality parameters", "Quality parameters for MS/MS spectra to be exported to the library.",
       new LibraryExportQualityParameters());
 
+  public static final AdvancedParametersParameter<AdvancedLibraryBatchGenerationParameters> advanced = new AdvancedParametersParameter<>(
+      new AdvancedLibraryBatchGenerationParameters(), false);
+
   public LibraryBatchGenerationParameters() {
     super(flists, file, exportFormat, postMergingMsLevelFilter, metadata, normalizer,
-        mergeMzTolerance, handleChimerics, quality);
+        mergeMzTolerance, handleChimerics, quality, advanced);
   }
 
 

--- a/mzmine-community/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
@@ -118,6 +118,14 @@ public class ScanUtils {
   private static final Logger logger = Logger.getLogger(ScanUtils.class.getName());
 
   /**
+   * Erase file format
+   */
+  @Nullable
+  public static String eraseRawFileFormat(@Nullable String fileName) {
+    return fileName == null ? null : FileAndPathUtil.eraseFormat(fileName);
+  }
+
+  /**
    * Source file of scan is defined of other MassSpectra may be undefined and return null
    */
   @Nullable
@@ -234,7 +242,7 @@ public class ScanUtils {
       case SpectralLibraryEntry entry -> {
         final FloatArrayList list = entry.getOrElse(DBEntryField.COLLISION_ENERGY,
             FloatArrayList.of());
-        if(!list.isEmpty()) {
+        if (!list.isEmpty()) {
           yield list.getFirst();
         }
         yield null;
@@ -601,7 +609,7 @@ public class ScanUtils {
           }
 
           double slope = (rightNeighbourValue - leftNeighbourValue) / (rightNeighbourBinIndex
-              - leftNeighbourBinIndex);
+                                                                       - leftNeighbourBinIndex);
           binValues[binIndex] = leftNeighbourValue + slope * (binIndex - leftNeighbourBinIndex);
 
         }
@@ -2214,11 +2222,37 @@ public class ScanUtils {
 
   /**
    * Extracts all universal spectrum identifier USI from source scans. If spectrum is merged this
-   * will return multiple source USI otherwise just a Stream of one elemen.
+   * will return multiple source USI otherwise just a Stream of one element.
    */
   public static Stream<String> extractUSI(MassSpectrum spectrum, @Nullable String datasetID) {
     String baseUSI = "mzspec:" + (datasetID == null ? "DATASET_ID_PLACEHOLDER" : datasetID) + ":";
     return streamSourceScans(spectrum, Scan.class).map(scan -> scanToUSI(scan, baseUSI)).distinct();
+  }
+
+  /**
+   * Extracts all universal spectrum identifier USI from source scans. If spectrum is merged this
+   * will return multiple source USI otherwise just a Stream of one element.
+   * <p>
+   * This reduced USI ranges merge all USI from the same sample, so different scan numbers, into
+   * number ranges like mzspec:DATASET:SAMPLE:1-5,9 would point to all scans from 1 to 5 and 9.
+   * <p>
+   * Tool compatibility is limited but this greatly reduces the size and redundancy in USI
+   * representing scans from the same file
+   */
+  public static Stream<String> extractCompressedUSIRanges(MassSpectrum spectrum,
+      @Nullable String datasetID) {
+    Map<RawDataFile, List<Scan>> scansForFile = streamSourceScans(spectrum, Scan.class).collect(
+        Collectors.groupingBy(Scan::getDataFile));
+
+    return scansForFile.entrySet().stream().map((entry) -> {
+      var raw = entry.getKey();
+      var scans = entry.getValue();
+      // combine all scans of this sample into range strings
+      String scanNumberStr = extractIdStringForScansOfSingleFile(scans);
+
+      String fileName = requireNonNullElse(eraseRawFileFormat(raw.getFileName()), "");
+      return createUSI(datasetID, fileName, scanNumberStr);
+    });
   }
 
   /**
@@ -2237,10 +2271,28 @@ public class ScanUtils {
   @NotNull
   private static String __scanToUSI(MassSpectrum scan, String baseUSI) {
     String fileName = getSourceFile(scan);
-    fileName = fileName == null ? "" : FileAndPathUtil.eraseFormat(fileName);
     int scanNumber = extractScanNumber(scan);
     // map to USI
     return baseUSI + fileName + ":" + scanNumber;
+  }
+
+  /**
+   * Universal spectrum identifier
+   *
+   * @param datasetID  will use the provided dataset ID or "DATASET_ID_PLACEHOLDER" if null
+   * @param rawFile    used as is. Caller may wants to remove the format first
+   * @param scanNumber adds a scan number if not null otherwise this USI is raw data file level
+   */
+  public static String createUSI(@Nullable String datasetID, final @NotNull String rawFile,
+      final @Nullable String scanNumber) {
+    if (datasetID == null) {
+      datasetID = "DATASET_ID_PLACEHOLDER";
+    }
+    if (scanNumber == null) {
+      return "mzspec:%s:%s".formatted(datasetID, rawFile);
+    } else {
+      return "mzspec:%s:%s:%s".formatted(datasetID, rawFile, scanNumber);
+    }
   }
 
   public static <T extends MassSpectrum> Stream<T> streamSourceScans(final MassSpectrum scan,
@@ -2318,7 +2370,8 @@ public class ScanUtils {
 
   /**
    * @param allScans Scans of a single {@link RawDataFile}. May contain mobility scans or regular
-   *                 scans. To handle merged spectra, use {@link #extractScanIdString(Scan)}
+   *                 scans. To handle merged spectra, use
+   *                 {@link #extractScanIdString(Scan, boolean)}
    * @return Consecutive enumeration of scan numbers. for mobility scans: 6[7-14,16],7[8-18]. for
    * regular scans: 5-13,15.
    */


### PR DESCRIPTION
Especially when merging MSn data USI explodes. I propose compact USI format with scan number ranges like we already do for scan numbers (mgf compatible format)

### JSON format
"usi":["mzspec:DATASET_ID_PLACEHOLDER:20230404_pluskal_nih_01P_E7_id_positive:475-495"]

### mgf
USI=[mzspec:DATASET_ID_PLACEHOLDER:20230404_pluskal_nih_01P_E7_id_positive:339-350]
