### PR TITLE
GNPS GC exports

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_mgf/AdapMgfExportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_mgf/AdapMgfExportTask.java
@@ -27,6 +27,7 @@ package io.github.mzmine.modules.io.export_features_mgf;
 
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.IsotopePattern;
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.main.MZmineCore;
@@ -168,7 +169,7 @@ public class AdapMgfExportTask extends AbstractTask {
 
   private void exportFeatureList(FeatureList featureList, FileWriter writer) throws IOException {
     for (FeatureListRow row : featureList.getRows()) {
-      IsotopePattern ip = row.getBestIsotopePattern();
+      Scan ip = row.getMostIntenseFragmentScan();
       if (ip == null) {
         continue;
       }
@@ -179,7 +180,7 @@ public class AdapMgfExportTask extends AbstractTask {
     }
   }
 
-  private void exportRow(FileWriter writer, FeatureListRow row, IsotopePattern ip)
+  private void exportRow(FileWriter writer, FeatureListRow row, Scan ip)
       throws IOException {
     // data points of this cluster
     DataPoint dataPoints[] = ScanUtils.extractDataPoints(ip);
@@ -199,6 +200,8 @@ public class AdapMgfExportTask extends AbstractTask {
     // needs to be MSLEVEL=2 for GC-GNPS (even for GC-EI-MS data)
     writer.write("MSLEVEL=2" + newLine);
     writer.write("CHARGE=1+" + newLine);
+    writer.write("Num peaks="+ dataPoints.length + newLine);
+
 
     for (DataPoint point : dataPoints) {
       String line = formatMZ(point.getMZ()) + " " + intensityForm.format(point.getIntensity());

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/BaseWizardBatchBuilder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/BaseWizardBatchBuilder.java
@@ -390,7 +390,7 @@ public abstract class BaseWizardBatchBuilder extends WizardBatchBuilder {
       makeAndAddProjectMetadataExport(q, exportPath);
 
       if (exportGnps) {
-        makeAndAddIimnGnpsExportStep(q, exportPath, mzTolScans);
+        makeAndAddIimnGnpsExportStep(q, exportPath, mzTolScans, "_iimn_gnps");
       }
       if (exportSirius) {
         makeAndAddSiriusExportStep(q, exportPath);
@@ -443,11 +443,11 @@ public abstract class BaseWizardBatchBuilder extends WizardBatchBuilder {
   }
 
   protected static void makeAndAddIimnGnpsExportStep(final BatchQueue q, final File exportPath,
-      final MZTolerance mzTolScans) {
+      final MZTolerance mzTolScans, final String fileNameSuffix) {
     final ParameterSet param = new GnpsFbmnExportAndSubmitParameters().cloneParameterSet();
 
     File fileName = FileAndPathUtil.eraseFormat(exportPath);
-    fileName = new File(fileName.getParentFile(), fileName.getName() + "_iimn_gnps");
+    fileName = new File(fileName.getParentFile(), fileName.getName() + fileNameSuffix);
 
     param.setParameter(GnpsFbmnExportAndSubmitParameters.FEATURE_LISTS,
         new FeatureListsSelection(FeatureListsSelectionType.BATCH_LAST_FEATURELISTS));

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/WizardBatchBuilderGcEiDeconvolution.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/WizardBatchBuilderGcEiDeconvolution.java
@@ -294,21 +294,7 @@ public class WizardBatchBuilderGcEiDeconvolution extends BaseWizardBatchBuilder 
 
 
   protected void makeAndAddGnpsExportStep(final BatchQueue q) {
-    final ParameterSet param = new GnpsGcExportAndSubmitParameters().cloneParameterSet();
-
-    File fileName = FileAndPathUtil.eraseFormat(exportPath);
-    fileName = new File(fileName.getParentFile(), fileName.getName() + "_gc_ei_gnps");
-    param.setParameter(GnpsGcExportAndSubmitParameters.FEATURE_LISTS,
-        new FeatureListsSelection(FeatureListsSelectionType.BATCH_LAST_FEATURELISTS));
-    // going back into scans so rather use scan mz tol
-    param.setParameter(GnpsGcExportAndSubmitParameters.REPRESENTATIVE_MZ,
-        MzMode.AS_IN_FEATURE_TABLE);
-    param.setParameter(GnpsGcExportAndSubmitParameters.OPEN_FOLDER, false);
-    param.setParameter(GnpsGcExportAndSubmitParameters.FEATURE_INTENSITY, AbundanceMeasure.Area);
-    param.setParameter(GnpsGcExportAndSubmitParameters.FILENAME, fileName);
-
-    q.add(new MZmineProcessingStepImpl<>(
-        MZmineCore.getModuleInstance(GnpsGcExportAndSubmitModule.class), param));
+    makeAndAddIimnGnpsExportStep(q, exportPath, mzTolScans, "_gc_ei_gnps");
   }
 
   protected void makeAndAddMSPExportStep(final BatchQueue q) {
@@ -320,8 +306,8 @@ public class WizardBatchBuilderGcEiDeconvolution extends BaseWizardBatchBuilder 
     param.setParameter(AdapMspExportParameters.FEATURE_LISTS,
         new FeatureListsSelection(FeatureListsSelectionType.BATCH_LAST_FEATURELISTS));
     param.setParameter(AdapMspExportParameters.FILENAME, fileName);
-    param.setParameter(AdapMspExportParameters.ADD_RET_TIME, true);
-    param.setParameter(AdapMspExportParameters.ADD_ANOVA_P_VALUE, true);
+    param.setParameter(AdapMspExportParameters.ADD_RET_TIME, true, "RT");
+    param.setParameter(AdapMspExportParameters.ADD_ANOVA_P_VALUE, true, "ANOVA_P_VALUE");
     param.setParameter(AdapMspExportParameters.INTEGER_MZ, false);
 
     q.add(new MZmineProcessingStepImpl<>(MZmineCore.getModuleInstance(AdapMspExportModule.class),


### PR DESCRIPTION
- use PseudoSpectrum in ADAP mgf and msp export
- use the LC-MS export for GNPS also for GC (allows merging of spectra)

Maybe we should remove the GNPS GC-MS export? And maybe also the ADAP msp and mgf export. They may be exchanged with the Export scans (feature) module - maybe build a wrapper module with simpler parameters for GC-EI-MS export
