### PR TITLE
Reuse frame lists in resolver and IMS expanding

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/data_access/FeatureDetectedDataAccess.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/data_access/FeatureDetectedDataAccess.java
@@ -151,4 +151,9 @@ public class FeatureDetectedDataAccess extends FeatureDataAccess {
   public IonTimeSeries<Scan> emptySeries() {
     return featureData.emptySeries();
   }
+
+  @Override
+  public List<Scan> getSpectraModifiable() {
+    return featureData.getSpectraModifiable();
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/data_access/FeatureFullDataAccess.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/data_access/FeatureFullDataAccess.java
@@ -204,4 +204,9 @@ public class FeatureFullDataAccess extends FeatureDataAccess {
   public IonTimeSeries<Scan> emptySeries() {
     return featureData.emptySeries();
   }
+
+  @Override
+  public List<Scan> getSpectraModifiable() {
+    return allScans;
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/IonTimeSeries.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/IonTimeSeries.java
@@ -28,6 +28,7 @@ package io.github.mzmine.datamodel.featuredata;
 import com.google.common.collect.Range;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.featuredata.impl.ModifiableSpectra;
 import io.github.mzmine.datamodel.featuredata.impl.SimpleIonTimeSeries;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.collections.BinarySearch;
@@ -44,7 +45,8 @@ import org.jetbrains.annotations.Nullable;
  * @param <T>
  * @author https://github.com/SteffenHeu
  */
-public interface IonTimeSeries<T extends Scan> extends IonSpectrumSeries<T>, IntensityTimeSeries {
+public interface IonTimeSeries<T extends Scan> extends IonSpectrumSeries<T>, IntensityTimeSeries,
+    ModifiableSpectra<T> {
 
   SimpleIonTimeSeries EMPTY = new SimpleIonTimeSeries(null, new double[0], new double[0],
       List.of());

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/impl/IonMobilogramTimeSeriesFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/impl/IonMobilogramTimeSeriesFactory.java
@@ -69,6 +69,26 @@ public class IonMobilogramTimeSeriesFactory {
   public static IonMobilogramTimeSeries of(@Nullable MemoryMapStorage storage,
       @NotNull final List<IonMobilitySeries> mobilograms,
       @NotNull final BinningMobilogramDataAccess mobilogramBinning) {
+    return of(storage, mobilograms, mobilogramBinning, null);
+  }
+
+  /**
+   * Stores a list of mobilograms. A summed intensity of each mobilogram is automatically calculated
+   * and represents this series when plotted as a 2D intensity-vs time chart (accessed via
+   * {@link SimpleIonMobilogramTimeSeries#getMZ(int)} and
+   * {@link SimpleIonMobilogramTimeSeries#getIntensity(int)}). The mz representing a mobilogram is
+   * calculated by a weighted average based on the mzs in eah mobility scan.
+   *
+   * @param storage     May be null if values shall be stored in ram.
+   * @param mobilograms
+   * @param frames      the precomputed or original list of frames - if null the frames will be
+   *                    collected from the mobilograms
+   * @see IonSpectrumSeries#copyAndReplace(MemoryMapStorage, double[], double[])
+   */
+  public static IonMobilogramTimeSeries of(@Nullable MemoryMapStorage storage,
+      @NotNull final List<IonMobilitySeries> mobilograms,
+      @NotNull final BinningMobilogramDataAccess mobilogramBinning,
+      final @Nullable List<Frame> frames) {
 
     double[][] summedAndWeighted = sumIntensitiesWeightMzs(mobilograms);
 
@@ -76,7 +96,12 @@ public class IonMobilogramTimeSeriesFactory {
     final SummedIntensityMobilitySeries summedMobilogram = mobilogramBinning.toSummedMobilogram(
         storage);
 
-    return of(storage, summedAndWeighted[0], summedAndWeighted[1], mobilograms, summedMobilogram);
+    if (frames == null) {
+      return of(storage, summedAndWeighted[0], summedAndWeighted[1], mobilograms, summedMobilogram);
+    } else {
+      return of(storage, summedAndWeighted[0], summedAndWeighted[1], mobilograms, frames,
+          summedMobilogram);
+    }
   }
 
   public static IonMobilogramTimeSeries of(@Nullable MemoryMapStorage storage,
@@ -215,7 +240,7 @@ public class IonMobilogramTimeSeriesFactory {
 
   static MobilogramStorageResult storeMobilograms(SimpleIonMobilogramTimeSeries trace,
       @Nullable MemoryMapStorage storage, List<IonMobilitySeries> mobilograms) {
-    if(mobilograms.isEmpty()) {
+    if (mobilograms.isEmpty()) {
       return MobilogramStorageResult.EMPTY;
     }
 
@@ -251,7 +276,7 @@ public class IonMobilogramTimeSeriesFactory {
   private static MobilogramStorageResult storeMobilogramsFromAlreadyStored(
       SimpleIonMobilogramTimeSeries newTrace, MemoryMapStorage storage,
       List<StorableIonMobilitySeries> mobilograms) {
-    if(mobilograms.isEmpty()) {
+    if (mobilograms.isEmpty()) {
       return MobilogramStorageResult.EMPTY;
     }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilogramTimeSeries.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilogramTimeSeries.java
@@ -25,9 +25,6 @@
 
 package io.github.mzmine.datamodel.featuredata.impl;
 
-import static io.github.mzmine.datamodel.featuredata.impl.StorageUtils.contentEquals;
-import static io.github.mzmine.datamodel.featuredata.impl.StorageUtils.numDoubles;
-
 import com.google.common.collect.Comparators;
 import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.MobilityType;
@@ -39,6 +36,8 @@ import io.github.mzmine.datamodel.featuredata.IonMobilitySeries;
 import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
 import io.github.mzmine.datamodel.featuredata.IonSpectrumSeries;
 import io.github.mzmine.datamodel.featuredata.MzSeries;
+import static io.github.mzmine.datamodel.featuredata.impl.StorageUtils.contentEquals;
+import static io.github.mzmine.datamodel.featuredata.impl.StorageUtils.numDoubles;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.modules.dataprocessing.featdet_ionmobilitytracebuilder.IonMobilityTraceBuilderModule;
 import io.github.mzmine.modules.dataprocessing.featdet_mobilogram_summing.MobilogramBinningModule;
@@ -104,6 +103,11 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
       throw new IllegalArgumentException(
           "Length of mz, intensity, frames and/or mobilograms does not match.");
     }
+    if (mzs.length != frames.size()) {
+      throw new IllegalArgumentException(
+          "Length of data arrays and number of frames mismatch: %d to %d".formatted(mzs.length,
+              frames.size()));
+    }
     if (!checkRawFileIntegrity(mobilograms)) {
       throw new IllegalArgumentException("Cannot combine mobilograms of different raw data files.");
     }
@@ -145,10 +149,15 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
       MemorySegment intensityValues, @Nullable MemoryMapStorage storage,
       @NotNull List<IonMobilitySeries> mobilograms, @NotNull List<Frame> frames,
       @NotNull final SummedIntensityMobilitySeries summedMobilogram) {
-    if (mzValues.byteSize() != intensityValues.byteSize() || mobilograms.size() != numDoubles(
-        intensityValues)) {
+    final long numDataPoints = numDoubles(intensityValues);
+    if (mzValues.byteSize() != intensityValues.byteSize() || mobilograms.size() != numDataPoints) {
       throw new IllegalArgumentException(
           "Length of mz, intensity, frames and/or mobilograms does not match.");
+    }
+    if (numDataPoints != frames.size()) {
+      throw new IllegalArgumentException(
+          "Length of data arrays and number of frames mismatch: %d to %d".formatted(numDataPoints,
+              frames.size()));
     }
     if (!checkRawFileIntegrity(mobilograms)) {
       throw new IllegalArgumentException("Cannot combine mobilograms of different raw data files.");

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonTimeSeries.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonTimeSeries.java
@@ -25,8 +25,6 @@
 
 package io.github.mzmine.datamodel.featuredata.impl;
 
-import static io.github.mzmine.datamodel.featuredata.impl.StorageUtils.numDoubles;
-
 import com.google.common.collect.Comparators;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
@@ -34,6 +32,7 @@ import io.github.mzmine.datamodel.featuredata.IntensitySeries;
 import io.github.mzmine.datamodel.featuredata.IonSpectrumSeries;
 import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
 import io.github.mzmine.datamodel.featuredata.MzSeries;
+import static io.github.mzmine.datamodel.featuredata.impl.StorageUtils.numDoubles;
 import io.github.mzmine.modules.io.projectload.CachedIMSFrame;
 import io.github.mzmine.modules.io.projectload.version_3_0.CONST;
 import io.github.mzmine.util.DataPointUtils;
@@ -257,7 +256,7 @@ public class SimpleIonTimeSeries implements IonTimeSeries<Scan> {
       return false;
     }
     return Objects.equals(scans, that.scans) && IntensitySeries.seriesSubsetEqual(this, that)
-        && MzSeries.seriesSubsetEqual(this, that);
+           && MzSeries.seriesSubsetEqual(this, that);
   }
 
   @Override
@@ -268,5 +267,10 @@ public class SimpleIonTimeSeries implements IonTimeSeries<Scan> {
   @Override
   public IonTimeSeries<Scan> emptySeries() {
     return IonTimeSeries.EMPTY;
+  }
+
+  @Override
+  public List<Scan> getSpectraModifiable() {
+    return (List<Scan>) scans;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/AbstractResolver.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/AbstractResolver.java
@@ -26,6 +26,7 @@
 package io.github.mzmine.modules.dataprocessing.featdet_chromatogramdeconvolution;
 
 import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.Frame;
 import io.github.mzmine.datamodel.IMSRawDataFile;
 import io.github.mzmine.datamodel.MobilityScan;
 import io.github.mzmine.datamodel.RawDataFile;
@@ -47,6 +48,7 @@ import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.util.IonMobilityUtils;
 import io.github.mzmine.util.MemoryMapStorage;
+import io.github.mzmine.util.collections.CollectionUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -123,8 +125,11 @@ public abstract class AbstractResolver implements Resolver {
       setSeriesToMobilogramDataAccess(series);
       final List<Range<Double>> resolvedRanges = resolveMobility(mobilogramDataAccess);
 
+      List<Frame> oldFrames = originalTrace.getSpectraModifiable();
+
       // make a new sub series for each resolved range.
       for (Range<Double> resolvedRange : resolvedRanges) {
+        final List<Frame> actualFrames = new ArrayList<>();
         final List<IonMobilitySeries> resolvedMobilograms = new ArrayList<>();
         for (IonMobilitySeries mobilogram : originalTrace.getMobilograms()) {
           // split every mobilogram
@@ -136,13 +141,21 @@ public abstract class AbstractResolver implements Resolver {
           }
           // IonMobilitySeries are stored in ram until they are added to an IonMobilogramTimeSeries
           resolvedMobilograms.add((SimpleIonMobilitySeries) mobilogram.subSeries(null, subset));
+          actualFrames.add(mobilogram.getSpectra().getFirst().getFrame());
         }
         if (resolvedMobilograms.isEmpty()) {
           continue;
         }
 
+        // try reusing the old frames or a sublist of oldframes to save memory
+        // reusing the list might offer memory improvements by using the same sublist pointing to
+        // the scan in list in feature list
+        // not all frames may have data - use actualFrames if there are holes. Or use oldFrames.sublist if it is a continuous region
+        final List<Frame> unifiedFrames = CollectionUtils.asContinuousRegionSubListByIdentity(
+            actualFrames, oldFrames);
+
         resolved.add((T) IonMobilogramTimeSeriesFactory.of(storage, resolvedMobilograms,
-            getMobilogramDataAccess()));
+            getMobilogramDataAccess(), unifiedFrames));
       }
     } else {
       throw new IllegalStateException(

--- a/utils/src/main/java/io/github/mzmine/util/collections/CollectionUtils.java
+++ b/utils/src/main/java/io/github/mzmine/util/collections/CollectionUtils.java
@@ -37,6 +37,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Logger;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -47,6 +48,8 @@ import org.jetbrains.annotations.NotNull;
  * Collection API related utilities
  */
 public class CollectionUtils {
+
+  private static final Logger logger = Logger.getLogger(CollectionUtils.class.getName());
 
   /**
    * Map of the object to its index to avoid indexOf. This method will take any collection as input
@@ -327,5 +330,91 @@ public class CollectionUtils {
 
   public static @NotNull <T> Collector<T, ?, ArrayList<T>> toArrayList() {
     return Collectors.toCollection(ArrayList::new);
+  }
+
+  /**
+   * Both lists need the same sorting. Compares elements by identity (==)
+   *
+   * @param subRegion needs contained in master without holes or missing parts
+   * @param master    the main list that contains subRegion
+   * @return true if sub is a continuous region in master
+   */
+  public static boolean isContinuousRegionByIdentity(final List<?> subRegion,
+      final List<?> master) {
+    if (subRegion.isEmpty()) {
+      return true;
+    }
+
+    boolean startFound = false;
+    int subIndex = 0;
+    Object sub = subRegion.getFirst();
+
+    for (Object o : master) {
+      // once the objects are the same we start the region that should contain all of subRegion
+      // scans need to be the exact same instance
+      if (sub == o) {
+        startFound = true;
+        subIndex++;
+
+        if (subIndex == subRegion.size()) {
+          return startFound;
+        }
+        // check next
+        sub = subRegion.get(subIndex);
+      } else if (startFound) {
+        // mismatch between objects after start was found
+        return false;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Both lists need the same sorting. Compares elements by identity (==)
+   *
+   * @param subRegion needs contained in master without holes or missing parts
+   * @param master    the main list that contains subRegion
+   * @return sublist of master if subRegion is a continuous region in master. Or subRegion itself if
+   * not
+   */
+  public static <T> List<T> asContinuousRegionSubListByIdentity(final List<T> subRegion,
+      final List<T> master) {
+    if (subRegion.isEmpty()) {
+      return List.of();
+    }
+
+    int startIndex = -1;
+    int subIndex = 0;
+    Object sub = subRegion.getFirst();
+
+    for (int masterIndex = 0; masterIndex < master.size(); masterIndex++) {
+      final T o = master.get(masterIndex);
+      // once the objects are the same we start the region that should contain all of subRegion
+      // scans need to be the exact same instance
+      if (sub == o) {
+        if (startIndex == -1) {
+          startIndex = masterIndex;
+        }
+        subIndex++;
+
+        if (subIndex == subRegion.size()) {
+          masterIndex++;
+          assert (masterIndex - startIndex == subRegion.size());
+//          logger.fine("REUSING OLD MASTER LIST FOR IMS DATA");
+          if (master.size() == masterIndex - startIndex) {
+            return master;
+          }
+          return master.subList(startIndex, masterIndex);
+        }
+        // check next
+        sub = subRegion.get(subIndex);
+      } else if (startIndex != -1) {
+        // mismatch between objects after start was found
+        break;
+      }
+    }
+
+//    logger.fine("NEED TO USE NEW ARRAYLIST FOR FRAMES");
+    return subRegion;
   }
 }


### PR DESCRIPTION
This is linked to #2393 and may improve memory usage for IMS processing by reusing frame lists if they are a continuous sublist of the old frames list