### PR TITLE
add import for tims-autoMSMS acquisitions on timsTOF classic

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFImportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFImportTask.java
@@ -307,6 +307,7 @@ public class TDFImportTask extends AbstractTask {
     constructMsMsInfo(newMZmineFile, framePrecursorTable);
     assignDiaMsMsInfo(newMZmineFile, diaFrameMsMsWindowTable, diaFrameMsMsInfoTable);
     assignBbCidMsMsInfo(newMZmineFile, frameTable, frameMsMsInfoTable, metaDataTable);
+    assignTimsAutoMsMsInfo(newMZmineFile, frameTable, frameMsMsInfoTable);
 
     tdfUtils.close();
 
@@ -544,6 +545,37 @@ public class TDFImportTask extends AbstractTask {
       final DIAImsMsMsInfoImpl diaImsMsMsInfo = new DIAImsMsMsInfoImpl(
           Range.closed(0, frame.getNumberOfMobilityScans() - 1), ce, frame, mzRange);
       frame.getImsMsMsInfos().add(diaImsMsMsInfo);
+    }
+  }
+
+  /**
+   * timsTOF classic only supports auto msms and not pasef.
+   */
+  private void assignTimsAutoMsMsInfo(IMSRawDataFile newMZmineFile, TDFFrameTable frameTable,
+      TDFFrameMsMsInfoTable frameMsMsInfoTable) {
+    List<? extends Frame> frames = newMZmineFile.getFrames();
+
+    final int firstFrameId = (int) frameTable.getFirstFrameNumber();
+
+    for (int i = 0; i < frames.size(); i++) {
+      Frame frame = frames.get(i);
+      final int frameTableIndex = frame.getFrameId() - firstFrameId;
+
+      if (frameTable.getScanModeColumn().get(frameTableIndex).intValue()
+          != BrukerScanMode.AUTO_MSMS.getNum()
+          || frameTable.getMsMsTypeColumn().get(frameTableIndex).intValue() != 2) {
+        continue;
+      }
+
+      final int frameMsMsTableIndex = BinarySearch.binarySearch(frameMsMsInfoTable.getFrameId(),
+          (double) frame.getFrameId(), DefaultTo.MINUS_INSERTION_POINT, Long::doubleValue);
+      if (frameMsMsTableIndex < 0) {
+        continue;
+      }
+
+      final PasefMsMsInfo ddaImsMsMsInfo = frameMsMsInfoTable.getImsAutoMsMsInfo(
+          frameMsMsTableIndex, frame, null);
+      frame.getImsMsMsInfos().add(ddaImsMsMsInfo);
     }
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/datamodel/sql/TDFFrameMsMsInfoTable.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/datamodel/sql/TDFFrameMsMsInfoTable.java
@@ -26,10 +26,14 @@
 package io.github.mzmine.modules.io.import_rawdata_bruker_tdf.datamodel.sql;
 
 import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.impl.DDAMsMsInfoImpl;
+import io.github.mzmine.datamodel.impl.PasefMsMsInfoImpl;
 import io.github.mzmine.datamodel.msms.ActivationMethod;
 import io.github.mzmine.datamodel.msms.DDAMsMsInfo;
+import io.github.mzmine.datamodel.msms.PasefMsMsInfo;
+import io.github.mzmine.util.RangeUtils;
 import java.util.Arrays;
 
 /**
@@ -112,6 +116,16 @@ public class TDFFrameMsMsInfoTable extends TDFDataTable<Long> {
     return ddaMsMsInfo;
   }
 
+  public PasefMsMsInfo getImsAutoMsMsInfo(int index, Frame msmsScan, Frame parentScan) {
+    final double precursor = precursorMz.get(index).doubleValue();
+    final double width = isolationWidth.get(index).doubleValue();
+    final float ce = getCe().get(index).floatValue();
+
+    final PasefMsMsInfoImpl ddaImsMsMsInfo = new PasefMsMsInfoImpl(precursor,
+        Range.closed(0, msmsScan.getNumberOfMobilityScans() - 1), ce, charge.get(index).intValue(),
+        parentScan, msmsScan, RangeUtils.rangeAround(precursor, width));
+    return ddaImsMsMsInfo;
+  }
 
   public TDFDataColumn<Long> getFrameId() {
     return frameId;


### PR DESCRIPTION
internally handled like a pasef file with a single precursor, which gives you the option to resolve coeluting isomers by mobility resolving