### PR TITLE
add batch check for raw files and flist parameter setting

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchQueueParameter.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchQueueParameter.java
@@ -156,7 +156,7 @@ public class BatchQueueParameter implements UserParameter<BatchQueue, AnchorPane
 
       // do meta checks through all parameters
       // check min samples filter
-      String warning = BatchUtils.checkMinSamplesFilter(value);
+      String warning = BatchUtils.checkBatchParameters(value);
       if (warning != null) {
         if (DesktopService.isGUI()) {
           final boolean continueAnyway = DialogLoggerUtil.showDialogYesNo("Warning", """


### PR DESCRIPTION
In case the feature list or raw file selection is all over the place for batches. If the first steps (e.g. if files are already imported) are something different than "last batch" but all consecutive are, no warning is shown, as that is a common case. Only if it happens in the middle of the batch

![grafik](https://github.com/user-attachments/assets/4b661cbe-44fe-44d6-802a-8acf2d1241e7)
