### PR TITLE
IonTimeSeries.subseries use copy of scans or a sublist view

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/IonTimeSeries.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/IonTimeSeries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -32,6 +32,7 @@ import io.github.mzmine.datamodel.featuredata.impl.SimpleIonTimeSeries;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.collections.BinarySearch;
 import io.github.mzmine.util.collections.IndexRange;
+import java.util.ArrayList;
 import java.util.List;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -95,7 +96,12 @@ public interface IonTimeSeries<T extends Scan> extends IonSpectrumSeries<T>, Int
     if (endIndexExclusive - startIndexInclusive <= 0) {
       return emptySeries();
     }
-    return subSeries(storage, getSpectra().subList(startIndexInclusive, endIndexExclusive));
+
+    // do not use sublist for now as it keeps the original list alive.
+    // TODO think about using this fact to just having one list of scans with continuos sublists
+    // like having one MemorySegment for chromatogram and then just save the index ranges of scans for resolved features.
+    List<T> scans = new ArrayList<>(getSpectra().subList(startIndexInclusive, endIndexExclusive));
+    return subSeries(storage, scans);
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilogramTimeSeries.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilogramTimeSeries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -231,15 +231,17 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
       return IonMobilogramTimeSeries.EMPTY;
     }
 
-    final List<IonMobilitySeries> mobilograms = this.mobilograms.subList(startIndexInclusive,
-        endIndexExclusive);
+    final List<IonMobilitySeries> mobilograms = new ArrayList<>(
+        this.mobilograms.subList(startIndexInclusive, endIndexExclusive));
     mobilogramBinning.setMobilogram(mobilograms);
+
+    // do not use sublist for now as it keeps the original list alive.
+    List<Frame> sublist = new ArrayList<>(frames.subList(startIndexInclusive, endIndexExclusive));
 
     return new SimpleIonMobilogramTimeSeries(
         StorageUtils.sliceDoubles(mzValues, startIndexInclusive, endIndexExclusive),
         StorageUtils.sliceDoubles(intensityValues, startIndexInclusive, endIndexExclusive), storage,
-        mobilograms, frames.subList(startIndexInclusive, endIndexExclusive),
-        mobilogramBinning.toSummedMobilogram(storage));
+        mobilograms, sublist, mobilogramBinning.toSummedMobilogram(storage));
   }
 
   @Override
@@ -314,7 +316,7 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
 
 
   private boolean checkRawFileIntegrity(@NotNull List<IonMobilitySeries> mobilograms) {
-    if(mobilograms.isEmpty()) {
+    if (mobilograms.isEmpty()) {
       return true;
     }
     RawDataFile file = null;
@@ -388,7 +390,7 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
         that.frames) && contentEquals(intensityValues, that.intensityValues) && contentEquals(
         mzValues, that.mzValues) && Objects.equals(getSummedMobilogram(),
         that.getSummedMobilogram()) && contentEquals(mobilogramMzValues, that.mobilogramMzValues)
-        && contentEquals(mobilogramIntensityValues, that.mobilogramIntensityValues);
+           && contentEquals(mobilogramIntensityValues, that.mobilogramIntensityValues);
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonTimeSeries.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonTimeSeries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -40,6 +40,7 @@ import io.github.mzmine.util.DataPointUtils;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.ParsingUtils;
 import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -186,10 +187,13 @@ public class SimpleIonTimeSeries implements IonTimeSeries<Scan> {
   public IonTimeSeries<Scan> subSeries(MemoryMapStorage storage, int startIndexInclusive,
       int endIndexExclusive) {
 
+    // better create copy - sublist keeps original list alive
+    List<? extends Scan> sublist = new ArrayList<>(
+        scans.subList(startIndexInclusive, endIndexExclusive));
     return new SimpleIonTimeSeries(
         StorageUtils.sliceDoubles(mzValues, startIndexInclusive, endIndexExclusive),
         StorageUtils.sliceDoubles(intensityValues, startIndexInclusive, endIndexExclusive),
-        scans.subList(startIndexInclusive, endIndexExclusive));
+        sublist);
   }
 
   @Override
@@ -257,7 +261,7 @@ public class SimpleIonTimeSeries implements IonTimeSeries<Scan> {
       return false;
     }
     return Objects.equals(scans, that.scans) && IntensitySeries.seriesSubsetEqual(this, that)
-        && MzSeries.seriesSubsetEqual(this, that);
+           && MzSeries.seriesSubsetEqual(this, that);
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulapredictionfeaturelist/FormulaPredictionFeatureListTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/id_formulapredictionfeaturelist/FormulaPredictionFeatureListTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -244,8 +244,10 @@ public class FormulaPredictionFeatureListTask extends AbstractTask {
       if (!resultingFormulas.isEmpty()) {
         FormulaUtils.sortFormulaList(resultingFormulas, sortPPMFactor, sortIsotopeFactor,
             sortMSMSFactor);
-        row.setFormulas(resultingFormulas.subList(0,
+        // do not set sublist directly as this will keep the original full list
+        var topNFormulas = new ArrayList<>(resultingFormulas.subList(0,
             Math.min(resultingFormulas.size(), maxBestFormulasPerFeature)));
+        row.setFormulas(topNFormulas);
       }
 
       if (isCanceled()) {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/fraggraphdashboard/fraggraph/FragmentUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/fraggraphdashboard/fraggraph/FragmentUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -143,7 +143,7 @@ public class FragmentUtils {
       final IndexRange indexRange = BinarySearch.indexRange(
           fragmentFormulaTol.getToleranceRange(signal.getMZ()), subFormulae,
           FormulaWithExactMz::mz);
-      peaksWithFormulae.add(new SignalWithFormulae(signal, indexRange.sublist(subFormulae)));
+      peaksWithFormulae.add(new SignalWithFormulae(signal, indexRange.sublist(subFormulae, true)));
     }
     return peaksWithFormulae;
   }

--- a/utils/src/main/java/io/github/mzmine/util/collections/IndexRange.java
+++ b/utils/src/main/java/io/github/mzmine/util/collections/IndexRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -176,7 +176,21 @@ public sealed interface IndexRange permits EmptyIndexRange, SimpleIndexRange, Si
    * Create a sublist view that contains this IndexRange
    */
   default <T> List<T> sublist(List<T> data) {
-    return isEmpty() ? List.of() : data.subList(min(), maxExclusive());
+    return sublist(data, false);
+  }
+
+  /**
+   * Create a sublist view or copy that contains this IndexRange
+   *
+   * @param createCopy if true then create a copy instead of a view. use copy if original list may
+   *                   be garbage collected but view will disrupt this
+   */
+  default <T> List<T> sublist(List<T> data, final boolean createCopy) {
+    if (isEmpty()) {
+      return List.of();
+    }
+    List<T> view = data.subList(min(), maxExclusive());
+    return createCopy ? new ArrayList<>(view) : view;
   }
 
   /**


### PR DESCRIPTION
IonTimeSeries.subseries used to just do list.sublist which creates a view and keeps the original list alive. This could lead to a chromatogram.getScans list to be kept alive by sub features. 

However, FeatureResolverTask already uses a FeatureFullDataAccess  that uses a single scans list. This was actually beneficial memory wise as all features from the same sample use the same backing list to create sublists, saving memory.