### PR TITLE
Make TIC plot faster, avoid freeze

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/ChartLogicsFX.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/ChartLogicsFX.java
@@ -39,8 +39,12 @@ import org.jfree.chart.entity.ChartEntity;
 import org.jfree.chart.entity.EntityCollection;
 import org.jfree.chart.fx.ChartCanvas;
 import org.jfree.chart.fx.ChartViewer;
+import org.jfree.chart.plot.CategoryPlot;
+import org.jfree.chart.plot.CombinedDomainCategoryPlot;
 import org.jfree.chart.plot.CombinedDomainXYPlot;
+import org.jfree.chart.plot.CombinedRangeCategoryPlot;
 import org.jfree.chart.plot.CombinedRangeXYPlot;
+import org.jfree.chart.plot.Plot;
 import org.jfree.chart.plot.PlotRenderingInfo;
 import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.plot.Zoomable;
@@ -597,6 +601,82 @@ public class ChartLogicsFX {
       chart.getXYPlot().getRangeAxis().setLowerMargin(margin);
     } catch (Exception ex) {
       // ignore as it only fails for combined plots or non XY plots
+    }
+  }
+
+  /**
+   * Set all axis of this chart to auto range or not when data is added. Auto range on axis is very
+   * slow if many datasets are added
+   *
+   * @param state auto range on of off
+   */
+  public static void setAutoRangeAxis(final JFreeChart chart, final boolean state) {
+    setAutoRangeAxis(chart.getPlot(), state);
+  }
+
+  public static void setAutoRangeAxis(final Plot plot, final boolean state) {
+    switch (plot) {
+      case CombinedDomainXYPlot cp -> {
+        for (final Object sub : cp.getSubplots()) {
+          if (sub instanceof Plot p) {
+            setAutoRangeAxis(p, state);
+          }
+        }
+        for (int i = 0; i < cp.getRangeAxisCount(); i++) {
+          cp.getRangeAxis(i).setAutoRange(state);
+        }
+        for (int i = 0; i < cp.getDomainAxisCount(); i++) {
+          cp.getDomainAxis(i).setAutoRange(state);
+        }
+      }
+      case CombinedRangeXYPlot cp -> {
+        for (final Object sub : cp.getSubplots()) {
+          if (sub instanceof Plot p) {
+            setAutoRangeAxis(p, state);
+          }
+        }
+        for (int i = 0; i < cp.getRangeAxisCount(); i++) {
+          cp.getRangeAxis(i).setAutoRange(state);
+        }
+        for (int i = 0; i < cp.getDomainAxisCount(); i++) {
+          cp.getDomainAxis(i).setAutoRange(state);
+        }
+      }
+      case CombinedRangeCategoryPlot cp -> {
+        for (final Object sub : cp.getSubplots()) {
+          if (sub instanceof Plot p) {
+            setAutoRangeAxis(p, state);
+          }
+        }
+        for (int i = 0; i < cp.getRangeAxisCount(); i++) {
+          cp.getRangeAxis(i).setAutoRange(state);
+        }
+      }
+      case CombinedDomainCategoryPlot cp -> {
+        for (final Object sub : cp.getSubplots()) {
+          if (sub instanceof Plot p) {
+            setAutoRangeAxis(p, state);
+          }
+        }
+        for (int i = 0; i < cp.getRangeAxisCount(); i++) {
+          cp.getRangeAxis(i).setAutoRange(state);
+        }
+      }
+      case XYPlot p -> {
+        for (int i = 0; i < p.getRangeAxisCount(); i++) {
+          p.getRangeAxis(i).setAutoRange(state);
+        }
+        for (int i = 0; i < p.getDomainAxisCount(); i++) {
+          p.getDomainAxis(i).setAutoRange(state);
+        }
+      }
+      case CategoryPlot p -> {
+        for (int i = 0; i < p.getRangeAxisCount(); i++) {
+          p.getRangeAxis(i).setAutoRange(state);
+        }
+      }
+      case null, default -> {
+      }
     }
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/ChartLogicsFX.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/ChartLogicsFX.java
@@ -80,7 +80,7 @@ public class ChartLogicsFX {
    * @param myChart
    * @param mouseX
    * @param mouseY
-   * @return Range as chart coordinates (never null)
+   * @return Range as chart coordinates
    */
   public static Point2D mouseXYToPlotXY(ChartViewer myChart, int mouseX, int mouseY) {
     XYPlot plot = null;
@@ -94,6 +94,10 @@ public class ChartLogicsFX {
     }
 
     ChartRenderingInfo info = myChart.getRenderingInfo();
+    if (info == null) {
+      return null; // this should not happen if there is actually a mouse event on the chart. musst be renedered first.
+    }
+
     int subplot = info.getPlotInfo().getSubplotIndex(new Point2D.Double(mouseX, mouseY));
     Rectangle2D dataArea = info.getPlotInfo().getDataArea();
     if (subplot != -1) {
@@ -505,7 +509,8 @@ public class ChartLogicsFX {
     if (plot instanceof Zoomable) {
       Zoomable z = plot;
       Point2D endPoint = new Point2D.Double(0, 0);
-      PlotRenderingInfo pri = myChart.getRenderingInfo().getPlotInfo();
+      // nullable but ok here
+      PlotRenderingInfo pri = getPlotRenderingInfo(myChart);
       boolean saved = plot.isNotify();
       plot.setNotify(false);
       z.zoomDomainAxes(0, pri, endPoint);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/chromatogram/FeatureDataSet.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/chromatogram/FeatureDataSet.java
@@ -52,6 +52,7 @@ public class FeatureDataSet extends AbstractXYDataset {
   private final double[] mzValues;
   private final String name;
   private final int featureItem;
+  private final String seriesKey;
 
   /**
    * Create the data set.
@@ -60,9 +61,9 @@ public class FeatureDataSet extends AbstractXYDataset {
    * @param id peak identity to use as a label.
    */
   public FeatureDataSet(final Feature p, final String id) {
-
     feature = p;
     name = id;
+    seriesKey = FeatureUtils.featureToString(feature);
 
     final List<Scan> scanNumbers = feature.getScanNumbers();
     final RawDataFile dataFile = feature.getRawDataFile();
@@ -121,7 +122,7 @@ public class FeatureDataSet extends AbstractXYDataset {
 
   @Override
   public Comparable<?> getSeriesKey(final int series) {
-    return FeatureUtils.featureToString(feature);
+    return seriesKey;
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICDataSet.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICDataSet.java
@@ -122,8 +122,12 @@ public class TICDataSet extends AbstractTaskXYZDataset {
 
     this.plotType = plotType;
 
+    // this will call to many update events if many datasets are added
     // Start-up the refresh task.
-    MZmineCore.getTaskController().addTask(this, TaskPriority.HIGH);
+//    MZmineCore.getTaskController().addTask(this, TaskPriority.HIGH);
+
+    // directly calculate data
+    calculateValues();
   }
 
   /**
@@ -151,8 +155,12 @@ public class TICDataSet extends AbstractTaskXYZDataset {
 
     this.plotType = TICPlotType.TIC;
 
+    // this will call to many update events if many datasets are added
     // Start-up the refresh task.
-    MZmineCore.getTaskController().addTask(this, TaskPriority.HIGH);
+//    MZmineCore.getTaskController().addTask(this, TaskPriority.HIGH);
+
+    // directly calculate data
+    calculateValues();
   }
 
   public TICDataSet(RawDataFile newFile, Scan[] scans, Range<Double> mzRange,

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICPlot.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICPlot.java
@@ -225,6 +225,10 @@ public class TICPlot extends EChartViewer implements LabelColorMatch {
     }
   }
 
+  public int getDatasetCount() {
+    return plot.getDatasetCount();
+  }
+
 
   public void setLegendVisible(boolean state) {
     final LegendTitle legend = getChart().getLegend();

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICVisualizerTab.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/chromatogram/TICVisualizerTab.java
@@ -33,9 +33,12 @@ import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.gui.MZmineDesktop;
+import io.github.mzmine.gui.chartbasics.ChartLogicsFX;
 import io.github.mzmine.gui.chartbasics.JFreeChartUtils;
 import io.github.mzmine.gui.mainwindow.MZmineTab;
+import io.github.mzmine.javafx.util.FxIconUtil;
 import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.dataprocessing.featdet_masscalibration.charts.ChartUtils;
 import io.github.mzmine.modules.visualization.spectra.simplespectra.SpectraVisualizerModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
@@ -43,7 +46,6 @@ import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.SimpleSorter;
 import io.github.mzmine.util.dialogs.AxesSetupDialog;
-import io.github.mzmine.javafx.util.FxIconUtil;
 import java.awt.BasicStroke;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
@@ -84,16 +86,16 @@ import org.jfree.chart.renderer.xy.XYLineAndShapeRenderer;
 public class TICVisualizerTab extends MZmineTab {
 
   // Icons.
-  private static final Image SHOW_SPECTRUM_ICON =
-      FxIconUtil.loadImageFromResources("icons/spectrumicon.png");
-  private static final Image DATA_POINTS_ICON =
-      FxIconUtil.loadImageFromResources("icons/datapointsicon.png");
-  private static final Image ANNOTATIONS_ICON =
-      FxIconUtil.loadImageFromResources("icons/annotationsicon.png");
+  private static final Image SHOW_SPECTRUM_ICON = FxIconUtil.loadImageFromResources(
+      "icons/spectrumicon.png");
+  private static final Image DATA_POINTS_ICON = FxIconUtil.loadImageFromResources(
+      "icons/datapointsicon.png");
+  private static final Image ANNOTATIONS_ICON = FxIconUtil.loadImageFromResources(
+      "icons/annotationsicon.png");
   private static final Image AXES_ICON = FxIconUtil.loadImageFromResources("icons/axesicon.png");
   private static final Image LEGEND_ICON = FxIconUtil.loadImageFromResources("icons/legendkey.png");
-  private static final Image BACKGROUND_ICON =
-      FxIconUtil.loadImageFromResources("icons/bgicon.png");
+  private static final Image BACKGROUND_ICON = FxIconUtil.loadImageFromResources(
+      "icons/bgicon.png");
 
   // CSV extension.
   private static final String CSV_EXTENSION = "*.csv";
@@ -166,13 +168,11 @@ public class TICVisualizerTab extends MZmineTab {
       }
     });
 
-
     Button datapointsBtn = new Button(null, new ImageView(DATA_POINTS_ICON));
     datapointsBtn.setTooltip(new Tooltip("Toggle displaying of data points"));
     datapointsBtn.setOnAction(e -> {
       ticPlot.switchDataPointsVisible();
     });
-
 
     Button annotationsBtn = new Button(null, new ImageView(ANNOTATIONS_ICON));
     annotationsBtn.setTooltip(new Tooltip("Toggle displaying of peak labels"));
@@ -180,12 +180,11 @@ public class TICVisualizerTab extends MZmineTab {
       ticPlot.switchItemLabelsVisible();
     });
 
-
     Button axesBtn = new Button(null, new ImageView(AXES_ICON));
     axesBtn.setTooltip(new Tooltip("Setup ranges for axes"));
+    final XYPlot plot = ticPlot.getXYPlot();
     axesBtn.setOnAction(e -> {
-      AxesSetupDialog dialog = new AxesSetupDialog(getTabPane().getScene().getWindow(),
-          ticPlot.getXYPlot());
+      AxesSetupDialog dialog = new AxesSetupDialog(getTabPane().getScene().getWindow(), plot);
       dialog.show();
     });
 
@@ -201,30 +200,43 @@ public class TICVisualizerTab extends MZmineTab {
       ticPlot.switchBackground();
     });
 
-    toolBar.getItems().addAll(showSpectrumBtn, datapointsBtn, annotationsBtn, axesBtn, legendBtn,
-        backgroundBtn);
+    toolBar.getItems()
+        .addAll(showSpectrumBtn, datapointsBtn, annotationsBtn, axesBtn, legendBtn, backgroundBtn);
     mainPane.setRight(toolBar);
 
-    // add all features
-    if (features != null) {
+    // avoid very long legends - check later how many datasets were added
+    ticPlot.setLegendVisible(false);
 
-      for (Feature feature : features) {
-        if (featureLabels != null && featureLabels.containsKey(feature)) {
+    ChartLogicsFX.setAutoRangeAxis(ticPlot.getChart(), false);
 
-          final String label = featureLabels.get(feature);
-          ticPlot.addLabelledPeakDataSet(new FeatureDataSet(feature, label), label);
+    ticPlot.applyWithNotifyChanges(false, () -> {
+      // add all features
+      if (features != null) {
+        for (Feature feature : features) {
+          if (featureLabels != null && featureLabels.containsKey(feature)) {
 
-        } else {
+            final String label = featureLabels.get(feature);
+            ticPlot.addLabelledPeakDataSet(new FeatureDataSet(feature, label), label);
 
-          ticPlot.addFeatureDataSet(new FeatureDataSet(feature));
+          } else {
+
+            ticPlot.addFeatureDataSet(new FeatureDataSet(feature));
+          }
         }
-      }
-    }
 
-    // add all data files
-    for (RawDataFile dataFile : dataFiles) {
-      addRawDataFile(dataFile);
-    }
+      }
+
+      // add all data files
+      for (RawDataFile dataFile : dataFiles) {
+        addRawDataFile(dataFile);
+      }
+
+      // only display if short enough. User can still activate the legend in the UI
+      if (ticPlot.getDatasetCount() < 50) {
+        ticPlot.setLegendVisible(true);
+      }
+    });
+
 
     // Add the Windows menu
 //    WindowsMenu.addWindowsMenu(mainScene);
@@ -232,8 +244,8 @@ public class TICVisualizerTab extends MZmineTab {
     // pack();
 
     // get the window settings parameter
-    ParameterSet paramSet =
-        MZmineCore.getConfiguration().getModuleParameters(ChromatogramVisualizerModule.class);
+    ParameterSet paramSet = MZmineCore.getConfiguration()
+        .getModuleParameters(ChromatogramVisualizerModule.class);
 //    WindowSettingsParameter settings =
 //        paramSet.getParameter(TICVisualizerParameters.WINDOWSETTINGSPARAMETER);
 
@@ -267,8 +279,8 @@ public class TICVisualizerTab extends MZmineTab {
           // Select or deselect dataset
           Font font = new Font("Helvetica", Font.BOLD, 11);
           BasicStroke stroke = new BasicStroke(4);
-          if (renderer.getDefaultLegendTextFont() != null
-              && renderer.getDefaultLegendTextFont().isBold()) {
+          if (renderer.getDefaultLegendTextFont() != null && renderer.getDefaultLegendTextFont()
+              .isBold()) {
             font = new Font("Helvetica", Font.PLAIN, 11);
             stroke = new BasicStroke(1);
           }
@@ -300,6 +312,7 @@ public class TICVisualizerTab extends MZmineTab {
       }
     });
 
+    ChartLogicsFX.autoAxes(ticPlot);
   }
 
   void updateTitle() {
@@ -340,8 +353,8 @@ public class TICVisualizerTab extends MZmineTab {
       }
     }
 
-    mainTitle.append(", m/z: " + mzFormat.format(mzRange.lowerEndpoint()) + " - "
-        + mzFormat.format(mzRange.upperEndpoint()));
+    mainTitle.append(", m/z: " + mzFormat.format(mzRange.lowerEndpoint()) + " - " + mzFormat.format(
+        mzRange.upperEndpoint()));
 
     ChromatogramCursorPosition pos = getCursorPosition();
 
@@ -362,8 +375,9 @@ public class TICVisualizerTab extends MZmineTab {
     RawDataFile files[] = ticDataSets.keySet().toArray(new RawDataFile[0]);
     Arrays.sort(files, new SimpleSorter());
     String dataFileNames = Joiner.on(",").join(files);
-    setText("Chromatogram: [" + dataFileNames + "; " + mzFormat.format(mzRange.lowerEndpoint())
-        + " - " + mzFormat.format(mzRange.upperEndpoint()) + " m/z" + "]");
+    setText(
+        "Chromatogram: [" + dataFileNames + "; " + mzFormat.format(mzRange.lowerEndpoint()) + " - "
+        + mzFormat.format(mzRange.upperEndpoint()) + " m/z" + "]");
 
     // update plot title
     ticPlot.setTitle(mainTitle.toString(), subTitle.toString());
@@ -382,6 +396,7 @@ public class TICVisualizerTab extends MZmineTab {
   }
 
   /**
+   *
    */
   public void setRTRange(Range<Double> rtRange) {
     ticPlot.getXYPlot().getDomainAxis().setRange(rtRange.lowerEndpoint(), rtRange.upperEndpoint());
@@ -443,8 +458,7 @@ public class TICVisualizerTab extends MZmineTab {
   }
 
   @Override
-  public void onAlignedFeatureListSelectionChanged(
-      Collection<? extends FeatureList> featureLists) {
+  public void onAlignedFeatureListSelectionChanged(Collection<? extends FeatureList> featureLists) {
 
   }
 
@@ -496,8 +510,8 @@ public class TICVisualizerTab extends MZmineTab {
       final File exportFile = exportChooser.showSaveDialog(getTabPane().getScene().getWindow());
       if (exportFile != null) {
 
-        MZmineCore.getTaskController().addTask(new ExportChromatogramTask(dataSet, exportFile,
-            Instant.now()));
+        MZmineCore.getTaskController()
+            .addTask(new ExportChromatogramTask(dataSet, exportFile, Instant.now()));
       }
     }
   }
@@ -518,8 +532,7 @@ public class TICVisualizerTab extends MZmineTab {
           mz = dataSet.getZValue(0, index);
         }
         ChromatogramCursorPosition pos = new ChromatogramCursorPosition(selectedRT, mz, selectedIT,
-            dataSet.getDataFile(),
-            dataSet.getScan(index));
+            dataSet.getDataFile(), dataSet.getScan(index));
         return pos;
       }
     }
@@ -577,7 +590,6 @@ public class TICVisualizerTab extends MZmineTab {
     }
 
   }
-
 
 
   public TICPlot getTICPlot() {

--- a/mzmine-community/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/scans/ScanUtils.java
@@ -423,10 +423,11 @@ public class ScanUtils {
    * @return the total ion count of the scan within the mass range.
    */
   public static double calculateTIC(Scan scan, Range<Double> mzRange) {
+    final IndexRange indexRange = BinarySearch.indexRange(mzRange, scan.getNumberOfDataPoints(), scan::getMzValue);
 
     double tic = 0.0;
-    for (final DataPoint dataPoint : selectDataPointsByMass(extractDataPoints(scan), mzRange)) {
-      tic += dataPoint.getIntensity();
+    for (int i = indexRange.min(); i < indexRange.maxExclusive(); i++) {
+      tic += scan.getIntensityValue(i);
     }
     return tic;
   }


### PR DESCRIPTION
- auto range on axis was slowing down things
- disabling change listeners on plot and axes helped
- also added a new thread that triggers the creation of TICTab on a different thread - avoids freeze
- TICDataSet was calculated in Task and then pushed the updates triggering repaint - now just runs on the calling thread. 
- tested with 100 samples and 50 rows or so
- the Raw data overview also seems to be faster?