### PR TITLE
make FeatureList.getRawDataFiles unmodifiable

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/FeatureList.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/FeatureList.java
@@ -164,7 +164,7 @@ public interface FeatureList {
   /**
    * Returns all raw data files participating in the feature list
    */
-  public ObservableList<RawDataFile> getRawDataFiles();
+  public List<RawDataFile> getRawDataFiles();
 
   /**
    * Returns true if this feature list contains given file

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/FeatureListRow.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/FeatureListRow.java
@@ -57,7 +57,7 @@ import org.jetbrains.annotations.Nullable;
 public interface FeatureListRow extends ModularDataModel {
 
   /**
-   * Return raw data with features on this row
+   * Return unmodifiable list of all raw data files in this feature list even those without detection in this row
    */
   List<RawDataFile> getRawDataFiles();
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureList.java
@@ -55,6 +55,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.DoubleSummaryStatistics;
@@ -99,7 +100,8 @@ public class ModularFeatureList implements FeatureList {
   private final Map<DataType<?>, List<DataTypeValueChangeListener<?>>> rowTypeListeners = new HashMap<>();
 
   // unmodifiable list
-  private final ObservableList<RawDataFile> dataFiles;
+  private final List<RawDataFile> dataFiles;
+  private final List<RawDataFile> readOnlyRawDataFiles; // keep one copy in case it is used somewhere
   private final ObservableMap<RawDataFile, List<? extends Scan>> selectedScans;
 
   private NodeGenerationThread nodeThread;
@@ -147,7 +149,8 @@ public class ModularFeatureList implements FeatureList {
     dataFiles = new ArrayList<>(dataFiles);
     dataFiles.sort(Comparator.comparing(RawDataFile::getName));
     ((ArrayList) dataFiles).trimToSize();
-    this.dataFiles = FXCollections.observableList(dataFiles);
+    this.dataFiles = dataFiles;
+    this.readOnlyRawDataFiles = Collections.unmodifiableList(dataFiles);
     featureListRows = FXCollections.observableArrayList();
     descriptionOfAppliedTasks = FXCollections.observableArrayList();
     dateCreated = DATA_FORMAT.format(new Date());
@@ -423,11 +426,11 @@ public class ModularFeatureList implements FeatureList {
   /**
    * Returns all raw data files participating in the alignment
    *
-   * @return the raw data files for this list
+   * @return an unmodifiable list raw data files for this list
    */
   @Override
-  public ObservableList<RawDataFile> getRawDataFiles() {
-    return dataFiles;
+  public List<RawDataFile> getRawDataFiles() {
+    return readOnlyRawDataFiles;
   }
 
   @Override
@@ -544,7 +547,7 @@ public class ModularFeatureList implements FeatureList {
           "Can not add non-modular feature list row to modular feature list");
     }
 
-    ObservableList<RawDataFile> myFiles = this.getRawDataFiles();
+    List<RawDataFile> myFiles = this.getRawDataFiles();
     for (RawDataFile testFile : modularRow.getRawDataFiles()) {
       if (!myFiles.contains(testFile)) {
         throw (new IllegalArgumentException(

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/ModularFeatureListRow.java
@@ -331,8 +331,12 @@ public class ModularFeatureListRow implements FeatureListRow {
     return get(AreaType.class);
   }
 
+  /**
+   *
+   * @return unmodifiable list of all raw data files - even if there is no feature
+   */
   @Override
-  public ObservableList<RawDataFile> getRawDataFiles() {
+  public List<RawDataFile> getRawDataFiles() {
     return flist.getRawDataFiles();
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/id_lipidid/annotation_modules/LipidAnnotationTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/id_lipidid/annotation_modules/LipidAnnotationTask.java
@@ -234,7 +234,7 @@ public class LipidAnnotationTask extends AbstractTask {
   @NotNull
   private Set<PolarityType> getPolarityTypes() {
     Set<PolarityType> polarityTypes = new HashSet<>();
-    ObservableList<RawDataFile> rawDataFiles = featureList.getRawDataFiles();
+    List<RawDataFile> rawDataFiles = featureList.getRawDataFiles();
     for (RawDataFile raw : rawDataFiles) {
       List<PolarityType> dataPolarity = raw.getDataPolarity();
       polarityTypes.addAll(dataPolarity);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectload/version_3_0/FeatureListLoadTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectload/version_3_0/FeatureListLoadTask.java
@@ -53,6 +53,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -188,6 +189,7 @@ public class FeatureListLoadTask extends AbstractTask {
         }
         parseFeatureList(storage, project, flist, flistFile);
 
+        // TODO maybe remove so that ModularFeatureList.getFeatureList can be unmodifiable
         // disable buffering after the import (replace references to CachedIMSRawDataFiles with IMSRawDataFiles
         flist.replaceCachedFilesAndScans();
 
@@ -339,8 +341,8 @@ public class FeatureListLoadTask extends AbstractTask {
       NodeList filesList = ((Element) nodelist.item(0))
           .getElementsByTagName(CONST.XML_RAW_FILE_ELEMENT);
 
-      // set selected scans - use LinkedHashMap to retain order
-      Map<RawDataFile, List<Scan>> selectedScansMap = new LinkedHashMap<>();
+      // order of raw files is not important. Will be sorted in feature list by name
+      Map<RawDataFile, List<Scan>> selectedScansMap = new HashMap<>();
       for (int i = 0; i < filesList.getLength(); i++) {
         NodeList nameList = ((Element) filesList.item(i))
             .getElementsByTagName(CONST.XML_RAW_FILE_NAME_ELEMENT);

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/FeaturesComponent.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/FeaturesComponent.java
@@ -98,7 +98,7 @@ public class FeaturesComponent extends HBox {
         if (featureList == null) {
           return;
         }
-        dataFilesCombo.setItems(featureList.getRawDataFiles());
+        dataFilesCombo.setItems(FXCollections.observableList(featureList.getRawDataFiles()));
         dataFilesCombo.getSelectionModel().selectFirst();
       });
       dataFilesCombo.setOnAction(e3 -> {

--- a/mzmine-community/src/main/java/io/github/mzmine/util/CorrelationGroupingUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/CorrelationGroupingUtils.java
@@ -89,7 +89,7 @@ public class CorrelationGroupingUtils {
       HashMap<FeatureListRow, RowGroup> used = new HashMap<>();
 
       int c = 0;
-      ObservableList<RawDataFile> raw = flist.getRawDataFiles();
+      List<RawDataFile> raw = flist.getRawDataFiles();
       // add all connections
       for (Entry<Integer, RowsRelationship> e : corrMap.entrySet()) {
         RowsRelationship r2r = e.getValue();


### PR DESCRIPTION
@SteffenHeu this changes getRawDataFiles to unmodifiable list.
ProjectLoadTask did not add the raw data files initially but then later. I think it is good if we enforce that RawDataFiles are provided during featurelist creation and that they dont change. 
This is actually already the case just in project load the order was create feature list and then add data files.