### PR TITLE
External (Waters) IMS Calibration permits negative T0 values

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/id_ccscalibration/external/WatersImsCalibrationReader.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/id_ccscalibration/external/WatersImsCalibrationReader.java
@@ -51,7 +51,8 @@ public class WatersImsCalibrationReader {
   private static final Pattern coefficientPattern = Pattern.compile(
       "(\\*\\sCoefficient:\\s)(\\d+.\\d+)");
   private static final Pattern exponentPattern = Pattern.compile("(\\*\\sExponent:\\s)(\\d+.\\d+)");
-  private static final Pattern t0Pattern = Pattern.compile("(\\*\\st0:\\s)(\\d+(.\\d+)?)");
+  /*t0 pattern has been updated to accept negative t0 values*/
+  private static final Pattern t0Pattern = Pattern.compile("(\\*\\st0:\\s)(-?\\d+(\\.\\d+)?)");
   private static final Pattern edcPattern = Pattern.compile(
       "(EDC Delay Coefficient)(\\s+)(\\d+.\\d+)");
   private static final Pattern edcLowPattern = Pattern.compile(


### PR DESCRIPTION
We've noticed that t0 in calibration files from out Waters Cyclic instrument can be below 0. An example calibration file is attached: 

[mob_cal.csv](https://github.com/user-attachments/files/18478064/mob_cal.csv)

A slight change to the REGEX used in interpreting Waters CCS calibration files allows files with a negative t0 values to be used and interpreted by the CCS calibration module, with no other changes apparently required.
