### PR TITLE
streamMsMsInfos check precursor mz in IMS Frames only

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/SimpleFrame.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/SimpleFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -207,6 +207,7 @@ public class SimpleFrame extends SimpleScan implements Frame {
   }
 
   public void setPrecursorInfos(@Nullable Set<IonMobilityMsMsInfo> precursorInfos) {
+    // precursorInfos needs to be modifiable
     this.precursorInfos = precursorInfos != null ? precursorInfos : new HashSet<>(0);
     this.precursorInfos.forEach(i -> i.setMsMsScan(this));
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/filter_diams2/DiaMs2CorrTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/filter_diams2/DiaMs2CorrTask.java
@@ -187,7 +187,7 @@ public class DiaMs2CorrTask extends AbstractTask {
   @Override
   public double getFinishedPercentage() {
     return isolationWindowMergingProgress * 0.25 + adapTaskProgess * 0.25
-        + (currentRow / (double) numRows) * 0.5d;
+           + (currentRow / (double) numRows) * 0.5d;
   }
 
   @Override
@@ -375,7 +375,7 @@ public class DiaMs2CorrTask extends AbstractTask {
         continue;
       }
       if (activationMethod == ActivationMethod.UNKNOWN) {
-        activationMethod = ScanUtils.streamMsMsInfos(subSeries.getSpectra())
+        activationMethod = ScanUtils.streamMsMsInfos(subSeries.getSpectra(), feature.getMZ())
             .map(MsMsInfo::getActivationMethod).findFirst().orElse(ActivationMethod.UNKNOWN);
       }
       final double[] rts = new double[subSeries.getNumberOfValues()];
@@ -424,9 +424,9 @@ public class DiaMs2CorrTask extends AbstractTask {
 
       ms2Mzs.add(mz);
       ms2Intensities.add(maxIntensity);
-      ScanUtils.streamMsMsInfos(subSeries.getSpectra()).map(MsMsInfo::getActivationEnergy)
-          .filter(Objects::nonNull).mapToDouble(Float::doubleValue).average()
-          .ifPresent(collisionEnergies::add);
+      ScanUtils.streamMsMsInfos(subSeries.getSpectra(), feature.getMZ())
+          .map(MsMsInfo::getActivationEnergy).filter(Objects::nonNull)
+          .mapToDouble(Float::doubleValue).average().ifPresent(collisionEnergies::add);
     }
 
     if (ms2Mzs.isEmpty()) {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/filter_diams2/DiaMs2CorrTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/filter_diams2/DiaMs2CorrTask.java
@@ -187,7 +187,7 @@ public class DiaMs2CorrTask extends AbstractTask {
   @Override
   public double getFinishedPercentage() {
     return isolationWindowMergingProgress * 0.25 + adapTaskProgess * 0.25
-           + (currentRow / (double) numRows) * 0.5d;
+        + (currentRow / (double) numRows) * 0.5d;
   }
 
   @Override
@@ -195,8 +195,9 @@ public class DiaMs2CorrTask extends AbstractTask {
     setStatus(TaskStatus.PROCESSING);
 
     if (flist.getNumberOfRawDataFiles() != 1) {
-      setErrorMessage("Cannot build DIA MS2 for feature lists with more than one raw data file.");
-      setStatus(TaskStatus.ERROR);
+      error(
+          "Cannot build DIA MS2 for feature lists with more than one raw data file. Run DIA pseudo MS2 builder before alignment.");
+      return;
     }
 
     final RawDataFile file = flist.getRawDataFile(0);
@@ -587,8 +588,8 @@ public class DiaMs2CorrTask extends AbstractTask {
           final SimpleFrame newFrame = new SimpleFrame(windowFile, scan.getScanNumber(),
               scan.getMSLevel(), scan.getRetentionTime(), mzIntensities[0], mzIntensities[1],
               scan.getSpectrumType(), scan.getPolarity(), scan.getScanDefinition(),
-              scan.getScanningMZRange(), ((Frame) scan).getMobilityType(), null,
-              scan.getInjectionTime());
+              scan.getScanningMZRange(), ((Frame) scan).getMobilityType(),
+              msMsInfo.map(Set::of).orElse(null), scan.getInjectionTime());
           newFrame.setMsMsInfo(msMsInfo.orElse(
               null)); //set to regular msmsinfo so we can extract for later CE setting
           newFrame.addMassList(new ScanPointerMassList(newFrame));

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/filter_diams2/DiaMs2CorrTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/filter_diams2/DiaMs2CorrTask.java
@@ -294,8 +294,11 @@ public class DiaMs2CorrTask extends AbstractTask {
       return null;
     }
 
+    final MsMsInfo msMsInfo = correlatedMs2s.stream().map(PseudoSpectrum::getMsMsInfo)
+        .filter(Objects::nonNull).map(MsMsInfo::createCopy).findFirst().orElse(null);
+
     return new SimplePseudoSpectrum(mostIntense.getDataFile(), mostIntense.getMSLevel(),
-        mostIntense.getRetentionTime(), null, mzs.toDoubleArray(), intensities.toDoubleArray(),
+        mostIntense.getRetentionTime(), msMsInfo, mzs.toDoubleArray(), intensities.toDoubleArray(),
         mostIntense.getPolarity(), mostIntense.getScanDefinition(),
         mostIntense.getPseudoSpectrumType());
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/WizardBatchBuilderLcDIA.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/WizardBatchBuilderLcDIA.java
@@ -133,6 +133,7 @@ public class WizardBatchBuilderLcDIA extends BaseWizardBatchBuilder {
     makeAndAddIinStep(q);
 
     // annotation
+    makeAndAddSpectralNetworkingSteps(q, isExportActive, exportPath, false);
     makeAndAddLibrarySearchStep(q, false);
     makeAndAddLocalCsvDatabaseSearchStep(q, interSampleRtTol);
     makeAndAddLipidAnnotationStep(q);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/WorkflowDiaWizardParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/WorkflowDiaWizardParameters.java
@@ -46,6 +46,8 @@ public final class WorkflowDiaWizardParameters extends WorkflowWizardParameters 
       "Minimum number of correlated points between MS1 and MS2 ions for pearson correlation.", 5, 3,
       Integer.MAX_VALUE);
 
+  public static final BooleanParameter applySpectralNetworking = WorkflowDdaWizardParameters.applySpectralNetworking.cloneParameter();
+
   public static final BooleanParameter exportSirius = new BooleanParameter("Export for SIRIUS", "",
       true);
   public static final BooleanParameter exportGnps = new BooleanParameter(
@@ -64,17 +66,19 @@ public final class WorkflowDiaWizardParameters extends WorkflowWizardParameters 
   public WorkflowDiaWizardParameters() {
     super(new WorkflowDIA(),
         // actual parameters
-        minPearson, minCorrelatedPoints, exportPath, exportGnps, exportSirius,
-        exportAnnotationGraphics);
+        minPearson, minCorrelatedPoints, applySpectralNetworking, exportPath, exportGnps,
+        exportSirius, exportAnnotationGraphics);
   }
 
 
   public WorkflowDiaWizardParameters(final double minPearsonCorrelation, final int minPoints,
-      final boolean exportActive, final File exportBasePath, final boolean exportGnpsActive,
-      boolean exportSiriusActive, boolean exportAnnotationGraphicsActive) {
+      final boolean applyNetworking, final boolean exportActive, final File exportBasePath,
+      final boolean exportGnpsActive, boolean exportSiriusActive,
+      boolean exportAnnotationGraphicsActive) {
     this();
     setParameter(minPearson, minPearsonCorrelation);
     setParameter(minCorrelatedPoints, minPoints);
+    setParameter(applySpectralNetworking, applyNetworking);
     setParameter(exportPath, exportActive);
     getParameter(exportPath).getEmbeddedParameter().setValue(exportBasePath);
     setParameter(exportGnps, exportGnpsActive);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/workflows/WorkflowDIA.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/subparameters/factories/workflows/WorkflowDIA.java
@@ -27,7 +27,7 @@ public class WorkflowDIA extends WorkflowWizardParameterFactory {
 
   @Override
   public WizardStepParameters create() {
-    return new WorkflowDiaWizardParameters(0.8, 5, true, null, true, true, false);
+    return new WorkflowDiaWizardParameters(0.8, 5, true, true, null, true, true, false);
   }
 
   @Override
@@ -49,7 +49,8 @@ public class WorkflowDIA extends WorkflowWizardParameterFactory {
 
     return switch (ionInterface.group()) {
       case CHROMATOGRAPHY_SOFT -> new WizardBatchBuilderLcDIA(steps);
-      case CHROMATOGRAPHY_HARD, SPATIAL_IMAGING, DIRECT_AND_FLOW -> throw new UnsupportedWorkflowException(steps);
+      case CHROMATOGRAPHY_HARD, SPATIAL_IMAGING, DIRECT_AND_FLOW ->
+          throw new UnsupportedWorkflowException(steps);
     };
   }
 


### PR DESCRIPTION
@SteffenHeu can you check if this makes sense to apply. 

This should only be required for IMS data but not for scans. Those are already filtered based on multiple criteria and therefore I dont filter based on precursor mz there. 