### PR TITLE
allow import of chromatograms with same x values but different y values

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/otherdetectors/SimpleOtherTimeSeries.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/otherdetectors/SimpleOtherTimeSeries.java
@@ -70,7 +70,7 @@ public class SimpleOtherTimeSeries implements OtherTimeSeries {
       throw new IllegalArgumentException("Intensities and RT values must have the same length");
     }
     for (int i = 0; i < rtValues.length - 1; i++) {
-      if (rtValues[i + 1] <= rtValues[i]) {
+      if (rtValues[i + 1] < rtValues[i]) {
         throw new IllegalArgumentException("Chromatogram not sorted in retention time");
       }
     }


### PR DESCRIPTION
I think some vendors put the MS1 and MS2 TIC/BPC chromatograms at the same rt values -> not removed by the current filters. So we need to allow same rt but different intensity in the chromatograms