### PR TITLE
Harmonize mgf export by using SpectralLibraryEntryFactory

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/PolarityType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/PolarityType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -78,8 +78,8 @@ public enum PolarityType {
     return UNKNOWN;
   }
 
-  public static PolarityType fromInt(int i) {
-    if (i == 0) {
+  public static PolarityType fromInt(@Nullable Integer i) {
+    if (i == null || i == 0) {
       return UNKNOWN;
     } else if (i < 0) {
       return NEGATIVE;
@@ -110,6 +110,13 @@ public enum PolarityType {
   @Override
   public String toString() {
     return asSingleChar();
+  }
+
+  /**
+   * @return true if positive or negative
+   */
+  public static boolean isDefined(@Nullable PolarityType polarity) {
+    return polarity != null && polarity.isDefined();
   }
 
   /**

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_gnps/GNPSUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_gnps/GNPSUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -31,6 +31,7 @@ import io.github.mzmine.modules.io.export_features_gnps.gc.GnpsGcSubmitParameter
 import io.github.mzmine.modules.io.export_features_gnps.masst.MasstDatabase;
 import io.github.mzmine.util.files.FileAndPathUtil;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntry;
+import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntryFactory;
 import io.github.mzmine.util.spectraldb.parser.MZmineJsonParser;
 import io.github.mzmine.util.web.RequestResponse;
 import jakarta.json.Json;
@@ -181,7 +182,7 @@ public class GNPSUtils {
         DataPoint[] spectrum = MZmineJsonParser.getDataPointsFromJsonArray(peaks);
         final double precursorMz = json.getJsonNumber("precursor_mz").doubleValue();
         final int charge = json.getJsonNumber("precursor_charge").intValue();
-        return SpectralLibraryEntry.create(null, precursorMz, charge, spectrum);
+        return SpectralLibraryEntryFactory.create(null, precursorMz, charge, spectrum);
       } else {
         // https://gnps.ucsd.edu/ProteoSAFe/SpectrumCommentServlet?SpectrumID=CCMSLIB00005463737
         // library ID
@@ -195,7 +196,7 @@ public class GNPSUtils {
           final JsonObject annotations = json.getJsonArray("annotations").getJsonObject(0);
           final double precursorMz = Double.parseDouble(
               annotations.getJsonString("Precursor_MZ").getString());
-          return SpectralLibraryEntry.create(null, precursorMz, spectrum);
+          return SpectralLibraryEntryFactory.create(null, precursorMz, spectrum);
         }
       }
     }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnMgfExportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnMgfExportTask.java
@@ -37,14 +37,11 @@
 package io.github.mzmine.modules.io.export_features_gnps.fbmn;
 
 import io.github.mzmine.datamodel.DataPoint;
-import io.github.mzmine.datamodel.MassList;
-import io.github.mzmine.datamodel.PolarityType;
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.main.MZmineCore;
-import io.github.mzmine.modules.dataprocessing.id_online_reactivity.OnlineReactionJsonWriter;
-import io.github.mzmine.modules.dataprocessing.id_online_reactivity.OnlineReactionMatch;
+import io.github.mzmine.modules.io.spectraldbsubmit.formats.MGFEntryGenerator;
 import io.github.mzmine.modules.tools.msmsspectramerge.MergedSpectrum;
 import io.github.mzmine.modules.tools.msmsspectramerge.MsMsSpectraMergeModule;
 import io.github.mzmine.modules.tools.msmsspectramerge.MsMsSpectraMergeParameters;
@@ -53,9 +50,10 @@ import io.github.mzmine.parameters.parametertypes.IntensityNormalizer;
 import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.taskcontrol.ProcessedItemsCounter;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import io.github.mzmine.util.FeatureUtils;
 import io.github.mzmine.util.files.FileAndPathUtil;
-import io.github.mzmine.util.spectraldb.entry.DBEntryField;
+import io.github.mzmine.util.scans.ScanUtils;
+import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntry;
+import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntryFactory;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
@@ -95,8 +93,8 @@ public class GnpsFbmnMgfExportTask extends AbstractTask implements ProcessedItem
   private final FeatureListRowsFilter filter;
   // track number of exported items
   private final AtomicInteger exportedRows = new AtomicInteger(0);
-  private final OnlineReactionJsonWriter reactionJsonWriter;
   private final IntensityNormalizer normalizer;
+  private final SpectralLibraryEntryFactory entryFactory;
   private int currentIndex = 0;
   // by robin
   private NumberFormat mzForm = MZmineCore.getConfiguration().getMZFormat();
@@ -120,7 +118,8 @@ public class GnpsFbmnMgfExportTask extends AbstractTask implements ProcessedItem
             .getEmbeddedParameters() : null;
     merger = MZmineCore.getModuleInstance(MsMsSpectraMergeModule.class);
 
-    reactionJsonWriter = new OnlineReactionJsonWriter(false);
+    entryFactory = new SpectralLibraryEntryFactory(true, true, true, false);
+    entryFactory.setAddOnlineReactivityFlags(true);
   }
 
   @Override
@@ -247,46 +246,6 @@ public class GnpsFbmnMgfExportTask extends AbstractTask implements ProcessedItem
         continue;
       }
 
-      MassList massList = msmsScan.getMassList();
-
-      if (massList == null) {
-        setErrorMessage("MS2 scan has no mass list. Run Mass detection on all scans");
-        setStatus(TaskStatus.ERROR);
-        throw new IllegalArgumentException(
-            "MS2 scan has no mass list. Run Mass detection on all scans");
-      }
-
-      String rowID = Integer.toString(row.getID());
-      final Float averageRT = row.getAverageRT();
-      double retTimeInSeconds = averageRT == null ? 0d : ((averageRT * 60 * 100.0) / 100.);
-
-      writer.append("BEGIN IONS").append(newLine);
-      writer.append("FEATURE_ID=").append(rowID).write(newLine);
-
-      final Double mz = row.getAverageMZ();
-      if (mz != null) {
-        writer.append("PEPMASS=").append(mzForm.format(mz)).write(newLine);
-      }
-
-      writer.append("SCANS=").append(rowID).write(newLine);
-      writer.append("RTINSECONDS=").append(rtsForm.format(retTimeInSeconds)).write(newLine);
-
-      // write reactions if available
-      List<OnlineReactionMatch> reactions = row.getOnlineReactionMatches();
-      String reactionJson = reactionJsonWriter.createReactivityString(row, reactions);
-      if (reactionJson != null) {
-        writer.append(DBEntryField.ONLINE_REACTIVITY.getMgfID()).append("=").append(reactionJson)
-            .write(newLine);
-      }
-
-      // TODO maybe skip writing if unknown
-      final int charge = FeatureUtils.extractBestAbsoluteChargeState(row, msmsScan).orElse(1);
-      final PolarityType pol = FeatureUtils.extractBestPolarity(row, msmsScan)
-          .orElse(PolarityType.POSITIVE);
-      writer.append("CHARGE=" + charge).append(pol.asSingleChar()).append(newLine);
-
-      writer.append("MSLEVEL=2").write(newLine);
-
       DataPoint[] dataPoints = null;
       // merge MS/MS spectra
       if (mergeMS2) {
@@ -304,19 +263,25 @@ public class GnpsFbmnMgfExportTask extends AbstractTask implements ProcessedItem
       }
       // nothing after merging or no merging active
       if (dataPoints == null) {
-        dataPoints = massList.getDataPoints();
+        dataPoints = ScanUtils.extractDataPoints(msmsScan, true);
       }
 
-      // normalize intensity
-      dataPoints = normalizer.normalize(dataPoints, true);
-
-      for (DataPoint feature : dataPoints) {
-        writer.append(mzForm.format(feature.getMZ())).append(" ")
-            .append(intensityForm.format(feature.getIntensity())).write(newLine);
+      if (dataPoints == null || dataPoints.length == 0) {
+        continue;
       }
-      //
-      writer.append("END IONS").append(newLine).write(newLine);
-      exportedRows.incrementAndGet();
+
+      SpectralLibraryEntry entry = entryFactory.createUnknown(null, row, msmsScan, dataPoints, null,
+          null);
+
+      // requires MS2? or can also be MSn?
+//      entry.putIfNotNull(DBEntryField.MS_LEVEL, 2);
+
+      final var mgfEntry = MGFEntryGenerator.createMGFEntry(entry, normalizer);
+      if (mgfEntry.numSignals() > 0) {
+        writer.write(mgfEntry.spectrum());
+        writer.newLine();
+        exportedRows.incrementAndGet();
+      }
     }
 
     if (exportedRows.get() == 0) {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnMgfExportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnMgfExportTask.java
@@ -279,9 +279,11 @@ public class GnpsFbmnMgfExportTask extends AbstractTask implements ProcessedItem
             .write(newLine);
       }
 
-      final int charge = FeatureUtils.extractBestAbsoluteChargeState(row, msmsScan);
-      final PolarityType pol = FeatureUtils.extractBestPolarity(row, msmsScan);
-      writer.write(STR."CHARGE=\{charge}\{pol.asSingleChar()}\{newLine}");
+      // TODO maybe skip writing if unknown
+      final int charge = FeatureUtils.extractBestAbsoluteChargeState(row, msmsScan).orElse(1);
+      final PolarityType pol = FeatureUtils.extractBestPolarity(row, msmsScan)
+          .orElse(PolarityType.POSITIVE);
+      writer.append("CHARGE=" + charge).append(pol.asSingleChar()).append(newLine);
 
       writer.append("MSLEVEL=2").write(newLine);
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnMgfExportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_gnps/fbmn/GnpsFbmnMgfExportTask.java
@@ -41,6 +41,7 @@ import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.io.export_features_sirius.SiriusExportTask;
 import io.github.mzmine.modules.io.spectraldbsubmit.formats.MGFEntryGenerator;
 import io.github.mzmine.modules.tools.msmsspectramerge.MergedSpectrum;
 import io.github.mzmine.modules.tools.msmsspectramerge.MsMsSpectraMergeModule;
@@ -253,9 +254,6 @@ public class GnpsFbmnMgfExportTask extends AbstractTask implements ProcessedItem
           MergedSpectrum spectrum = merger.getBestMergedSpectrum(mergeParameters, row);
           if (spectrum != null) {
             dataPoints = spectrum.data;
-            writer.write("MERGED_STATS=");
-            writer.write(spectrum.getMergeStatsDescription());
-            writer.write(newLine);
           }
         } catch (Exception ex) {
           logger.log(Level.WARNING, "Error during MS2 merge in mgf export: " + ex.getMessage(), ex);
@@ -273,6 +271,9 @@ public class GnpsFbmnMgfExportTask extends AbstractTask implements ProcessedItem
       SpectralLibraryEntry entry = entryFactory.createUnknown(null, row, msmsScan, dataPoints, null,
           null);
 
+      if (msmsScan instanceof MergedSpectrum spec) {
+        SiriusExportTask.putMergedSpectrumFieldsIntoEntry(spec, entry);
+      }
       // requires MS2? or can also be MSn?
 //      entry.putIfNotNull(DBEntryField.MS_LEVEL, 2);
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_sirius/SiriusExportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_sirius/SiriusExportTask.java
@@ -130,6 +130,7 @@ public class SiriusExportTask extends AbstractTask {
     totalRows = Arrays.stream(featureLists).mapToInt(FeatureList::getNumberOfRows).sum();
 
     entryFactory = new SpectralLibraryEntryFactory(true, true, true, false);
+    entryFactory.setAddOnlineReactivityFlags(true);
   }
 
   private static void putMergedSpectrumFieldsIntoEntry(MergedSpectrum spectrum,

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_sirius/SiriusExportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_sirius/SiriusExportTask.java
@@ -133,7 +133,7 @@ public class SiriusExportTask extends AbstractTask {
     entryFactory.setAddOnlineReactivityFlags(true);
   }
 
-  private static void putMergedSpectrumFieldsIntoEntry(MergedSpectrum spectrum,
+  public static void putMergedSpectrumFieldsIntoEntry(MergedSpectrum spectrum,
       SpectralLibraryEntry entry) {
     entry.putIfNotNull(DBEntryField.FILENAME,
         Arrays.stream(spectrum.origins).map(RawDataFile::getName).collect(Collectors.joining(";")));

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/batch/LibraryBatchGenerationTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/batch/LibraryBatchGenerationTask.java
@@ -169,7 +169,7 @@ public class LibraryBatchGenerationTask extends AbstractTask {
         IncludeInputSpectra.HIGHEST_TIC_PER_ENERGY, IntensityMergingType.MAXIMUM,
         postMergingMsLevelFilter);
 
-    entryFactory = new SpectralLibraryEntryFactory(compactUSI, true, true);
+    entryFactory = new SpectralLibraryEntryFactory(compactUSI, false, true, true);
     if (handleChimericsOption == ChimericMsOption.FLAG) {
       entryFactory.setFlagChimerics(true);
     }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/batch/LibraryBatchGenerationTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/batch/LibraryBatchGenerationTask.java
@@ -66,11 +66,11 @@ import io.github.mzmine.util.annotations.CompoundAnnotationUtils;
 import io.github.mzmine.util.files.FileAndPathUtil;
 import io.github.mzmine.util.scans.FragmentScanSelection;
 import io.github.mzmine.util.scans.FragmentScanSelection.IncludeInputSpectra;
-import io.github.mzmine.util.scans.ScanUtils;
 import io.github.mzmine.util.scans.SpectraMerging.IntensityMergingType;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibrary;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntry;
+import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntryFactory;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
@@ -80,11 +80,9 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.openscience.cdk.interfaces.IMolecularFormula;
 
@@ -108,7 +106,7 @@ public class LibraryBatchGenerationTask extends AbstractTask {
   private final boolean enableMsnMerge;
   private final MsLevelFilter postMergingMsLevelFilter;
   private final IntensityNormalizer normalizer;
-  private final boolean compactUSI;
+  private final SpectralLibraryEntryFactory entryFactory;
   public long totalRows = 0;
   public AtomicInteger finishedRows = new AtomicInteger(0);
   public AtomicInteger exported = new AtomicInteger(0);
@@ -157,6 +155,7 @@ public class LibraryBatchGenerationTask extends AbstractTask {
     }
 
     boolean isAdvanced = parameters.getValue(LibraryBatchGenerationParameters.advanced);
+    boolean compactUSI;
     if (isAdvanced) {
       var advanced = parameters.getParameter(LibraryBatchGenerationParameters.advanced)
           .getEmbeddedParameters();
@@ -169,6 +168,11 @@ public class LibraryBatchGenerationTask extends AbstractTask {
     selection = new FragmentScanSelection(mzTolMerging, true,
         IncludeInputSpectra.HIGHEST_TIC_PER_ENERGY, IntensityMergingType.MAXIMUM,
         postMergingMsLevelFilter);
+
+    entryFactory = new SpectralLibraryEntryFactory(compactUSI, true, true);
+    if (handleChimericsOption == ChimericMsOption.FLAG) {
+      entryFactory.setFlagChimerics(true);
+    }
   }
 
   @Override
@@ -234,6 +238,7 @@ public class LibraryBatchGenerationTask extends AbstractTask {
     // if multiple compounds match, they are sorted by score descending
     matches = CompoundAnnotationUtils.getBestMatchesPerCompoundName(matches);
 
+    // TODO this seems duplicated as there is already a stream filter with the same matchesName call?
     if (matches.stream().noneMatch(match -> msMsQualityChecker.matchesName(match, featureList))) {
       return;
     }
@@ -294,8 +299,10 @@ public class LibraryBatchGenerationTask extends AbstractTask {
         DataPoint[] dps = explainedSignalsOnly ? score.getAnnotatedDataPoints()
             : extractDataPoints(msmsScan, true);
 
-        SpectralLibraryEntry entry = createEntry(row, match, chimericMap, msmsScan, score, dps,
-            filteredMatches);
+        var chimeric = chimericMap.getOrDefault(msmsScan, ChimericPrecursorResults.PASSED);
+
+        SpectralLibraryEntry entry = entryFactory.createAnnotated(library.getStorage(), row,
+            msmsScan, match, dps, chimeric, score, filteredMatches, metadataMap);
         exportEntry(writer, entry);
         exported.incrementAndGet();
       }
@@ -304,77 +311,11 @@ public class LibraryBatchGenerationTask extends AbstractTask {
 
 
   /**
-   * @param row                 row that was matched
-   * @param match               the match to export
-   * @param chimericMap         mpas scans to their chimeric results. might be empty if scoring was
-   *                            off
-   * @param msmsScan            scan to export
-   * @param score               fragmentation pattern score
-   * @param dps                 data points
-   * @param allMatchedCompounds filtered list of all matched compounds (one adduct per compound
-   *                            name). also contains match which is currently exported.
-   * @return the new spectral library entry
-   */
-  @NotNull
-  private SpectralLibraryEntry createEntry(final FeatureListRow row, final FeatureAnnotation match,
-      final Map<Scan, ChimericPrecursorResults> chimericMap, final Scan msmsScan,
-      final MSMSScore score, final DataPoint[] dps,
-      final List<FeatureAnnotation> allMatchedCompounds) {
-    // add instrument type etc by parameter
-    SpectralLibraryEntry entry = SpectralLibraryEntry.create(row, library.getStorage(), msmsScan,
-        match, dps, metadataMap);
-
-    if (compactUSI) {
-      String dataset = entry.getOrElse(DBEntryField.DATASET_ID, null);
-      var compressedUSIs = ScanUtils.extractCompressedUSIRanges(msmsScan, dataset).toList();
-      entry.putIfNotNull(DBEntryField.USI, compressedUSIs);
-    }
-
-    // matched against mutiple compounds in the same sample?
-    // usually metadata is filtered so that raw data files only contain specific compounds without interference
-    if (allMatchedCompounds.size() > 1) {
-      // 1 would be the match itself
-      entry.putIfNotNull(DBEntryField.OTHER_MATCHED_COMPOUNDS_N, allMatchedCompounds.size() - 1);
-      entry.putIfNotNull(DBEntryField.OTHER_MATCHED_COMPOUNDS_NAMES, allMatchedCompounds.stream()
-          .filter(m -> !Objects.equals(match.getCompoundName(), m.getCompoundName()))
-          .map(FeatureAnnotation::toString).collect(Collectors.joining("; ")));
-    }
-    // score might be successful without having a formula - so check if we actually have scores
-    if (score.explainedSignals() > 0) {
-      entry.putIfNotNull(DBEntryField.QUALITY_EXPLAINED_INTENSITY, score.explainedIntensity());
-      entry.putIfNotNull(DBEntryField.QUALITY_EXPLAINED_SIGNALS, score.explainedSignals());
-    }
-    if (ChimericMsOption.FLAG.equals(handleChimericsOption)) {
-      // default is passed
-      ChimericPrecursorResults chimeric = chimericMap.getOrDefault(msmsScan,
-          ChimericPrecursorResults.PASSED);
-      entry.putIfNotNull(DBEntryField.QUALITY_PRECURSOR_PURITY, chimeric.purity());
-      entry.putIfNotNull(DBEntryField.QUALITY_CHIMERIC, chimeric.flag());
-      if (ChimericPrecursorFlag.CHIMERIC.equals(chimeric.flag())) {
-        entry.putIfNotNull(DBEntryField.NAME,
-            entry.getField(DBEntryField.NAME).orElse("") + " (Chimeric precursor selection)");
-      }
-    }
-
-    // add experimental data
-    if (entry.getField(DBEntryField.RT).isEmpty()) {
-      entry.putIfNotNull(DBEntryField.RT, row.getAverageRT());
-    }
-    if (entry.getField(DBEntryField.CCS).isEmpty()) {
-      entry.putIfNotNull(DBEntryField.CCS, row.getAverageCCS());
-    }
-    if (entry.getField(DBEntryField.FEATURE_MS1_HEIGHT).isEmpty()) {
-      entry.putIfNotNull(DBEntryField.FEATURE_MS1_HEIGHT, row.getMaxHeight());
-    }
-
-    return entry;
-  }
-
-  /**
    * @param scans might be filtered if the chimeric handling is set to SKIP
    * @return a map that flags spectra as chimeric or passed - or an empty map if handeChimerics is
    * off
    */
+  @NotNull
   private Map<Scan, ChimericPrecursorResults> handleChimericsAndFilterScansIfSelected(
       final FeatureListRow row, final List<Scan> scans) {
     if (handleChimerics) {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/batch/LibraryBatchGenerationTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/spectraldbsubmit/batch/LibraryBatchGenerationTask.java
@@ -238,11 +238,6 @@ public class LibraryBatchGenerationTask extends AbstractTask {
     // if multiple compounds match, they are sorted by score descending
     matches = CompoundAnnotationUtils.getBestMatchesPerCompoundName(matches);
 
-    // TODO this seems duplicated as there is already a stream filter with the same matchesName call?
-    if (matches.stream().noneMatch(match -> msMsQualityChecker.matchesName(match, featureList))) {
-      return;
-    }
-
     // handle chimerics
     final var chimericMap = handleChimericsAndFilterScansIfSelected(row, scans);
 

--- a/mzmine-community/src/main/java/io/github/mzmine/util/FeatureUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/FeatureUtils.java
@@ -617,8 +617,9 @@ public class FeatureUtils {
   }
 
   /**
-   * Get the absolute/unsigned charge of this row. Checks the row charge first, then the supplied
-   * scan and then the best feature then the annotation, which at times may be wrong charge.
+   * Get the absolute/unsigned charge of this row. Checks the row charge first, then the instrument
+   * detected charge in the most intense fragment scan and then the best feature then the
+   * annotation, which at times may be wrong charge.
    */
   @NotNull
   public static OptionalInt extractBestAbsoluteChargeState(@Nullable FeatureListRow row) {

--- a/mzmine-community/src/main/java/io/github/mzmine/util/FeatureUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/FeatureUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -24,6 +24,8 @@
  */
 
 package io.github.mzmine.util;
+
+import static io.github.mzmine.util.annotations.CompoundAnnotationUtils.getTypeValue;
 
 import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.DataPoint;
@@ -53,19 +55,23 @@ import io.github.mzmine.datamodel.features.types.ListWithSubsType;
 import io.github.mzmine.datamodel.features.types.annotations.CompoundDatabaseMatchesType;
 import io.github.mzmine.datamodel.features.types.annotations.SpectralLibraryMatchesType;
 import io.github.mzmine.datamodel.features.types.modifiers.AnnotationType;
+import io.github.mzmine.datamodel.features.types.numbers.ChargeType;
+import io.github.mzmine.datamodel.features.types.otherdectectors.PolarityTypeType;
 import io.github.mzmine.datamodel.identities.iontype.IonType;
 import io.github.mzmine.datamodel.impl.SimpleDataPoint;
 import io.github.mzmine.datamodel.msms.DDAMsMsInfo;
 import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.util.annotations.CompoundAnnotationUtils;
 import io.github.mzmine.util.scans.ScanUtils;
 import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import java.text.Format;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -510,7 +516,7 @@ public class FeatureUtils {
 
   public static boolean isImsFeature(Feature f) {
     return f.getRawDataFile() instanceof IMSRawDataFile
-        && f.getFeatureData() instanceof IonMobilogramTimeSeries;
+           && f.getFeatureData() instanceof IonMobilogramTimeSeries;
   }
 
   /**
@@ -607,62 +613,160 @@ public class FeatureUtils {
     return result;
   }
 
-  public static Integer extractBestAbsoluteChargeState(FeatureListRow row) {
-    return extractBestAbsoluteChargeState(row, row.getMostIntenseFragmentScan());
+  /**
+   * Get the absolute/unsigned charge of this row. Checks the row charge first, then the supplied
+   * scan and then the best feature then the annotation, which at times may be wrong charge.
+   */
+  @NotNull
+  public static OptionalInt extractBestAbsoluteChargeState(@Nullable FeatureListRow row) {
+    return extractBestAbsoluteChargeState(row,
+        row != null ? row.getMostIntenseFragmentScan() : null);
   }
 
   /**
-   * Get the absolute/unsigned polarity of this row. Checks the row charge first, then the supplied
-   * scan and then the best feature. If the charge is undetermined, the default of 1 is returned.
+   * Get the absolute/unsigned charge of this row. Checks the row charge first, then the supplied
+   * scan and then the best feature then the annotation, which at times may be wrong charge.
    */
-  public static int extractBestAbsoluteChargeState(FeatureListRow row, Scan scan) {
-    final Integer rowCharge = row.getRowCharge();
-    if (rowCharge != null && rowCharge != 0) {
-      return Math.abs(rowCharge);
-    }
-    if (scan.getMsMsInfo() instanceof DDAMsMsInfo dda) {
-      final Integer precursorCharge = dda.getPrecursorCharge();
-      if (precursorCharge != null && precursorCharge != 0) {
-        return Math.abs(precursorCharge);
-      }
-    }
-    final Integer featureCharge = row.getBestFeature().getCharge();
-    if (featureCharge != null && featureCharge != 0) {
-      return Math.abs(featureCharge);
-    }
-
-    return 1;
+  @NotNull
+  public static OptionalInt extractBestAbsoluteChargeState(@Nullable FeatureListRow row,
+      @Nullable Scan scan) {
+    var annotation = CompoundAnnotationUtils.getBestFeatureAnnotation(row).orElse(null);
+    return extractBestAbsoluteChargeState(row, scan, annotation);
   }
 
-  public static PolarityType extractBestPolarity(FeatureListRow row) {
+  /**
+   * Get the absolute/unsigned charge of this row. Checks the row charge first, then the supplied
+   * scan and then the best feature then the annotation, which at times may be wrong charge.
+   */
+  @NotNull
+  public static OptionalInt extractBestAbsoluteChargeState(@Nullable FeatureListRow row,
+      @Nullable Scan scan, @Nullable FeatureAnnotation annotation) {
+    return extractBestChargeState(row, scan, annotation).stream().map(Math::abs).findFirst();
+  }
+
+  /**
+   * Get the charge of this row. Checks the row charge first, then the supplied scan and then the
+   * best feature then the annotation, which at times may be wrong charge.
+   */
+  @NotNull
+  public static OptionalInt extractBestChargeState(@Nullable FeatureListRow row,
+      @Nullable Scan scan) {
+    var annotation = CompoundAnnotationUtils.getBestFeatureAnnotation(row).orElse(null);
+    return extractBestChargeState(row, scan, annotation);
+  }
+
+  /**
+   * Get the charge of this row. Checks the row charge first, then the supplied scan and then the
+   * best feature then the annotation, which at times may be wrong charge.
+   */
+  @NotNull
+  public static OptionalInt extractBestChargeState(@Nullable FeatureListRow row,
+      @Nullable Scan scan, @Nullable FeatureAnnotation annotation) {
+    final Integer rowCharge = row != null ? row.getRowCharge() : null;
+    if (rowCharge != null && rowCharge != 0) {
+      return OptionalInt.of(rowCharge);
+    }
+    if (scan != null && scan.getMsMsInfo() instanceof DDAMsMsInfo dda) {
+      final Integer precursorCharge = dda.getPrecursorCharge();
+      if (precursorCharge != null && precursorCharge != 0) {
+        return OptionalInt.of(precursorCharge);
+      }
+    }
+    final Integer featureCharge = row != null ? row.getBestFeature().getCharge() : null;
+    if (featureCharge != null && featureCharge != 0) {
+      return OptionalInt.of(featureCharge);
+    }
+    // via annotation
+    return CompoundAnnotationUtils.extractAbsCharge(annotation);
+  }
+
+  /**
+   * Extracts the best polarity from the row. Checks the supplied scan first, then the row fragment
+   * scan and then the best feature fragment scan, last checks the annotation (which may sometimes
+   * be wrong polarity, therefore last). Optional.empty if no polarity is found.
+   */
+  public static Optional<PolarityType> extractBestPolarity(@Nullable FeatureListRow row) {
     return extractBestPolarity(row, null);
   }
 
   /**
    * Extracts the best polarity from the row. Checks the supplied scan first, then the row fragment
-   * scan and then the best feature fragment scan. IF no polarity is found, positive
+   * scan and then the best feature fragment scan, last checks the annotation (which may sometimes
+   * be wrong polarity, therefore last). Optional.empty if no polarity is found.
    */
-  public static PolarityType extractBestPolarity(FeatureListRow row, Scan scan) {
-    if (scan != null && scan.getPolarity() != null) {
-      return scan.getPolarity();
-    }
-    if (row.getMostIntenseFragmentScan() != null) {
-      return row.getMostIntenseFragmentScan().getPolarity();
-    }
-    if (row.getBestFeature().getRepresentativeScan() != null) {
-      final PolarityType pol = row.getBestFeature().getRepresentativeScan().getPolarity();
-      if (pol != null) {
-        return pol;
-      }
-    }
-    return PolarityType.POSITIVE;
+  public static Optional<PolarityType> extractBestPolarity(@Nullable FeatureListRow row,
+      @Nullable Scan scan) {
+    var annotation = CompoundAnnotationUtils.getBestFeatureAnnotation(row).orElse(null);
+    return extractBestPolarity(row, scan, annotation);
   }
 
-  public static Integer extractBestSignedChargeState(FeatureListRow row, Scan scan) {
-    final int absCharge = extractBestAbsoluteChargeState(row, scan);
-    final PolarityType pol = extractBestPolarity(row, scan);
+  /**
+   * Extracts the best polarity from the row. Checks the supplied scan first, then the row fragment
+   * scan and then the best feature fragment scan, last checks the annotation (which may sometimes
+   * be wrong polarity, therefore last). Optional.empty if no polarity is found.
+   */
+  public static Optional<PolarityType> extractBestPolarity(@Nullable FeatureListRow row,
+      @Nullable Scan scan, @Nullable FeatureAnnotation annotation) {
+    PolarityType polarity = scan != null ? scan.getPolarity() : null;
+    if (PolarityType.isDefined(polarity)) {
+      return Optional.of(polarity);
+    }
+    if (row != null) {
+      polarity = ScanUtils.getPolarity(row.getMostIntenseFragmentScan());
+      if (PolarityType.isDefined(polarity)) {
+        return Optional.of(polarity);
+      }
 
-    return absCharge * pol.getSign();
+      polarity = ScanUtils.getPolarity(row.getBestFeature().getRepresentativeScan());
+      if (PolarityType.isDefined(polarity)) {
+        return Optional.of(polarity);
+      }
+    }
+
+    if (annotation != null) {
+      polarity = getTypeValue(annotation, PolarityTypeType.class);
+      if (PolarityType.isDefined(polarity)) {
+        return Optional.of(polarity);
+      }
+      Integer charge = getTypeValue(annotation, ChargeType.class);
+      if (charge != null && charge != 0) {
+        return Optional.of(PolarityType.fromInt(charge));
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  /**
+   * Takes into account the charge and polarity to provide charge state.
+   *
+   * @return signed int charge state
+   */
+  @NotNull
+  public static OptionalInt extractBestSignedChargeState(@Nullable FeatureListRow row,
+      @Nullable Scan scan) {
+    var annotation = CompoundAnnotationUtils.getBestFeatureAnnotation(row).orElse(null);
+    return extractBestSignedChargeState(row, scan, annotation);
+  }
+
+  /**
+   * Takes into account the charge and polarity to provide charge state.
+   *
+   * @return signed int charge state
+   */
+  @NotNull
+  public static OptionalInt extractBestSignedChargeState(@Nullable FeatureListRow row,
+      @Nullable Scan scan, @Nullable FeatureAnnotation annotation) {
+    // just use positive as default here
+    final Optional<PolarityType> pol = extractBestPolarity(row, scan, annotation);
+    return extractBestChargeState(row, scan, annotation).stream().map(charge -> {
+      // apply polarity to abs charge if present - otherwise take signed charge
+      if (pol.isPresent()) {
+        return Math.abs(charge) * pol.get().getSign();
+      } else {
+        return charge;
+      }
+    }).findFirst();
   }
 
   public static List<IonType> extractAllIonTypes(FeatureListRow row) {
@@ -683,5 +787,36 @@ public class FeatureUtils {
         }).toList();
 
     return allIonTypes;
+  }
+
+  /**
+   * Extracts precursor mz from match, row mz, or scan.getPrecursorMz depending which first is
+   * available
+   */
+  @NotNull
+  public static Optional<Double> getPrecursorMz(@Nullable final FeatureAnnotation match,
+      @Nullable final FeatureListRow row, @Nullable final Scan scan) {
+    if (match != null) {
+      Double mz = match.getPrecursorMZ();
+      if (mz != null) {
+        return Optional.of(mz);
+      }
+    }
+
+    if (row != null) {
+      Double mz = row.getAverageMZ();
+      if (mz != null) {
+        return Optional.of(mz);
+      }
+    }
+
+    if (scan != null) {
+      Double mz = scan.getPrecursorMz();
+      if (mz != null) {
+        return Optional.of(mz);
+      }
+    }
+
+    return Optional.empty();
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/util/FeatureUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/FeatureUtils.java
@@ -650,21 +650,14 @@ public class FeatureUtils {
 
   /**
    * Get the charge of this row. Checks the row charge first, then the supplied scan and then the
-   * best feature then the annotation, which at times may be wrong charge.
+   * best feature then the annotation, which at times may be wrong charge. This charge state may or
+   * may not be charged. Therefore, use
+   * {@link #extractBestAbsoluteChargeState(FeatureListRow, Scan, FeatureAnnotation)} for abs charge
+   * or {@link #extractBestSignedChargeState(FeatureListRow, MassSpectrum, FeatureAnnotation)} for a
+   * charge that also uses the polarity to determine sign
    */
   @NotNull
-  public static OptionalInt extractBestChargeState(@Nullable FeatureListRow row,
-      @Nullable Scan scan) {
-    var annotation = CompoundAnnotationUtils.getBestFeatureAnnotation(row).orElse(null);
-    return extractBestChargeState(row, scan, annotation);
-  }
-
-  /**
-   * Get the charge of this row. Checks the row charge first, then the supplied scan and then the
-   * best feature then the annotation, which at times may be wrong charge.
-   */
-  @NotNull
-  public static OptionalInt extractBestChargeState(@Nullable FeatureListRow row,
+  private static OptionalInt extractBestChargeState(@Nullable FeatureListRow row,
       @Nullable MassSpectrum spec, @Nullable FeatureAnnotation annotation) {
     final Integer rowCharge = row != null ? row.getRowCharge() : null;
     if (rowCharge != null && rowCharge != 0) {

--- a/mzmine-community/src/main/java/io/github/mzmine/util/annotations/CompoundAnnotationUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/annotations/CompoundAnnotationUtils.java
@@ -42,6 +42,7 @@ import io.github.mzmine.datamodel.features.types.annotations.compounddb.Database
 import io.github.mzmine.datamodel.features.types.annotations.formula.FormulaType;
 import io.github.mzmine.datamodel.features.types.annotations.iin.IonTypeType;
 import io.github.mzmine.datamodel.features.types.numbers.CCSType;
+import io.github.mzmine.datamodel.features.types.numbers.ChargeType;
 import io.github.mzmine.datamodel.features.types.numbers.MZType;
 import io.github.mzmine.datamodel.features.types.numbers.MobilityType;
 import io.github.mzmine.datamodel.features.types.numbers.PrecursorMZType;
@@ -63,6 +64,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -211,6 +214,13 @@ public class CompoundAnnotationUtils {
         .map(FeatureAnnotation.class::cast);
   }
 
+  /**
+   * First FeatureAnnotation in {@link #streamFeatureAnnotations(FeatureListRow)}
+   */
+  public static Optional<FeatureAnnotation> getBestFeatureAnnotation(final FeatureListRow row) {
+    return CompoundAnnotationUtils.streamFeatureAnnotations(row).findFirst();
+  }
+
   public static void calculateBoundTypes(CompoundDBAnnotation annotation, FeatureListRow row) {
     ConnectedTypeCalculation.LIST.forEach(calc -> calc.calculateIfAbsent(row, annotation));
   }
@@ -253,6 +263,30 @@ public class CompoundAnnotationUtils {
         };
       }
     };
+  }
+
+  /**
+   * @return usually the signed charge if present. Either from adduct or from charge type
+   */
+  public static OptionalInt extractCharge(@Nullable final FeatureAnnotation annotation) {
+    IonType adduct = annotation.getAdductType();
+    if (adduct != null) {
+      return OptionalInt.of(adduct.getCharge());
+    }
+
+    Integer annCharge = getTypeValue(annotation, ChargeType.class);
+    if (annCharge != null) {
+      return OptionalInt.of(annCharge);
+    }
+
+    return OptionalInt.empty();
+  }
+
+  /**
+   * @return absolute charge if present
+   */
+  public static OptionalInt extractAbsCharge(@Nullable final FeatureAnnotation annotation) {
+    return extractCharge(annotation).stream().map(Math::abs).findFirst();
   }
 
   /**

--- a/mzmine-community/src/main/java/io/github/mzmine/util/annotations/CompoundAnnotationUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/annotations/CompoundAnnotationUtils.java
@@ -269,6 +269,10 @@ public class CompoundAnnotationUtils {
    * @return usually the signed charge if present. Either from adduct or from charge type
    */
   public static OptionalInt extractCharge(@Nullable final FeatureAnnotation annotation) {
+    if (annotation == null) {
+      return OptionalInt.empty();
+    }
+
     IonType adduct = annotation.getAdductType();
     if (adduct != null) {
       return OptionalInt.of(adduct.getCharge());

--- a/mzmine-community/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
@@ -290,6 +290,7 @@ public class ScanUtils {
    * @return array of data points
    */
   @Deprecated
+  @NotNull
   public static DataPoint[] extractDataPoints(MassSpectrum spectrum) {
     int size = spectrum.getNumberOfDataPoints();
     DataPoint[] result = new DataPoint[size];
@@ -2077,7 +2078,7 @@ public class ScanUtils {
   /**
    * Only use the array when needed. Best way to iterate scan data in a single thread is
    * {@link ScanDataAccess} by {@link EfficientDataAccess}. When sorting of data is needed use
-   * {@link #extractDataPoints(Scan, boolean)} but discouraged for data storage in memory.
+   * {@link #extractDataPoints(MassSpectrum, boolean)} but discouraged for data storage in memory.
    *
    * @param scan        target scan
    * @param useMassList either use mass list or return the input scan
@@ -2093,7 +2094,7 @@ public class ScanUtils {
   /**
    * Only use the array when needed. Best way to iterate scan data in a single thread is
    * {@link ScanDataAccess} by {@link EfficientDataAccess}. When sorting of data is needed use
-   * {@link #extractDataPoints(Scan, boolean)} but discouraged for data storage in memory.
+   * {@link #extractDataPoints(MassSpectrum, boolean)} but discouraged for data storage in memory.
    *
    * @param scan        target scan
    * @param useMassList either use mass list or return the input scan
@@ -2117,7 +2118,8 @@ public class ScanUtils {
    * @throws MissingMassListException users need to run mass detection before on this scan
    */
   @Deprecated
-  public static DataPoint[] extractDataPoints(final Scan scan, final boolean useMassList)
+  @NotNull
+  public static DataPoint[] extractDataPoints(final MassSpectrum scan, final boolean useMassList)
       throws MissingMassListException {
     return extractDataPoints(getMassSpectrum(scan, useMassList));
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/DBEntryField.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/DBEntryField.java
@@ -91,8 +91,15 @@ public enum DBEntryField {
   // identifier
   CAS, PUBMED, PUBCHEM, GNPS_ID, MONA_ID, CHEMSPIDER,
 
-  // sometimes just ID sometimes feature list name:id
+  /**
+   * row ID, used by GNPS, SIRIUS and other tools to connect results
+   */
   FEATURE_ID,
+
+  /**
+   * feature list name:row ID
+   */
+  FEATURELIST_NAME_FEATURE_ID,
 
   // spectrum specific
   MS_LEVEL, RT(Float.class), CCS(Float.class), ION_TYPE, PRECURSOR_MZ(Double.class), CHARGE(
@@ -292,7 +299,7 @@ public enum DBEntryField {
            SIRIUS_MERGED_SCANS, SIRIUS_MERGED_STATS, OTHER_MATCHED_COMPOUNDS_N,
            OTHER_MATCHED_COMPOUNDS_NAMES, //
            MERGED_SPEC_TYPE, MSN_COLLISION_ENERGIES, MSN_PRECURSOR_MZS, MSN_FRAGMENTATION_METHODS,
-           MSN_ISOLATION_WINDOWS, IMS_TYPE -> StringType.class;
+           MSN_ISOLATION_WINDOWS, IMS_TYPE, FEATURELIST_NAME_FEATURE_ID -> StringType.class;
       case CLASSYFIRE_SUPERCLASS -> ClassyFireSuperclassType.class;
       case CLASSYFIRE_CLASS -> ClassyFireClassType.class;
       case CLASSYFIRE_SUBCLASS -> ClassyFireSubclassType.class;
@@ -393,6 +400,7 @@ public enum DBEntryField {
       case OTHER_MATCHED_COMPOUNDS_N -> "other_matched_compounds";
       case OTHER_MATCHED_COMPOUNDS_NAMES -> "other_matched_compounds_names";
       case FEATURE_ID -> "feature_id";
+      case FEATURELIST_NAME_FEATURE_ID -> "featurelist_feature_id";
       case FILENAME -> "raw_file_name";
       case SIRIUS_MERGED_SCANS -> "merged_scans";
       case SIRIUS_MERGED_STATS -> "merged_statistics";
@@ -452,6 +460,7 @@ public enum DBEntryField {
       case OTHER_MATCHED_COMPOUNDS_N -> "other_matched_compounds";
       case OTHER_MATCHED_COMPOUNDS_NAMES -> "other_matched_compounds_names";
       case FEATURE_ID -> "feature_id";
+      case FEATURELIST_NAME_FEATURE_ID -> "featurelist_feature_id";
       case FILENAME -> "file_name";
       case ONLINE_REACTIVITY -> "online_reactivity";
       case FEATURE_MS1_HEIGHT -> "feature_ms1_height";
@@ -515,6 +524,7 @@ public enum DBEntryField {
       case OTHER_MATCHED_COMPOUNDS_N -> "OTHER_MATCHED_COMPOUNDS";
       case OTHER_MATCHED_COMPOUNDS_NAMES -> "OTHER_MATCHED_COMPOUNDS_NAMES";
       case FEATURE_ID -> "FEATURE_ID";
+      case FEATURELIST_NAME_FEATURE_ID -> "FEATURELIST_FEATURE_ID";
       case FILENAME -> "FILENAME";
       case SIRIUS_MERGED_SCANS -> "MERGED_SCANS";
       case SIRIUS_MERGED_STATS -> "MERGED_STATS";
@@ -580,6 +590,7 @@ public enum DBEntryField {
       case OTHER_MATCHED_COMPOUNDS_N -> "OTHER_MATCHED_COMPOUNDS";
       case OTHER_MATCHED_COMPOUNDS_NAMES -> "OTHER_MATCHED_COMPOUNDS_NAMES";
       case FEATURE_ID -> "FEATURE_ID";
+      case FEATURELIST_NAME_FEATURE_ID -> "FEATURELIST_FEATURE_ID";
       case SIRIUS_MERGED_SCANS -> "MERGED_SCANS";
       case SIRIUS_MERGED_STATS -> "MERGED_STATS";
       case ONLINE_REACTIVITY -> "ONLINE_REACTIVITY";
@@ -646,7 +657,7 @@ public enum DBEntryField {
       case QUALITY_CHIMERIC -> "";
       case QUALITY_EXPLAINED_INTENSITY -> "";
       case QUALITY_EXPLAINED_SIGNALS -> "";
-      case FEATURE_ID -> "";
+      case FEATURE_ID, FEATURELIST_NAME_FEATURE_ID -> "";
       case SIRIUS_MERGED_SCANS -> "";
       case UNSPECIFIED -> "";
     };
@@ -715,7 +726,7 @@ public enum DBEntryField {
            PEPTIDE_SEQ, //
            IMS_TYPE, ONLINE_REACTIVITY, CLASSYFIRE_SUPERCLASS, CLASSYFIRE_CLASS,
            CLASSYFIRE_SUBCLASS, CLASSYFIRE_PARENT, NPCLASSIFIER_SUPERCLASS, NPCLASSIFIER_CLASS,
-           NPCLASSIFIER_PATHWAY -> value.toString();
+           NPCLASSIFIER_PATHWAY, FEATURELIST_NAME_FEATURE_ID -> value.toString();
       case SCAN_NUMBER -> switch (value) {
         // multiple scans can be written as 1,4,6-9
         case List<?> list -> {

--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/DBEntryField.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/DBEntryField.java
@@ -755,7 +755,9 @@ public enum DBEntryField {
         case Number d -> MZmineCore.getConfiguration().getExportFormats().percent(d);
         default -> throw new IllegalArgumentException("Relative height has to be a number");
       };
-      case POLARITY -> PolarityType.NEGATIVE.equals(value) ? "Negative" : "Positive";
+      // SIRIUS 6.0.7 had issues with Polarity and would parse the spectrum without extended metadata like the adduct
+      // Therefore it was changed from Positive to POSITIVE
+      case POLARITY -> PolarityType.NEGATIVE.equals(value) ? "NEGATIVE" : "POSITIVE";
     };
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralLibraryEntry.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralLibraryEntry.java
@@ -25,35 +25,12 @@
 
 package io.github.mzmine.util.spectraldb.entry;
 
-import com.google.common.collect.Range;
-import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.datamodel.MassList;
-import io.github.mzmine.datamodel.MergedMassSpectrum;
-import io.github.mzmine.datamodel.MergedMassSpectrum.MergingType;
 import io.github.mzmine.datamodel.PolarityType;
-import io.github.mzmine.datamodel.Scan;
-import io.github.mzmine.datamodel.features.FeatureListRow;
-import io.github.mzmine.datamodel.features.compoundannotations.CompoundDBAnnotation;
-import io.github.mzmine.datamodel.features.compoundannotations.FeatureAnnotation;
-import io.github.mzmine.datamodel.identities.iontype.IonType;
-import io.github.mzmine.datamodel.impl.MSnInfoImpl;
-import io.github.mzmine.datamodel.msms.DDAMsMsInfo;
-import io.github.mzmine.datamodel.msms.MsMsInfo;
 import io.github.mzmine.datamodel.structures.MolecularStructure;
-import io.github.mzmine.util.DataPointUtils;
-import io.github.mzmine.util.FeatureUtils;
-import io.github.mzmine.util.MemoryMapStorage;
-import io.github.mzmine.util.RangeUtils;
-import io.github.mzmine.util.scans.ScanUtils;
-import it.unimi.dsi.fastutil.floats.FloatArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
@@ -71,173 +48,6 @@ public interface SpectralLibraryEntry extends MassList {
 
   Logger logger = Logger.getLogger(SpectralLibraryEntry.class.getName());
   String XML_ELEMENT_ENTRY = "spectraldatabaseentry";
-
-  static SpectralLibraryEntry create(@Nullable MemoryMapStorage storage, double precursorMZ,
-      DataPoint[] dps) {
-    double[][] data = DataPointUtils.getDataPointsAsDoubleArray(dps);
-    Map<DBEntryField, Object> fields = new HashMap<>();
-    fields.put(DBEntryField.PRECURSOR_MZ, precursorMZ);
-    fields.put(DBEntryField.NUM_PEAKS, dps.length);
-    return new SpectralDBEntry(storage, data[0], data[1], fields);
-  }
-
-  static SpectralLibraryEntry create(@Nullable MemoryMapStorage storage, double precursorMZ,
-      int charge, DataPoint[] dps) {
-    SpectralLibraryEntry entry = create(storage, precursorMZ, dps);
-    entry.putIfNotNull(DBEntryField.CHARGE, charge);
-    return entry;
-  }
-
-  static SpectralLibraryEntry create(@Nullable MemoryMapStorage storage,
-      Map<DBEntryField, Object> fields, DataPoint[] dps) {
-    double[][] data = DataPointUtils.getDataPointsAsDoubleArray(dps);
-    return new SpectralDBEntry(storage, data[0], data[1], fields);
-  }
-
-  /**
-   * Create a new spectral library entry from any {@link FeatureAnnotation} but new spectral data
-   *
-   * @param scan        only used for scan metadata - data is provided through dataPoints
-   * @param match       the annotation for additional metadata
-   * @param dataPoints  the actual data
-   * @param metadataMap add additional fields to the spectral library entry
-   * @return spectral library entry
-   */
-  static SpectralLibraryEntry create(final FeatureListRow row, @Nullable MemoryMapStorage storage,
-      final Scan scan, final FeatureAnnotation match, final DataPoint[] dataPoints,
-      final @Nullable Map<DBEntryField, Object> metadataMap) {
-
-    Double precursorMZ = Objects.requireNonNullElse(match.getPrecursorMZ(), scan.getPrecursorMz());
-    SpectralLibraryEntry entry = create(storage, precursorMZ, dataPoints);
-
-    // add additional fields early
-    if (metadataMap != null) {
-      entry.putAll(metadataMap);
-    }
-
-    // write feature ID as feature list and row ID to identify MSn trees or MS2 spectra of the same row
-    var flist = row.getFeatureList();
-    if (flist != null) {
-      entry.putIfNotNull(DBEntryField.FEATURE_ID, flist.getName() + ":" + row.getID());
-    }
-
-    // transfer match to fields
-    entry.addFeatureAnnotationFields(match);
-
-    // scan details
-    Integer charge = getCharge(match, row, scan);
-    if (charge != null) {
-      entry.putIfNotNull(DBEntryField.CHARGE, charge);
-    }
-    entry.putIfNotNull(DBEntryField.POLARITY, scan.getPolarity());
-
-    MsMsInfo msMsInfo = scan.getMsMsInfo();
-    if (msMsInfo instanceof MSnInfoImpl msnInfo) {
-      // energies are quite complex
-      // [MS2, MS3, MS4] and multiple energies in last level due to merging
-      var msnEnergies = ScanUtils.extractMSnCollisionEnergies(scan);
-      if (!msnEnergies.isEmpty()) {
-        entry.putIfNotNull(DBEntryField.MSN_COLLISION_ENERGIES, msnEnergies);
-      }
-      //
-      List<DDAMsMsInfo> precursors = msnInfo.getPrecursors();
-      entry.putIfNotNull(DBEntryField.MSN_PRECURSOR_MZS,
-          extractJsonList(precursors, DDAMsMsInfo::getIsolationMz));
-      entry.putIfNotNull(DBEntryField.MSN_FRAGMENTATION_METHODS,
-          extractJsonList(precursors, DDAMsMsInfo::getActivationMethod));
-      entry.putIfNotNull(DBEntryField.MSN_ISOLATION_WINDOWS, extractJsonList(precursors, info -> {
-        Range<Double> window = info.getIsolationWindow();
-        return window == null ? null : RangeUtils.rangeLength(window);
-      }));
-      entry.putIfNotNull(DBEntryField.MS_LEVEL, msnInfo.getMsLevel());
-    } else if (msMsInfo != null) {
-      entry.putIfNotNull(DBEntryField.FRAGMENTATION_METHOD, msMsInfo.getActivationMethod());
-      Range<Double> window = msMsInfo.getIsolationWindow();
-      if (window != null) {
-        entry.putIfNotNull(DBEntryField.ISOLATION_WINDOW, RangeUtils.rangeLength(window));
-      }
-      entry.putIfNotNull(DBEntryField.MS_LEVEL, msMsInfo.getMsLevel());
-    }
-    List<Float> energies = ScanUtils.extractCollisionEnergies(scan);
-    if (!energies.isEmpty()) {
-      FloatArrayList list = new FloatArrayList(energies);
-      entry.putIfNotNull(DBEntryField.COLLISION_ENERGY, list);
-    }
-
-    // merged scans are derived from multiple source scans - add all information here and overwrite
-    String datasetID = entry.getOrElse(DBEntryField.DATASET_ID, null);
-    entry.putIfNotNull(DBEntryField.USI, ScanUtils.extractUSI(scan, datasetID).toList());
-
-    if (scan instanceof MergedMassSpectrum merged) {
-      entry.putIfNotNull(DBEntryField.MS_LEVEL, merged.getMSLevel());
-      entry.putIfNotNull(DBEntryField.SCAN_NUMBER,
-          ScanUtils.extractScanNumbers(merged).boxed().toList());
-      entry.putIfNotNull(DBEntryField.MERGED_SPEC_TYPE, merged.getMergingType());
-    } else {
-      entry.putIfNotNull(DBEntryField.MERGED_SPEC_TYPE, MergingType.SINGLE_BEST_SCAN);
-      entry.putIfNotNull(DBEntryField.SCAN_NUMBER, scan.getScanNumber());
-    }
-
-    return entry;
-  }
-
-  /**
-   * Add metadata to spectral library entry from feature annotation.
-   *
-   * @param match
-   */
-  default void addFeatureAnnotationFields(FeatureAnnotation match) {
-    switch (match) {
-      case CompoundDBAnnotation dbmatch -> addAnnotationFields(dbmatch);
-      case SpectralLibraryEntry dbmatch -> addAnnotationFields(dbmatch);
-      case FeatureAnnotation _ -> {
-        putIfNotNull(DBEntryField.ION_TYPE, match.getAdductType());
-        putIfNotNull(DBEntryField.CCS, match.getCCS());
-        putIfNotNull(DBEntryField.NAME, match.getCompoundName());
-        putIfNotNull(DBEntryField.FORMULA, match.getFormula());
-        putIfNotNull(DBEntryField.INCHI, match.getInChI());
-        putIfNotNull(DBEntryField.INCHIKEY, match.getInChIKey());
-        putIfNotNull(DBEntryField.SMILES, match.getSmiles());
-      }
-    }
-  }
-
-  default void addAnnotationFields(CompoundDBAnnotation match) {
-    for (var dbentry : match.getReadOnlyMap().entrySet()) {
-      DBEntryField field = DBEntryField.fromDataType(dbentry.getKey());
-      if (field == DBEntryField.UNSPECIFIED) {
-        continue;
-      }
-      try {
-        putIfNotNull(field, dbentry.getValue());
-      } catch (Exception ex) {
-        logger.log(Level.WARNING,
-            "Types were not converted from DB match to DB entry " + ex.getMessage(), ex);
-      }
-    }
-  }
-
-  default void addAnnotationFields(SpectralLibraryEntry match) {
-    for (var dbentry : match.getFields().entrySet()) {
-      switch (dbentry.getKey()) {
-        case RT, NAME, FORMULA, SMILES, INCHI, INCHIKEY, EXACT_MASS, ION_TYPE, SYNONYMS, CAS,
-             PUBCHEM, PUBMED, MOLWEIGHT -> putIfNotNull(dbentry.getKey(), dbentry.getValue());
-      }
-    }
-  }
-
-  static Integer getCharge(FeatureAnnotation match, FeatureListRow row, Scan scan) {
-    IonType adduct = match.getAdductType();
-    if (adduct != null) {
-      return adduct.getCharge();
-    }
-    return FeatureUtils.extractBestSignedChargeState(row, scan);
-  }
-
-  private static List<?> extractJsonList(final List<DDAMsMsInfo> precursors,
-      Function<DDAMsMsInfo, Object> extractor) {
-    return precursors.stream().map(extractor).filter(Objects::nonNull).toList();
-  }
 
   static SpectralLibraryEntry loadFromXML(XMLStreamReader reader, MZmineProject project)
       throws XMLStreamException {
@@ -267,7 +77,7 @@ public interface SpectralLibraryEntry extends MassList {
 
   /**
    * Sets the charge and the polarity of this entry. The polarity overrides any +/- in the charge
-   * integer.
+   * integer. Sets an integer charge
    *
    * @return {@link #putIfNotNull(DBEntryField, Object)}
    */
@@ -275,9 +85,12 @@ public interface SpectralLibraryEntry extends MassList {
     if (charge == null) {
       return false;
     }
-    return putIfNotNull(DBEntryField.CHARGE,
-        Math.abs(charge) + Objects.requireNonNullElse(polarity, PolarityType.POSITIVE)
-            .asSingleChar());
+    if (PolarityType.isDefined(polarity)) {
+      return putIfNotNull(DBEntryField.CHARGE, Math.abs(charge) * polarity.getSign());
+    } else {
+      // previously this would set charge as 1- but we actually expect charge to be integer
+      return putIfNotNull(DBEntryField.CHARGE, charge);
+    }
   }
 
   /**

--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralLibraryEntryFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralLibraryEntryFactory.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright (c) 2004-2024 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.util.spectraldb.entry;
+
+import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.MergedMassSpectrum;
+import io.github.mzmine.datamodel.MergedMassSpectrum.MergingType;
+import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.features.FeatureListRow;
+import io.github.mzmine.datamodel.features.compoundannotations.CompoundDBAnnotation;
+import io.github.mzmine.datamodel.features.compoundannotations.FeatureAnnotation;
+import io.github.mzmine.datamodel.impl.MSnInfoImpl;
+import io.github.mzmine.datamodel.msms.DDAMsMsInfo;
+import io.github.mzmine.datamodel.msms.MsMsInfo;
+import io.github.mzmine.modules.dataanalysis.spec_chimeric_precursor.ChimericPrecursorFlag;
+import io.github.mzmine.modules.dataanalysis.spec_chimeric_precursor.ChimericPrecursorResults;
+import io.github.mzmine.modules.tools.msmsscore.MSMSScore;
+import io.github.mzmine.util.DataPointUtils;
+import io.github.mzmine.util.FeatureUtils;
+import io.github.mzmine.util.MemoryMapStorage;
+import io.github.mzmine.util.RangeUtils;
+import io.github.mzmine.util.scans.ScanUtils;
+import it.unimi.dsi.fastutil.floats.FloatArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.OptionalInt;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Control generation of library entries from matches, scans, rows
+ */
+public class SpectralLibraryEntryFactory {
+
+  private static final Logger logger = Logger.getLogger(
+      SpectralLibraryEntryFactory.class.getName());
+  private final boolean compactUSI;
+  private final boolean addExperimentalResults;
+  private final boolean addAnnotation;
+  private boolean flagChimerics;
+
+  /**
+   * Experimental results and annotation added
+   *
+   * @param compactUSI may reduce compatibility if true but compacting scan numbers of the same file
+   *                   into a list of ranges
+   */
+  public SpectralLibraryEntryFactory(final boolean compactUSI) {
+    this(compactUSI, true, true);
+  }
+
+  /**
+   * @param compactUSI             may reduce compatibility if true but compacting scan numbers of
+   *                               the same file into a list of ranges
+   * @param addExperimentalResults add experimental results like retention time, CCS, feature
+   *                               Height
+   * @param addAnnotation          add annotation fields if available
+   */
+  public SpectralLibraryEntryFactory(final boolean compactUSI, final boolean addExperimentalResults,
+      final boolean addAnnotation) {
+    this.compactUSI = compactUSI;
+    this.addExperimentalResults = addExperimentalResults;
+    this.addAnnotation = addAnnotation;
+  }
+
+  static List<?> extractJsonList(final List<DDAMsMsInfo> precursors,
+      Function<DDAMsMsInfo, Object> extractor) {
+    return precursors.stream().map(extractor).filter(Objects::nonNull).toList();
+  }
+
+  /**
+   * General spectral library creation independent of this factories internal state
+   */
+  public static SpectralLibraryEntry create(@Nullable MemoryMapStorage storage,
+      @Nullable Double precursorMZ, DataPoint[] dps) {
+    double[][] data = DataPointUtils.getDataPointsAsDoubleArray(dps);
+    Map<DBEntryField, Object> fields = new HashMap<>();
+    if (precursorMZ != null) {
+      fields.put(DBEntryField.PRECURSOR_MZ, precursorMZ);
+    }
+    fields.put(DBEntryField.NUM_PEAKS, dps.length);
+    return new SpectralDBEntry(storage, data[0], data[1], fields);
+  }
+
+  /**
+   * General spectral library creation independent of this factories internal state
+   */
+  public static SpectralLibraryEntry create(@Nullable MemoryMapStorage storage,
+      @Nullable Double precursorMZ, int charge, DataPoint[] dps) {
+    SpectralLibraryEntry entry = create(storage, precursorMZ, dps);
+    entry.putIfNotNull(DBEntryField.CHARGE, charge);
+    return entry;
+  }
+
+  /**
+   * General spectral library creation independent of this factories internal state
+   */
+  public static SpectralLibraryEntry create(@Nullable MemoryMapStorage storage,
+      Map<DBEntryField, Object> fields, DataPoint[] dps) {
+    double[][] data = DataPointUtils.getDataPointsAsDoubleArray(dps);
+    return new SpectralDBEntry(storage, data[0], data[1], fields);
+  }
+
+  /**
+   * Create a new spectral library entry from any row, scan, and {@link FeatureAnnotation} - all
+   * three optional. Already processed data can be provided as DataPoint[].
+   *
+   * @param scan        only used for scan metadata - data is provided through dataPoints
+   * @param match       the annotation for additional metadata
+   * @param dataPoints  the actual data
+   * @param metadataMap add additional fields to the spectral library entry
+   * @return spectral library entry
+   */
+  public SpectralLibraryEntry create(final @Nullable FeatureListRow row,
+      @Nullable MemoryMapStorage storage, final @Nullable Scan scan,
+      @Nullable final FeatureAnnotation match, final @NotNull DataPoint[] dataPoints,
+      final @Nullable Map<DBEntryField, Object> metadataMap) {
+
+    var precursorMZ = FeatureUtils.getPrecursorMz(match, row, scan);
+    SpectralLibraryEntry entry = SpectralLibraryEntryFactory.create(storage,
+        precursorMZ.orElse(null), dataPoints);
+
+    // add additional fields early
+    if (metadataMap != null) {
+      entry.putAll(metadataMap);
+    }
+
+    if (row != null) {
+      // write feature ID as feature list and row ID to identify MSn trees or MS2 spectra of the same row
+      var flist = row.getFeatureList();
+      if (flist != null) {
+        entry.putIfNotNull(DBEntryField.FEATURE_ID, flist.getName() + ":" + row.getID());
+      }
+      // add experimental data
+      if (addExperimentalResults) {
+        addExperimentalFeatureResults(entry, row);
+      }
+    }
+
+    // transfer match to fields
+    if (addAnnotation && match != null) {
+      addFeatureAnnotationFields(entry, match);
+    }
+
+    // scan details
+    if (scan != null) {
+      addScanSpecificFields(entry, scan);
+    }
+
+    // combined fields extracted from multiple
+    OptionalInt charge = FeatureUtils.extractBestSignedChargeState(row, scan, match);
+    charge.ifPresent(c -> entry.putIfNotNull(DBEntryField.CHARGE, c));
+    var polarity = FeatureUtils.extractBestPolarity(row, scan, match);
+    polarity.ifPresent(pol -> entry.putIfNotNull(DBEntryField.POLARITY, pol));
+
+    return entry;
+  }
+
+
+  /**
+   * This method is specific to annotated compounds for library generation. Also see
+   * {@link SpectralLibraryEntryFactory#create(FeatureListRow, MemoryMapStorage, Scan,
+   * FeatureAnnotation, DataPoint[], Map)} for generation of spectral library entries in a more
+   * general way also for unannotated.
+   *
+   * @param storage             optional memory storage to memory map data
+   * @param row                 row that was matched
+   * @param msmsScan            scan to export
+   * @param match               the match to export
+   * @param dps                 data points
+   * @param chimeric            chimeric result of msmsScan
+   * @param score               fragmentation pattern score
+   * @param allMatchedCompounds filtered list of all matched compounds (one adduct per compound
+   *                            name). also contains match which is currently exported.
+   * @return the new spectral library entry
+   */
+  @NotNull
+  public SpectralLibraryEntry createAnnotated(final @Nullable MemoryMapStorage storage,
+      final @Nullable FeatureListRow row, final @Nullable Scan msmsScan,
+      final @NotNull FeatureAnnotation match, @NotNull final DataPoint[] dps,
+      @Nullable final ChimericPrecursorResults chimeric, final @Nullable MSMSScore score,
+      final @Nullable List<FeatureAnnotation> allMatchedCompounds,
+      final @Nullable Map<DBEntryField, Object> metadataMap) {
+    // add instrument type etc by parameter
+    SpectralLibraryEntry entry = create(row, storage, msmsScan, match, dps, metadataMap);
+
+    // only add fields here that are specific to library generation
+    // all other fields should be added in {@link SpectralLibraryEntryFactory}
+
+    // matched against mutiple compounds in the same sample?
+    // usually metadata is filtered so that raw data files only contain specific compounds without interference
+    addOtherMatchedCompounds(entry, match, allMatchedCompounds);
+
+    // score might be successful without having a formula - so check if we actually have scores
+    addMsMsScore(entry, score);
+
+    if (flagChimerics && chimeric != null) {
+      // default is passed
+      addChimericMs1PrecursorResults(entry, chimeric);
+    }
+
+    return entry;
+  }
+
+
+  private static void addExperimentalFeatureResults(final SpectralLibraryEntry entry,
+      final @NotNull FeatureListRow row) {
+    if (entry.getField(DBEntryField.RT).isEmpty()) {
+      entry.putIfNotNull(DBEntryField.RT, row.getAverageRT());
+    }
+    if (entry.getField(DBEntryField.CCS).isEmpty()) {
+      entry.putIfNotNull(DBEntryField.CCS, row.getAverageCCS());
+    }
+    if (entry.getField(DBEntryField.FEATURE_MS1_HEIGHT).isEmpty()) {
+      entry.putIfNotNull(DBEntryField.FEATURE_MS1_HEIGHT, row.getMaxHeight());
+    }
+  }
+
+
+  public void addScanSpecificFields(@NotNull final SpectralLibraryEntry entry,
+      final @Nullable Scan scan) {
+    if (scan == null) {
+      return;
+    }
+    MsMsInfo msMsInfo = scan.getMsMsInfo();
+    if (msMsInfo instanceof MSnInfoImpl msnInfo) {
+      // energies are quite complex
+      // [MS2, MS3, MS4] and multiple energies in last level due to merging
+      var msnEnergies = ScanUtils.extractMSnCollisionEnergies(scan);
+      if (!msnEnergies.isEmpty()) {
+        entry.putIfNotNull(DBEntryField.MSN_COLLISION_ENERGIES, msnEnergies);
+      }
+      //
+      List<DDAMsMsInfo> precursors = msnInfo.getPrecursors();
+      entry.putIfNotNull(DBEntryField.MSN_PRECURSOR_MZS,
+          SpectralLibraryEntryFactory.extractJsonList(precursors, DDAMsMsInfo::getIsolationMz));
+      entry.putIfNotNull(DBEntryField.MSN_FRAGMENTATION_METHODS,
+          SpectralLibraryEntryFactory.extractJsonList(precursors,
+              DDAMsMsInfo::getActivationMethod));
+      entry.putIfNotNull(DBEntryField.MSN_ISOLATION_WINDOWS,
+          SpectralLibraryEntryFactory.extractJsonList(precursors, info -> {
+            Range<Double> window = info.getIsolationWindow();
+            return window == null ? null : RangeUtils.rangeLength(window);
+          }));
+      entry.putIfNotNull(DBEntryField.MS_LEVEL, msnInfo.getMsLevel());
+    } else if (msMsInfo != null) {
+      entry.putIfNotNull(DBEntryField.FRAGMENTATION_METHOD, msMsInfo.getActivationMethod());
+      Range<Double> window = msMsInfo.getIsolationWindow();
+      if (window != null) {
+        entry.putIfNotNull(DBEntryField.ISOLATION_WINDOW, RangeUtils.rangeLength(window));
+      }
+      entry.putIfNotNull(DBEntryField.MS_LEVEL, msMsInfo.getMsLevel());
+    }
+    List<Float> energies = ScanUtils.extractCollisionEnergies(scan);
+    if (!energies.isEmpty()) {
+      FloatArrayList list = new FloatArrayList(energies);
+      entry.putIfNotNull(DBEntryField.COLLISION_ENERGY, list);
+    }
+
+    addUniversalSpectrumIdentifiers(entry, scan);
+
+    if (scan instanceof MergedMassSpectrum merged) {
+      entry.putIfNotNull(DBEntryField.MS_LEVEL, merged.getMSLevel());
+      entry.putIfNotNull(DBEntryField.SCAN_NUMBER,
+          ScanUtils.extractScanNumbers(merged).boxed().toList());
+      entry.putIfNotNull(DBEntryField.MERGED_SPEC_TYPE, merged.getMergingType());
+    } else {
+      entry.putIfNotNull(DBEntryField.MERGED_SPEC_TYPE, MergingType.SINGLE_BEST_SCAN);
+      entry.putIfNotNull(DBEntryField.SCAN_NUMBER, scan.getScanNumber());
+    }
+  }
+
+
+  /**
+   * Flag chimeric precursor isolation in name
+   */
+  public void setFlagChimerics(final boolean flagChimerics) {
+    this.flagChimerics = flagChimerics;
+  }
+
+  public void addChimericMs1PrecursorResults(final @NotNull SpectralLibraryEntry entry,
+      final @NotNull ChimericPrecursorResults chimeric) {
+    if (!flagChimerics) {
+      return;
+    }
+
+    entry.putIfNotNull(DBEntryField.QUALITY_PRECURSOR_PURITY, chimeric.purity());
+    entry.putIfNotNull(DBEntryField.QUALITY_CHIMERIC, chimeric.flag());
+    if (ChimericPrecursorFlag.CHIMERIC.equals(chimeric.flag())) {
+      entry.putIfNotNull(DBEntryField.NAME,
+          entry.getField(DBEntryField.NAME).orElse("") + " (Chimeric precursor selection)");
+    }
+  }
+
+  public void addUniversalSpectrumIdentifiers(final @NotNull SpectralLibraryEntry entry,
+      final @NotNull Scan scan) {
+    // merged scans are derived from multiple source scans - add all USI here
+    String datasetID = entry.getOrElse(DBEntryField.DATASET_ID, null);
+    final List<String> usis;
+    if (compactUSI) {
+      usis = ScanUtils.extractCompressedUSIRanges(scan, datasetID).toList();
+    } else {
+      usis = ScanUtils.extractUSI(scan, datasetID).toList();
+    }
+    entry.putIfNotNull(DBEntryField.USI, usis);
+  }
+
+  /**
+   * Add metadata to spectral library entry from feature annotation.
+   *
+   * @param match
+   */
+  public void addFeatureAnnotationFields(@NotNull final SpectralLibraryEntry entry,
+      @Nullable FeatureAnnotation match) {
+    if (addAnnotation && match == null) {
+      return;
+    }
+    switch (match) {
+      case CompoundDBAnnotation dbmatch -> addAnnotationFields(entry, dbmatch);
+      case SpectralLibraryEntry dbmatch -> addAnnotationFields(entry, dbmatch);
+      case FeatureAnnotation _ -> {
+        entry.putIfNotNull(DBEntryField.ION_TYPE, match.getAdductType());
+        entry.putIfNotNull(DBEntryField.CCS, match.getCCS());
+        entry.putIfNotNull(DBEntryField.NAME, match.getCompoundName());
+        entry.putIfNotNull(DBEntryField.FORMULA, match.getFormula());
+        entry.putIfNotNull(DBEntryField.INCHI, match.getInChI());
+        entry.putIfNotNull(DBEntryField.INCHIKEY, match.getInChIKey());
+        entry.putIfNotNull(DBEntryField.SMILES, match.getSmiles());
+      }
+    }
+  }
+
+  public void addAnnotationFields(@NotNull final SpectralLibraryEntry entry,
+      @Nullable CompoundDBAnnotation match) {
+    if (addAnnotation && match == null) {
+      return;
+    }
+    for (var dbentry : match.getReadOnlyMap().entrySet()) {
+      DBEntryField field = DBEntryField.fromDataType(dbentry.getKey());
+      if (field == DBEntryField.UNSPECIFIED) {
+        continue;
+      }
+      try {
+        entry.putIfNotNull(field, dbentry.getValue());
+      } catch (Exception ex) {
+        logger.log(Level.WARNING,
+            "Types were not converted from DB match to DB entry " + ex.getMessage(), ex);
+      }
+    }
+  }
+
+  public void addAnnotationFields(@NotNull final SpectralLibraryEntry entry,
+      @Nullable SpectralLibraryEntry match) {
+    if (addAnnotation && match == null) {
+      return;
+    }
+    for (var dbentry : match.getFields().entrySet()) {
+      switch (dbentry.getKey()) {
+        case RT, NAME, FORMULA, SMILES, INCHI, INCHIKEY, EXACT_MASS, ION_TYPE, SYNONYMS, CAS,
+             PUBCHEM, PUBMED, MOLWEIGHT -> entry.putIfNotNull(dbentry.getKey(), dbentry.getValue());
+      }
+    }
+  }
+
+  public void addMsMsScore(@NotNull final SpectralLibraryEntry entry,
+      @Nullable final MSMSScore score) {
+    if (score != null && score.explainedSignals() > 0) {
+      entry.putIfNotNull(DBEntryField.QUALITY_EXPLAINED_INTENSITY, score.explainedIntensity());
+      entry.putIfNotNull(DBEntryField.QUALITY_EXPLAINED_SIGNALS, score.explainedSignals());
+    }
+  }
+
+  /**
+   * Adds count of other matched compounds with different compound name
+   *
+   * @param match               the match to export
+   * @param allMatchedCompounds filtered list of all matched compounds (one adduct per compound
+   *                            name). also contains match which is currently exported.
+   */
+  public void addOtherMatchedCompounds(@NotNull final SpectralLibraryEntry entry,
+      final @NotNull FeatureAnnotation match,
+      @Nullable final List<FeatureAnnotation> allMatchedCompounds) {
+    if (allMatchedCompounds == null) {
+      return;
+    }
+    // matched against mutiple compounds in the same sample?
+    // usually metadata is filtered so that raw data files only contain specific compounds without interference
+    if (allMatchedCompounds.size() > 1) {
+      // 1 would be the match itself
+      entry.putIfNotNull(DBEntryField.OTHER_MATCHED_COMPOUNDS_N, allMatchedCompounds.size() - 1);
+      entry.putIfNotNull(DBEntryField.OTHER_MATCHED_COMPOUNDS_NAMES, allMatchedCompounds.stream()
+          .filter(m -> !Objects.equals(match.getCompoundName(), m.getCompoundName()))
+          .map(FeatureAnnotation::toString).collect(Collectors.joining("; ")));
+    }
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralLibraryEntryFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralLibraryEntryFactory.java
@@ -221,7 +221,7 @@ public class SpectralLibraryEntryFactory {
    *
    * @param storage  optional memory storage to memory map data
    * @param row      row to export
-   * @param scan     scan to export
+   * @param scan     only used for scan metadata - data is provided through dps dataPoints
    * @param dps      data points
    * @param chimeric chimeric result of scan.
    * @return the new spectral library entry
@@ -245,7 +245,8 @@ public class SpectralLibraryEntryFactory {
    *
    * @param storage             optional memory storage to memory map data
    * @param row                 row that was matched
-   * @param msmsScan            scan to export
+   * @param msmsScan            only used for scan metadata - data is provided through dps
+   *                            dataPoints
    * @param match               the match to export
    * @param dps                 data points
    * @param chimeric            chimeric result of msmsScan
@@ -314,15 +315,13 @@ public class SpectralLibraryEntryFactory {
         //
         List<DDAMsMsInfo> precursors = msnInfo.getPrecursors();
         entry.putIfNotNull(DBEntryField.MSN_PRECURSOR_MZS,
-            SpectralLibraryEntryFactory.extractJsonList(precursors, DDAMsMsInfo::getIsolationMz));
+            extractJsonList(precursors, DDAMsMsInfo::getIsolationMz));
         entry.putIfNotNull(DBEntryField.MSN_FRAGMENTATION_METHODS,
-            SpectralLibraryEntryFactory.extractJsonList(precursors,
-                DDAMsMsInfo::getActivationMethod));
-        entry.putIfNotNull(DBEntryField.MSN_ISOLATION_WINDOWS,
-            SpectralLibraryEntryFactory.extractJsonList(precursors, info -> {
-              Range<Double> window = info.getIsolationWindow();
-              return window == null ? null : RangeUtils.rangeLength(window);
-            }));
+            extractJsonList(precursors, DDAMsMsInfo::getActivationMethod));
+        entry.putIfNotNull(DBEntryField.MSN_ISOLATION_WINDOWS, extractJsonList(precursors, info -> {
+          Range<Double> window = info.getIsolationWindow();
+          return window == null ? null : RangeUtils.rangeLength(window);
+        }));
         entry.putIfNotNull(DBEntryField.MS_LEVEL, msnInfo.getMsLevel());
       } else if (msMsInfo != null) {
         entry.putIfNotNull(DBEntryField.FRAGMENTATION_METHOD, msMsInfo.getActivationMethod());

--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralLibraryEntryFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralLibraryEntryFactory.java
@@ -85,7 +85,7 @@ public class SpectralLibraryEntryFactory {
    *                   into a list of ranges
    */
   public SpectralLibraryEntryFactory(final boolean compactUSI) {
-    this(compactUSI, true, true, true);
+    this(compactUSI, false, true, true);
   }
 
   /**

--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralLibraryEntryFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/SpectralLibraryEntryFactory.java
@@ -280,8 +280,11 @@ public class SpectralLibraryEntryFactory {
   }
 
 
-  private static void addExperimentalFeatureResults(final SpectralLibraryEntry entry,
+  public void addExperimentalFeatureResults(final SpectralLibraryEntry entry,
       final @NotNull FeatureListRow row) {
+    if (!addExperimentalResults) {
+      return;
+    }
     if (entry.getField(DBEntryField.RT).isEmpty()) {
       entry.putIfNotNull(DBEntryField.RT, row.getAverageRT());
     }
@@ -387,12 +390,10 @@ public class SpectralLibraryEntryFactory {
 
   /**
    * Add metadata to spectral library entry from feature annotation.
-   *
-   * @param match
    */
   public void addFeatureAnnotationFields(@NotNull final SpectralLibraryEntry entry,
       @Nullable FeatureAnnotation match) {
-    if (addAnnotation && match == null) {
+    if (!addAnnotation || match == null) {
       return;
     }
     switch (match) {
@@ -412,7 +413,7 @@ public class SpectralLibraryEntryFactory {
 
   public void addAnnotationFields(@NotNull final SpectralLibraryEntry entry,
       @Nullable CompoundDBAnnotation match) {
-    if (addAnnotation && match == null) {
+    if (!addAnnotation || match == null) {
       return;
     }
     for (var dbentry : match.getReadOnlyMap().entrySet()) {
@@ -431,7 +432,7 @@ public class SpectralLibraryEntryFactory {
 
   public void addAnnotationFields(@NotNull final SpectralLibraryEntry entry,
       @Nullable SpectralLibraryEntry match) {
-    if (addAnnotation && match == null) {
+    if (!addAnnotation || match == null) {
       return;
     }
     for (var dbentry : match.getFields().entrySet()) {
@@ -478,7 +479,7 @@ public class SpectralLibraryEntryFactory {
    * Put experimental results from feature to entry
    */
   public void putFeatureFieldsIntoEntry(@NotNull SpectralLibraryEntry entry, @Nullable Feature f) {
-    if (f == null && addExperimentalResults) {
+    if (f == null || !addExperimentalResults) {
       return;
     }
 
@@ -491,21 +492,22 @@ public class SpectralLibraryEntryFactory {
     this.addOnlineReactivityFlags = addOnlineReactivityFlags;
   }
 
+  /**
+   * Add online reactivity fields if activated by flag
+   */
   public void addOnlineReactivityFlags(@NotNull final SpectralLibraryEntry entry,
-      @Nullable FeatureListRow row) {
-    if (row == null) {
+      @Nullable final FeatureListRow row) {
+    if (row == null || !addOnlineReactivityFlags) {
       return;
     }
 
-    if (addOnlineReactivityFlags) {
-      // reactivity only for MS1
-      if (entry.getMsLevel().stream().anyMatch(msLevel -> msLevel == 1)) {
-        String reactivityString = reactionJsonWriter.createReactivityString(row,
-            row.getOnlineReactionMatches());
+    // reactivity only for MS1
+    if (entry.getMsLevel().stream().anyMatch(msLevel -> msLevel == 1)) {
+      String reactivityString = reactionJsonWriter.createReactivityString(row,
+          row.getOnlineReactionMatches());
 
-        if (reactivityString != null) {
-          entry.putIfNotNull(DBEntryField.ONLINE_REACTIVITY, reactivityString);
-        }
+      if (reactivityString != null) {
+        entry.putIfNotNull(DBEntryField.ONLINE_REACTIVITY, reactivityString);
       }
     }
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/GnpsMgfParser.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/GnpsMgfParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -32,6 +32,7 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibrary;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntry;
+import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntryFactory;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -94,8 +95,8 @@ public class GnpsMgfParser extends SpectralDBTextParser {
               if (l.equalsIgnoreCase("END IONS")) {
                 // add entry and reset
                 if (fields.size() > 1 && dps.size() > 1) {
-                  SpectralLibraryEntry entry = SpectralLibraryEntry.create(library.getStorage(),
-                      fields, dps.toArray(new DataPoint[dps.size()]));
+                  SpectralLibraryEntry entry = SpectralLibraryEntryFactory.create(
+                      library.getStorage(), fields, dps.toArray(new DataPoint[dps.size()]));
                   // add and push
                   addLibraryEntry(entry);
                   correct++;

--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/JdxParser.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/JdxParser.java
@@ -30,6 +30,7 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibrary;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntry;
+import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntryFactory;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -109,8 +110,8 @@ public class JdxParser extends SpectralDBTextParser {
           if (l.contains("END")) {
             // row with END
             // add entry and reset
-            SpectralLibraryEntry entry = SpectralLibraryEntry.create(library.getStorage(), fields,
-                dps.toArray(new DataPoint[dps.size()]));
+            SpectralLibraryEntry entry = SpectralLibraryEntryFactory.create(library.getStorage(),
+                fields, dps.toArray(new DataPoint[dps.size()]));
             fields = new EnumMap<>(fields);
             dps.clear();
             addLibraryEntry(entry);

--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/MZmineJsonParser.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/MZmineJsonParser.java
@@ -31,6 +31,7 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibrary;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntry;
+import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntryFactory;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonNumber;
@@ -175,7 +176,7 @@ public class MZmineJsonParser extends SpectralDBTextParser {
       }
     }
 
-    return SpectralLibraryEntry.create(library.getStorage(), map, dps);
+    return SpectralLibraryEntryFactory.create(library.getStorage(), map, dps);
   }
 
   public static DataPoint[] getDataPointsFromJsonArray(JsonArray data) {

--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/MonaJsonParser.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/MonaJsonParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -31,6 +31,7 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibrary;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntry;
+import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntryFactory;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonNumber;
@@ -163,7 +164,7 @@ public class MonaJsonParser extends SpectralDBTextParser {
     // metadata
     Map<DBEntryField, Object> map = new EnumMap<>(DBEntryField.class);
     extractAllFields(main, map);
-    return SpectralLibraryEntry.create(library.getStorage(), map, dps);
+    return SpectralLibraryEntryFactory.create(library.getStorage(), map, dps);
   }
 
   public void extractAllFields(JsonObject main, Map<DBEntryField, Object> map) {

--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/NistMspParser.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/NistMspParser.java
@@ -31,6 +31,7 @@ import io.github.mzmine.taskcontrol.AbstractTask;
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibrary;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntry;
+import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntryFactory;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -94,8 +95,8 @@ public class NistMspParser extends SpectralDBTextParser {
             if (isData) {
               // empty row after data
               // add entry and reset
-              SpectralLibraryEntry entry = SpectralLibraryEntry.create(library.getStorage(), fields,
-                  dps.toArray(new DataPoint[dps.size()]));
+              SpectralLibraryEntry entry = SpectralLibraryEntryFactory.create(library.getStorage(),
+                  fields, dps.toArray(new DataPoint[dps.size()]));
               // add and push
               addLibraryEntry(entry);
               // reset

--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/mzmine/MZmineJsonLibraryEntry.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/mzmine/MZmineJsonLibraryEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -213,7 +213,8 @@ public class MZmineJsonLibraryEntry {
       case SIRIUS_MERGED_STATS -> null;
       case OTHER_MATCHED_COMPOUNDS_N -> null;
       case OTHER_MATCHED_COMPOUNDS_NAMES -> null;
-      case FEATURE_ID, FEATURE_MS1_HEIGHT, FEATURE_MS1_REL_HEIGHT -> null;
+      case FEATURE_ID, FEATURELIST_NAME_FEATURE_ID, FEATURE_MS1_HEIGHT, FEATURE_MS1_REL_HEIGHT ->
+          null;
       case SCAN_NUMBER -> scanNumber;
       case UNSPECIFIED -> null;
     };

--- a/mzmine-community/src/test/java/datamodel/IMSScanTypesTest.java
+++ b/mzmine-community/src/test/java/datamodel/IMSScanTypesTest.java
@@ -59,6 +59,7 @@ import io.github.mzmine.util.scans.similarity.impl.composite.CompositeCosineSpec
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
 import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntry;
+import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntryFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -254,7 +255,7 @@ public class IMSScanTypesTest {
     Map<DBEntryField, Object> map = Map.of(DBEntryField.ENTRY_ID, "123swd", DBEntryField.CAS,
         "468-531-21", DBEntryField.DATA_COLLECTOR, "Dr. Xy", DBEntryField.CHARGE, 1);
 
-    SpectralLibraryEntry entry = SpectralLibraryEntry.create(null, map,
+    SpectralLibraryEntry entry = SpectralLibraryEntryFactory.create(null, map,
         ScanUtils.extractDataPoints(library));
 
     SpectralSimilarity similarity = simFunc.getSimilarity(new MZTolerance(0.005, 15), 0,

--- a/mzmine-community/src/test/java/datamodel/RegularScanTypesTest.java
+++ b/mzmine-community/src/test/java/datamodel/RegularScanTypesTest.java
@@ -74,6 +74,7 @@ import io.github.mzmine.util.scans.similarity.impl.composite.CompositeCosineSpec
 import io.github.mzmine.util.spectraldb.entry.DBEntryField;
 import io.github.mzmine.util.spectraldb.entry.SpectralDBAnnotation;
 import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntry;
+import io.github.mzmine.util.spectraldb.entry.SpectralLibraryEntryFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -245,7 +246,7 @@ public class RegularScanTypesTest {
     Map<DBEntryField, Object> map = Map.of(DBEntryField.ENTRY_ID, "123swd", DBEntryField.CAS,
         "468-531-21", DBEntryField.DATA_COLLECTOR, "Dr. Xy", DBEntryField.CHARGE, 1);
 
-    SpectralLibraryEntry entry = SpectralLibraryEntry.create(null, map,
+    SpectralLibraryEntry entry = SpectralLibraryEntryFactory.create(null, map,
         ScanUtils.extractDataPoints(library));
 
     SpectralSimilarity similarity = simFunc.getSimilarity(new MZTolerance(0.005, 15), 0,


### PR DESCRIPTION
Moved all general code to SpectralLibraryEntryFactory which can be configured for specific flavors of entries.

Mostly moved all creation of SpectralLibraryEntry into a factory. Logic changes are mostly focussed on how to pick charge and polarity from row, scan, and match in some priority order.

There were some defaults like positive polarity that were changed for Optional<> return types for better downstream control. 



Test runs still running on GNPS and SIRIUS

https://gnps.ucsd.edu/ProteoSAFe/status.jsp?task=4f3c62d9873a4e8b916d57978386c127

https://gnps.ucsd.edu/ProteoSAFe/status.jsp?task=d451bf16197942f9a980715ee266da35

https://gnps2.org/status?task=4cc24485b44d484f85790a985b993faa

https://gnps2.org/status?task=76c6076cae704d1dbaafbc28699b1808

SIRIUS, GNPS, GNPS2 all work with the new format.

### New Format SIRIUS:

```
BEGIN IONS
FEATURE_ID=14
FEATURELIST_FEATURE_ID=Aligned feature list corr PEARSON r greq 0.85 dp greq 5:14
MSLEVEL=2
RTINSECONDS=59.26
PEPMASS=239.149
CHARGE=1
FEATURE_MS1_HEIGHT=5.088E5
SPECTYPE=SINGLE_BEST_SCAN
COLLISION_ENERGY=[30.0]
FRAGMENTATION_METHOD=HCD
ISOLATION_WINDOW=0.8000000000000114
IONMODE=POSITIVE
USI=[mzspec:DATASET_ID_PLACEHOLDER:20230620_pluskal_nih_04P_G12_id_rt_ms2_positive:275]
SCANS=14
Num peaks=3
45.033367 2.973898E6
89.059395 2.0568146E6
133.085693 8.1614941E5
END IONS
```

### Old format
``` 
BEGIN IONS
FEATURE_ID=998
MSLEVEL=2
RTINSECONDS=387.28
PEPMASS=157.12215
CHARGE=1+ 
FILENAME=32mix_Cysteine_0.1mM_10ulmin_2_P8-F-2_1_4700.mzml
SCANS=998
Num peaks=2
148.960175 100
171.055771 100
END IONS
```