### PR TITLE
Mass detection param check

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchQueueParameter.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchQueueParameter.java
@@ -147,7 +147,8 @@ public class BatchQueueParameter implements UserParameter<BatchQueue, AnchorPane
 
         if (!newErrors.isEmpty()) {
           // add module name and
-          errorMessages.add("\n%s:".formatted(batchStep.getModule().getName()));
+          errorMessages.add("\n%s (step %d):".formatted(batchStep.getModule().getName(),
+              value.indexOf(batchStep) + 1));
           errorMessages.addAll(newErrors);
           newErrors.clear();
         }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/MassDetectionParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/MassDetectionParameters.java
@@ -99,6 +99,10 @@ public class MassDetectionParameters extends SimpleParameterSet {
       return false;
     }
 
+    if (skipRawDataAndFeatureListParameters) {
+      return superCheck;
+    }
+
     // check files
     RawDataFile[] selectedFiles = getParameter(dataFiles).getValue().getMatchingRawDataFiles();
     getParameter(dataFiles).getValue().resetSelection(); // reset selection after evaluation.

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/MassDetectionParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_massdetection/MassDetectionParameters.java
@@ -82,8 +82,10 @@ public class MassDetectionParameters extends SimpleParameterSet {
   }
 
   @Override
-  public boolean checkParameterValues(Collection<String> errorMessages) {
-    final boolean superCheck = super.checkParameterValues(errorMessages);
+  public boolean checkParameterValues(Collection<String> errorMessages,
+      boolean skipRawDataAndFeatureListParameters) {
+    final boolean superCheck = super.checkParameterValues(errorMessages,
+        skipRawDataAndFeatureListParameters);
     // Check the selected mass detector
     MassDetectors detector = getValue(massDetector);
 


### PR DESCRIPTION
Mass detection parameters should have overridden the 

```
public boolean checkParameterValues(Collection<String> errorMessages,
      boolean skipRawDataAndFeatureListParameters)
```

instead of 


```
public boolean checkParameterValues(Collection<String> errorMessages)
```

to properly check the parameters in batch mode before launching the batch.

Also added the step index of the erroneous steps to the dialog

![grafik](https://github.com/user-attachments/assets/d1f932db-f53a-4971-88e2-333d243278ce)
