### PR TITLE
fix alignment in lc library wizard not using rt tolerance

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/WizardBatchBuilderLcLibraryGen.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/WizardBatchBuilderLcLibraryGen.java
@@ -113,7 +113,7 @@ public class WizardBatchBuilderLcLibraryGen extends BaseWizardBatchBuilder {
     makeAndAddBatchLibraryGeneration(q, exportPath, libGenMetadata);
 
     // join after the generation but just concat all lists together
-    makeAndAddJoinAlignmentStep(q, null);
+    makeAndAddJoinAlignmentStep(q, interSampleRtTol);
 
     // ions annotation and feature grouping
     makeAndAddMetaCorrStep(q);


### PR DESCRIPTION
Noticed today that some features were misaligned after processing with the LC Library wizard, because the join aligner did not specify an rt tolerance.