### PR TITLE
drop duplicate data points from other traces

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/otherdetectors/SimpleOtherTimeSeries.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/otherdetectors/SimpleOtherTimeSeries.java
@@ -69,6 +69,12 @@ public class SimpleOtherTimeSeries implements OtherTimeSeries {
     if (intensityValues.length != rtValues.length) {
       throw new IllegalArgumentException("Intensities and RT values must have the same length");
     }
+    for (int i = 0; i < rtValues.length - 1; i++) {
+      if (rtValues[i + 1] <= rtValues[i]) {
+        throw new IllegalArgumentException("Chromatogram not sorted in retention time");
+      }
+    }
+
     this.timeSeriesData = timeSeriesData;
     intensityBuffer = StorageUtils.storeValuesToDoubleBuffer(storage, intensityValues);
     timeBuffer = StorageUtils.storeValuesToFloatBuffer(storage, rtValues);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/ConversionUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/ConversionUtils.java
@@ -29,6 +29,7 @@ import io.github.msdk.datamodel.ActivationInfo;
 import io.github.msdk.datamodel.Chromatogram;
 import io.github.msdk.datamodel.IsolationInfo;
 import io.github.msdk.datamodel.MsSpectrumType;
+import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.MassSpectrumType;
 import io.github.mzmine.datamodel.PolarityType;
 import io.github.mzmine.datamodel.RawDataFile;
@@ -37,6 +38,7 @@ import io.github.mzmine.datamodel.features.types.MsMsInfoType;
 import io.github.mzmine.datamodel.features.types.numbers.MZType;
 import io.github.mzmine.datamodel.features.types.otherdectectors.PolarityTypeType;
 import io.github.mzmine.datamodel.impl.DDAMsMsInfoImpl;
+import io.github.mzmine.datamodel.impl.SimpleDataPoint;
 import io.github.mzmine.datamodel.impl.SimpleScan;
 import io.github.mzmine.datamodel.msms.ActivationMethod;
 import io.github.mzmine.datamodel.msms.MsMsInfo;
@@ -63,6 +65,8 @@ import io.github.mzmine.modules.io.import_rawdata_mzml.msdk.data.MzMLPrecursorEl
 import io.github.mzmine.modules.io.import_rawdata_mzml.msdk.data.MzMLPrecursorList;
 import io.github.mzmine.modules.io.import_rawdata_mzml.msdk.data.MzMLPrecursorSelectedIonList;
 import io.github.mzmine.modules.io.import_rawdata_mzml.msdk.data.MzMLUnits;
+import io.github.mzmine.util.DataPointSorter;
+import io.github.mzmine.util.collections.CollectionUtils;
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -403,15 +407,19 @@ public class ConversionUtils {
         for (MzMLChromatogram chrom : unitChromEntry.getValue()) {
           if (chrom.getNumberOfDataPoints() == 0) {
             // drop empty chromatograms
-            logger.finest(
-                () -> "%s: Empty chromatogram %s imported. Will be skipped.".formatted(
-                    file.getName(), chrom.getId()));
+            logger.finest(() -> "%s: Empty chromatogram %s imported. Will be skipped.".formatted(
+                file.getName(), chrom.getId()));
             continue;
           }
 
+          // intermediate filtering to remove duplicates from traces. Why is this even necessary?
+          final List<DataPoint> dps = removeDuplicateRtDataPoints(file, chrom);
+
           final SimpleOtherTimeSeries timeSeries = new SimpleOtherTimeSeries(
-              file.getMemoryMapStorage(), chrom.getRetentionTimes(), chrom.getIntensities(),
-              chrom.getId(), timeSeriesData);
+              file.getMemoryMapStorage(), ConversionUtils.convertDoublesToFloats(
+              dps.stream().mapToDouble(DataPoint::getMZ).toArray()),
+              dps.stream().mapToDouble(DataPoint::getIntensity).toArray(), chrom.getId(),
+              timeSeriesData);
 
           final OtherFeatureImpl otherFeature = new OtherFeatureImpl(timeSeries);
           timeSeriesData.addRawTrace(otherFeature);
@@ -434,6 +442,28 @@ public class ConversionUtils {
     }
 
     return otherFiles;
+  }
+
+  /**
+   * Apparently it is not guaranteed that data points are unique or sorted. So we do that here.
+   */
+  private static @NotNull List<DataPoint> removeDuplicateRtDataPoints(RawDataFile file,
+      MzMLChromatogram chrom) {
+    final List<DataPoint> dps = new ArrayList<>();
+    final float[] rts = chrom.getRetentionTimes();
+    final double[] intensities = chrom.getIntensities();
+    for (int i = 0; i < chrom.getNumberOfDataPoints(); i++) {
+      dps.add(new SimpleDataPoint(rts[i], intensities[i]));
+    }
+    dps.sort(DataPointSorter.DEFAULT_MZ_ASCENDING);
+    final int before = dps.size();
+    CollectionUtils.dropDuplicatesRetainOrder(dps);
+    if (before != dps.size()) {
+      logger.info(
+          "%s - dropped %d duplicate values from chromatogram trace %s".formatted(file.getName(),
+              dps.size(), chrom.getId()));
+    }
+    return dps;
   }
 
   /**


### PR DESCRIPTION
Apparently it is not guaranteed that data points for chromatograms are unique or sorted. Occurred in bruker chromatography files. I put the same changes into the mzml import to be safe, as the bruker files may be converted to mzml.
