### PR TITLE
Minimum height in InputTypeComponent otherwise error in wizard

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/ImportTypeComponent.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/ImportTypeComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -44,6 +44,7 @@ public class ImportTypeComponent extends BorderPane {
 
     table.setEditable(true);
     setMaxHeight(400);
+    setMinHeight(150);
 
     final TableColumn<ImportType, Boolean> importColumn = new TableColumn<>("Import");
     importColumn.setCellFactory(column -> new CheckBoxTableCell());

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/ImportTypeComponent.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/ImportTypeComponent.java
@@ -44,7 +44,7 @@ public class ImportTypeComponent extends BorderPane {
 
     table.setEditable(true);
     setMaxHeight(400);
-    setMinHeight(150);
+    setMinHeight(200);
 
     final TableColumn<ImportType, Boolean> importColumn = new TableColumn<>("Import");
     importColumn.setCellFactory(column -> new CheckBoxTableCell());


### PR DESCRIPTION
@SteffenHeu you were right the minimum height was important here. I thought it would figure something out but it really shrunk into nothing in the wizard.

This is the minimum height now:
![image](https://github.com/user-attachments/assets/6df4da91-afcd-4fe5-b59e-a7153c10629b)
