### PR TITLE
Bugfix: added a check to stop empty features during GC alignment

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/align_common/BaseFeatureListAligner.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/align_common/BaseFeatureListAligner.java
@@ -135,9 +135,15 @@ public class BaseFeatureListAligner {
           final RawDataFile dataFile = feature.getRawDataFile();
           if (!alignedRow.hasFeature(dataFile)) {
             var newFeature = featureCloner.cloneFeature(feature, alignedFeatureList, alignedRow);
-            alignedRow.addFeature(dataFile, newFeature, false);
-            alignedRowsMap.put(row, true);
-            alignedRows.getAndIncrement();
+            if (newFeature.getMZ() != 0) {
+              // For GC-MS, ExtractMzMismatchFeatureCloner may search in raw data files for a closer ion series
+              // if no masses are found in range, MZ = 0 and we skip this
+
+              // Otherwise, add feature to aligned row, skip this file for it in the future
+              alignedRow.addFeature(dataFile, newFeature, true);
+              alignedRowsMap.put(row, true);
+              alignedRows.getAndIncrement();
+            }
           }
         }
       }


### PR DESCRIPTION
See comments for a description of the bug. I would have had the cloner return null, but it's guaranteed to return non-null and I didn't want to mess with the interface, since that might require changes elsewhere.

I also reenabled row bindings here. It probably slows things down, but I've been getting incorrect exported results -- particularly, average MZ for the row.