### PR TITLE
add exception handling to WrappedTask and to AbstractSimpleToolTask

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/MobilityScanStorage.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/MobilityScanStorage.java
@@ -53,6 +53,7 @@ import org.jetbrains.annotations.Nullable;
 public class MobilityScanStorage {
 
   // raw data
+  @NotNull
   private final Frame frame;
   /**
    * doubles
@@ -365,7 +366,7 @@ public class MobilityScanStorage {
     if (massListStorageOffsets == null) {
       throw new MissingMassListException(
           "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
-          null);
+          frame);
     }
     assert index < getNumberOfMobilityScans();
 
@@ -384,7 +385,7 @@ public class MobilityScanStorage {
     if (massListStorageOffsets == null) {
       throw new MissingMassListException(
           "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
-          null);
+          frame);
     }
     return massListStorageOffsets.getAtIndex(ValueLayout.JAVA_INT, index);
   }
@@ -397,7 +398,7 @@ public class MobilityScanStorage {
     if (massListBasePeakIndices == null) {
       throw new MissingMassListException(
           "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
-          null);
+          frame);
     }
     return massListBasePeakIndices.getAtIndex(ValueLayout.JAVA_INT, index);
   }
@@ -409,7 +410,7 @@ public class MobilityScanStorage {
     if (massListMaxNumPoints == -1) {
       throw new MissingMassListException(
           "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
-          null);
+          frame);
     }
     return massListMaxNumPoints;
   }
@@ -421,7 +422,7 @@ public class MobilityScanStorage {
     if (massListIntensityValues == null) {
       throw new MissingMassListException(
           "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
-          null);
+          frame);
     }
     return (int) StorageUtils.numDoubles(massListIntensityValues);
   }
@@ -430,7 +431,7 @@ public class MobilityScanStorage {
     if (massListMzValues == null) {
       throw new MissingMassListException(
           "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
-          null);
+          frame);
     }
     final int numMassListDp = getNumberOfMassListDatapoints(mobilityScanIndex);
     assert numMassListDp <= dst.length;
@@ -445,7 +446,7 @@ public class MobilityScanStorage {
     if (massListMzValues == null) {
       throw new MissingMassListException(
           "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
-          null);
+          frame);
     }
     assert dst.length >= getMassListTotalNumPoints();
     StorageUtils.copyToBuffer(dst, massListMzValues, 0, getMassListTotalNumPoints());
@@ -455,7 +456,7 @@ public class MobilityScanStorage {
     if (massListIntensityValues == null) {
       throw new MissingMassListException(
           "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
-          null);
+          frame);
     }
     final int numMassListDp = getNumberOfMassListDatapoints(mobilityScanIndex);
     assert numMassListDp <= dst.length;
@@ -470,7 +471,7 @@ public class MobilityScanStorage {
     if (massListIntensityValues == null) {
       throw new MissingMassListException(
           "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
-          null);
+          frame);
     }
     assert dst.length >= getMassListTotalNumPoints();
     StorageUtils.copyToBuffer(dst, massListIntensityValues, 0, getMassListTotalNumPoints());
@@ -480,7 +481,7 @@ public class MobilityScanStorage {
     if (massListMzValues == null) {
       throw new MissingMassListException(
           "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
-          null);
+          frame);
     }
     return massListMzValues.getAtIndex(ValueLayout.JAVA_DOUBLE,
         getMassListStorageOffset(mobilityScanIndex) + index);
@@ -490,7 +491,7 @@ public class MobilityScanStorage {
     if (massListIntensityValues == null) {
       throw new MissingMassListException(
           "No mass list present for mobility scans. Run mass detection for scan type \"Mobility scans\" prior.",
-          null);
+          frame);
     }
     return massListIntensityValues.getAtIndex(ValueLayout.JAVA_DOUBLE,
         getMassListStorageOffset(mobilityScanIndex) + index);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchTask.java
@@ -165,10 +165,11 @@ public class BatchTask extends AbstractTask {
 
     String errorMessage = finishedTask.getErrorMessage();
     if (finishedTask.getStatus() == TaskStatus.ERROR) {
-      if (DesktopService.isGUI()) {
-        FxThread.runLater(
-            () -> DialogLoggerUtil.showErrorDialog("Batch had errors and stopped", errorMessage));
-      }
+      // not needed as this is done by caller - just important to set this task to error
+//      if (DesktopService.isGUI()) {
+//        FxThread.runLater(
+//            () -> DialogLoggerUtil.showErrorDialog("Batch had errors and stopped", errorMessage));
+//      }
       error(errorMessage);
       return TaskStatus.ERROR;
     }
@@ -187,6 +188,7 @@ public class BatchTask extends AbstractTask {
       // BatchTask is often run directly without WrappedTask, so handling of error message is important
       runBatchQueue();
     } catch (Throwable e) {
+      logger.log(Level.WARNING, e.getMessage(), e);
       // in case of an exception
       // regular errors are already handled in the runBatchQueue methods
       if (getErrorMessage() != null) {
@@ -195,8 +197,6 @@ public class BatchTask extends AbstractTask {
               () -> DialogLoggerUtil.showErrorDialog("EXCEPTION Batch had errors and stopped",
                   getErrorMessage()));
         }
-      } else {
-        logger.log(Level.WARNING, e.getMessage(), e);
       }
       return;
     }
@@ -254,7 +254,7 @@ public class BatchTask extends AbstractTask {
               setStatus(TaskStatus.ERROR);
               setErrorMessage(
                   "Could not set data files in advanced batch mode. Will cancel all jobs. "
-                      + datasetName);
+                  + datasetName);
               return;
             }
           }
@@ -379,7 +379,7 @@ public class BatchTask extends AbstractTask {
         if (selectedFiles == null) {
           setStatus(TaskStatus.ERROR);
           setErrorMessage("Invalid parameter settings for module " + method.getName() + ": "
-              + "Missing parameter value for " + p.getName());
+                          + "Missing parameter value for " + p.getName());
           return;
         }
         selectedFiles.setBatchLastFiles(createdFiles);
@@ -479,15 +479,16 @@ public class BatchTask extends AbstractTask {
 
     TaskStatus result = TaskUtils.waitForTasksToFinish(this, wrappedTasks);
 
-    // any error message?
+    // any error message - even if null this means that there was an error
     Optional<String> errorMessage = Arrays.stream(wrappedTasks)
         .filter(t -> t.getStatus() == TaskStatus.ERROR).map(WrappedTask::getErrorMessage)
         .findFirst();
     if (errorMessage.isPresent()) {
-      if (DesktopService.isGUI()) {
-        FxThread.runLater(() -> DialogLoggerUtil.showErrorDialog("Batch had errors and stopped",
-            errorMessage.get()));
-      }
+      // not needed as this is done by caller - just important to set this task to error
+//      if (DesktopService.isGUI()) {
+//        FxThread.runLater(() -> DialogLoggerUtil.showErrorDialog("Batch had errors and stopped",
+//            errorMessage.get()));
+//      }
       error(errorMessage.get());
       return TaskStatus.ERROR;
     }
@@ -512,7 +513,7 @@ public class BatchTask extends AbstractTask {
         setStatus(TaskStatus.ERROR);
         setErrorMessage(
             "Wanted to set the last batch files from raw data import but failed because less data files were imported than expected.\n"
-                + "expected %d  but loaded %d".formatted(loadedRawDataFiles.size(),
+            + "expected %d  but loaded %d".formatted(loadedRawDataFiles.size(),
                 createdDataFiles.size()));
       }
     }
@@ -535,7 +536,7 @@ public class BatchTask extends AbstractTask {
         if (selectedFeatureLists == null) {
           setStatus(TaskStatus.ERROR);
           setErrorMessage("Invalid parameter settings for module " + method.getName() + ": "
-              + "Missing parameter value for " + p.getName());
+                          + "Missing parameter value for " + p.getName());
           return false;
         }
         selectedFeatureLists.setBatchLastFeatureLists(createdFlists);

--- a/mzmine-community/src/main/java/io/github/mzmine/taskcontrol/AbstractSimpleToolTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/taskcontrol/AbstractSimpleToolTask.java
@@ -29,6 +29,8 @@ import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -41,6 +43,8 @@ import org.jetbrains.annotations.Nullable;
  * {@link #incrementFinishedItems()}.
  */
 public abstract class AbstractSimpleToolTask extends AbstractTask {
+
+  private static final Logger logger = Logger.getLogger(AbstractSimpleToolTask.class.getName());
 
   protected final ParameterSet parameters;
   protected long totalItems;
@@ -73,12 +77,23 @@ public abstract class AbstractSimpleToolTask extends AbstractTask {
 
   @Override
   public void run() {
-    setStatus(TaskStatus.PROCESSING);
+    try {
+      setStatus(TaskStatus.PROCESSING);
 
-    process();
+      process();
 
-    if (!isCanceled()) {
-      setStatus(TaskStatus.FINISHED);
+      if (!isCanceled()) {
+        setStatus(TaskStatus.FINISHED);
+      }
+    } catch (Throwable e) {
+      logger.log(Level.SEVERE, "Unhandled exception " + e.getMessage() + " while processing task "
+                               + getTaskDescription(), e);
+
+      if (e instanceof Exception exception) {
+        error(e.getMessage(), exception);
+      } else {
+        error(e.getMessage());
+      }
     }
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/util/exceptions/MissingMassListException.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/exceptions/MissingMassListException.java
@@ -27,6 +27,7 @@ package io.github.mzmine.util.exceptions;
 
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.util.scans.ScanUtils;
+import org.jetbrains.annotations.Nullable;
 
 public class MissingMassListException extends RuntimeException {
 
@@ -34,13 +35,16 @@ public class MissingMassListException extends RuntimeException {
     this("", scan);
   }
 
-  public MissingMassListException(String message, Scan scan) {
-    super("Missing mass list in scan " + ScanUtils.scanToString(scan, true) + ". " + message);
+  public MissingMassListException(String message, @Nullable Scan scan) {
+    super(
+        "Missing mass list in scan " + (scan != null ? ScanUtils.scanToString(scan, true) : "null")
+            + ". " + message);
   }
 
   /**
-   * This constructor is only to be used when no direct scan object is present. (e.g., {@link
-   * io.github.mzmine.datamodel.impl.MobilityScanStorage}) Use other constructors by default.
+   * This constructor is only to be used when no direct scan object is present. (e.g.,
+   * {@link io.github.mzmine.datamodel.impl.MobilityScanStorage}) Use other constructors by
+   * default.
    *
    * @param message Error message
    */

--- a/taskcontroller/src/main/java/io/github/mzmine/taskcontrol/impl/WrappedTask.java
+++ b/taskcontroller/src/main/java/io/github/mzmine/taskcontrol/impl/WrappedTask.java
@@ -193,8 +193,7 @@ public class WrappedTask implements Task {
        */
 
       logger.log(Level.SEVERE,
-          "Unhandled exception " + e + " while processing task " + actualTask.getTaskDescription(),
-          e);
+          "Unhandled exception " + e + " while processing task " + actualTask.getTaskDescription());
 
       if (e instanceof Exception exception) {
         actualTask.error(e.getMessage(), exception);

--- a/taskcontroller/src/main/java/io/github/mzmine/taskcontrol/impl/WrappedTask.java
+++ b/taskcontroller/src/main/java/io/github/mzmine/taskcontrol/impl/WrappedTask.java
@@ -196,6 +196,12 @@ public class WrappedTask implements Task {
           "Unhandled exception " + e + " while processing task " + actualTask.getTaskDescription(),
           e);
 
+      if (e instanceof Exception exception) {
+        actualTask.error(e.getMessage(), exception);
+      } else {
+        actualTask.error(e.getMessage());
+      }
+
 //      DesktopService.getDesktop().displayErrorMessage(
 //          "Unhandled exception in task " + actualTask.getTaskDescription() + ": "
 //          + ExceptionUtils.exceptionToString(e));


### PR DESCRIPTION
This feels like it should be the right thing to do but maybe better to think about this together. 

I feel like unhandled exceptions in tasks can always happen and the WrappedTask or the task itself should change its state to ERROR in this case and maybe even log the error