### PR TITLE
add unknown imaging pattern and fix npe in image viewer

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_imzml/ImagingParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_imzml/ImagingParameters.java
@@ -181,6 +181,9 @@ public class ImagingParameters {
         lateralWidth = maxNumberOfPixelX * pixelWidth;
       }
     }
+    if(pattern == null) {
+      pattern = Pattern.UNKNOWN;
+    }
   }
 
   public double getMinMZ() {
@@ -410,7 +413,7 @@ public class ImagingParameters {
 
 
   public enum Pattern {
-    MEANDER("Meander"), FLY_BACK("Fly Back"), RANDOM("Random");
+    MEANDER("Meander"), FLY_BACK("Fly Back"), RANDOM("Random"), UNKNOWN("Unknown");
 
     final String name;
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/image/ImageVisualizerTab.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/image/ImageVisualizerTab.java
@@ -36,6 +36,7 @@ import io.github.mzmine.gui.mainwindow.MZmineTab;
 import io.github.mzmine.gui.preferences.MZminePreferences;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.io.import_rawdata_imzml.ImagingParameters;
+import io.github.mzmine.modules.io.import_rawdata_imzml.ImagingParameters.Pattern;
 import io.github.mzmine.modules.visualization.spectra.simplespectra.SpectraPlot;
 import io.github.mzmine.modules.visualization.spectra.simplespectra.SpectraVisualizerTab;
 import io.github.mzmine.parameters.ParameterSet;
@@ -47,6 +48,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.logging.Level;
 import javafx.fxml.FXMLLoader;
 import javafx.geometry.Pos;
@@ -307,7 +309,8 @@ public class ImageVisualizerTab extends MZmineTab {
     imagingPatternLabel.setAlignment(Pos.CENTER_LEFT);
     imagingParametersInfoPane.add(imagingPatternLabel, 0, 3);
 
-    Label imagingPatternValueLabel = new Label(imagingParameters.getPattern().getName());
+    Label imagingPatternValueLabel = new Label(
+        Objects.requireNonNullElse(imagingParameters.getPattern(), Pattern.UNKNOWN).getName());
     imagingPatternValueLabel.setAlignment(Pos.CENTER_LEFT);
     imagingParametersInfoPane.add(imagingPatternValueLabel, 1, 3);
 


### PR DESCRIPTION
johannes made a python tool which set the imaging pattern to ` <cvParam cvRef="IMS" accession="IMS:1000411" name="one way"/>` which does not exist in the imzml parser. it's techically a fly-back. to prevent similar issues, i added a UNKNOWN pattern and a fallback value in the imaging viewer.