### PR TITLE
Metadata table

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/MetadataRow.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/MetadataRow.java
@@ -1,0 +1,91 @@
+package io.github.mzmine.modules.visualization.projectmetadata;
+
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.javafx.dialogs.DialogLoggerUtil;
+import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTable;
+import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
+import java.util.logging.Logger;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.value.ObservableValue;
+import java.util.Objects;
+
+/**
+ * Represents a single row in the TableView, linked to a RawDataFile.
+ */
+public class MetadataRow {
+
+  private static final Logger logger = Logger.getLogger(MetadataRow.class.getName());
+
+  private final RawDataFile rawDataFile;
+  private final MetadataTable sourceTable; // Keep reference for updates
+
+  public MetadataRow(RawDataFile rawDataFile, MetadataTable sourceTable) {
+    Objects.requireNonNull(rawDataFile, "RawDataFile cannot be null");
+    Objects.requireNonNull(sourceTable, "Source MetadataTable cannot be null");
+    this.rawDataFile = rawDataFile;
+    this.sourceTable = sourceTable;
+  }
+
+  public RawDataFile getRawDataFile() {
+    return rawDataFile;
+  }
+
+  /**
+   * Gets an ObservableValue for a specific column in this row. This is used by the TableColumn's
+   * cellValueFactory.
+   *
+   * @param column The MetadataColumn definition.
+   * @return An ObservableValue containing the data for the cell.
+   */
+  public ObservableValue<String> getCellValueProperty(MetadataColumn<?> column) {
+    // We use SimpleStringProperty to wrap the value.
+    // It reads directly from the underlying sourceTable.
+    // NOTE: This doesn't automatically update if the underlying table changes
+    // externally. For full two-way binding *observability*, the underlying
+    // MetadataTable would need to support listeners, which is much more complex.
+    // This implementation focuses on displaying and *editing* via the TableView.
+    Object value = sourceTable.getValue(column, this.rawDataFile);
+    return new SimpleStringProperty(Objects.requireNonNullElse(value, "").toString());
+  }
+
+  /**
+   * Updates the value in the underlying MetadataTable for a specific column. This is typically
+   * called from the TableColumn's onEditCommit handler.
+   *
+   * @param column   The column being updated.
+   * @param newValue The new value from the TableView cell editor.
+   */
+  public <T> void updateValue(MetadataColumn<T> column, String newValue) {
+    // Perform type check/conversion if necessary before putting
+    T castedValue = column.convertOrElse(newValue, column.defaultValue());
+
+    // Update the underlying map
+    sourceTable.setValue(column, this.rawDataFile, castedValue);
+    logger.finest("Updated Model: [" + rawDataFile.getName() + ", " + column.getTitle() + "] = "
+        + castedValue); // For debugging
+  }
+
+  // equals/hashCode based on the unique identifier RawDataFile
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MetadataRow that = (MetadataRow) o;
+    return Objects.equals(rawDataFile, that.rawDataFile);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(rawDataFile);
+  }
+
+  @Override
+  public String toString() {
+    return "MetadataRow{" + "rawDataFile=" + rawDataFile + '}';
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/MetadataTableModel.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/MetadataTableModel.java
@@ -1,0 +1,193 @@
+package io.github.mzmine.modules.visualization.projectmetadata;
+
+import static io.github.mzmine.util.StringUtils.inQuotes;
+
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.javafx.dialogs.DialogLoggerUtil;
+import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTable;
+import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.control.cell.TextFieldTableCell;
+import javafx.util.StringConverter;
+
+
+import java.util.*;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Model/Wrapper for displaying a MetadataTable in a JavaFX TableView. Handles row creation, column
+ * definition, data access, and updates.
+ */
+public class MetadataTableModel {
+
+  private final MetadataTable metadataTable;
+  private final TableView<MetadataRow> tableView;
+
+  public MetadataTableModel(MetadataTable metadataTable, TableView<MetadataRow> tableView) {
+    this.tableView = tableView;
+    Objects.requireNonNull(metadataTable, "MetadataTable cannot be null");
+    this.metadataTable = metadataTable;
+
+    createAndSetExistingColumns();
+  }
+
+  private void addRows(MetadataTable metadataTable, TableView<MetadataRow> tableView) {
+    // 2. Determine the unique rows (gather all unique RawDataFile keys)
+    Set<RawDataFile> uniqueFiles = metadataTable.getData().values().stream()
+        .flatMap(innerMap -> innerMap.keySet().stream()).collect(Collectors.toSet());
+
+    // 3. Create MetadataRow objects for each unique RawDataFile
+    List<MetadataRow> rows = uniqueFiles.stream()
+        .map(file -> new MetadataRow(file, this.metadataTable)) // Pass table ref
+        .sorted(Comparator.comparing(row -> row.getRawDataFile().getName()))
+        .collect(Collectors.toCollection(ArrayList::new));
+    tableView.setItems(FXCollections.observableList(rows));
+  }
+
+  /**
+   * Creates and configures the TableColumn instances for a given TableView based on the
+   * MetadataTable structure.
+   * <p>
+   * NOTE: This clears existing columns in the TableView.
+   */
+  public void createAndSetExistingColumns() {
+    tableView.getColumns().clear();
+    tableView.setEditable(true); // Make table editable
+
+    final TableColumn<MetadataRow, String> dataFileColumn = createDataFileColumn();
+    tableView.getColumns().add(dataFileColumn);
+
+    final List<MetadataColumn<?>> tableColumns = metadataTable.getData().keySet().stream().sorted()
+        .toList();
+
+    for (MetadataColumn<?> metaColumn : tableColumns) {
+      createAndAddColumnToTableView(metaColumn);
+    }
+
+    addRows(metadataTable, tableView);
+  }
+
+  /**
+   * Adds a column that already exists to the table view. To create a new column in the
+   * {@link MetadataTable} as well use {@link MetadataTableModel#createAndAddNewColumn}
+   */
+  private void createAndAddColumnToTableView(MetadataColumn<?> metaColumn) {
+    final TableColumn<MetadataRow, String> fxColumn = createColumn(metaColumn);
+    tableView.getColumns().add(fxColumn);
+  }
+
+  /**
+   * Adds a new column to the underlying {@link MetadataTable} and the GUI model.
+   */
+  public void createAndAddNewColumn(MetadataColumn<?> column) {
+    metadataTable.addColumn(column);
+    createAndAddColumnToTableView(column);
+  }
+
+  private @NotNull TableColumn<MetadataRow, String> createColumn(MetadataColumn<?> metaColumn) {
+    // Create a JavaFX TableColumn for each MetadataColumn
+    TableColumn<MetadataRow, String> fxColumn = new TableColumn<>(metaColumn.getTitle());
+
+    // --- Cell Value Factory ---
+    // Tells the column how to get the data for a cell from a MetadataRow object
+    fxColumn.setCellValueFactory(cellDataFeatures -> {
+      MetadataRow row = cellDataFeatures.getValue();
+      // Use the helper method in MetadataRow to get an ObservableValue
+      return row.getCellValueProperty(metaColumn);
+    });
+
+    // --- Cell Factory (for editing) ---
+    // Use appropriate cell factories and converters based on MetadataColumn type
+    fxColumn.setCellFactory(column -> createEditingCell(metaColumn));
+
+    // --- On Edit Commit ---
+    // Tells the column what to do when a cell edit is committed
+    fxColumn.setOnEditCommit(event -> {
+      MetadataRow row = event.getRowValue(); // Get the row that was edited
+      String newValue = event.getNewValue(); // Get the new value from the editor
+
+      // Ask the MetadataRow object to update the underlying MetadataTable
+      // Pass the specific MetadataColumn definition to ensure correct update
+      // (Need to capture metaColumn in the lambda scope)
+      row.updateValue(metaColumn, newValue);
+
+      // Optional: Refresh the specific cell or row visually if needed,
+      // though the change should ideally be reflected via the
+      // observable value returned by getCellValueProperty if it were
+      // truly bound to an observable underlying model.
+      // In this setup, a manual refresh might sometimes be needed
+      // if the underlying change isn't picked up automatically.
+      // event.getTableView().refresh(); // Can be heavy
+      event.getTableView().getItems().set(event.getTablePosition().getRow(), row); // Force update?
+    });
+
+    // Set preferred width or other properties if desired
+    fxColumn.setPrefWidth(140);
+    return fxColumn;
+  }
+
+  private @NotNull TableColumn<MetadataRow, String> createDataFileColumn() {
+    final TableColumn<MetadataRow, String> fxColumn = new TableColumn<>(
+        MetadataColumn.FILENAME_HEADER);
+
+    fxColumn.setCellValueFactory(cellDataFeatures -> {
+      MetadataRow row = cellDataFeatures.getValue();
+      // Use the helper method in MetadataRow to get an ObservableValue
+      return new SimpleStringProperty(row.getRawDataFile().getName());
+    });
+
+    // Set preferred width or other properties if desired
+    fxColumn.setPrefWidth(180);
+    return fxColumn;
+  }
+
+  /**
+   * Helper method to create an appropriate TextFieldTableCell with a StringConverter based on the
+   * target data type defined in the MetadataColumn.
+   */
+  private <T> TextFieldTableCell<MetadataRow, String> createEditingCell(
+      MetadataColumn<T> metaColumn) {
+    StringConverter<String> converter = getConverterForType(metaColumn);
+    // Cast needed because forTableColumn expects TableColumn<S, T>, CellFactory<S, T, U>
+    // Here S=MetadataRow, T=Object. The converter handles String <-> String and validation.
+    return new TextFieldTableCell<>(converter);
+  }
+
+  /**
+   * Use the string converter as a validator
+   */
+  private StringConverter<String> getConverterForType(MetadataColumn<?> column) {
+    return new StringConverter<>() {
+      @Override
+      public String toString(String o) {
+        if (o == null) {
+          return "";
+        }
+        return o;
+      }
+
+      @Override
+      public String fromString(String s) {
+        final var converted = column.convertOrElse(s, null);
+        if (converted == null) {
+          DialogLoggerUtil.showErrorDialog("Cannot convert input",
+              "The input %s is invalid for the column %s of type %s. Please adhere to the format %s.".formatted(
+                  inQuotes(s), inQuotes(column.getTitle()), inQuotes(column.getType().toString()),
+                  inQuotes(column.exampleValue().toString())));
+          return null;
+        }
+        return s;
+      }
+    };
+  }
+
+  public void removeColumn(MetadataColumn<?> metaColumn, TableView<MetadataRow> tableView) {
+    tableView.getColumns().removeIf(col -> col.getText().equalsIgnoreCase(metaColumn.getTitle()));
+    metadataTable.removeColumn(metaColumn);
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/MetadataTableModel.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/MetadataTableModel.java
@@ -8,7 +8,6 @@ import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTabl
 import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.cell.TextFieldTableCell;
@@ -89,6 +88,9 @@ public class MetadataTableModel {
     createAndAddColumnToTableView(column);
   }
 
+  /**
+   * Creates the java fx column from an existing metadata column
+   */
   private @NotNull TableColumn<MetadataRow, String> createColumn(MetadataColumn<?> metaColumn) {
     // Create a JavaFX TableColumn for each MetadataColumn
     TableColumn<MetadataRow, String> fxColumn = new TableColumn<>(metaColumn.getTitle());
@@ -131,6 +133,10 @@ public class MetadataTableModel {
     return fxColumn;
   }
 
+  /**
+   * The data file column is the index of the {@link MetadataTable} and thus not a real column. need
+   * to add manually.
+   */
   private @NotNull TableColumn<MetadataRow, String> createDataFileColumn() {
     final TableColumn<MetadataRow, String> fxColumn = new TableColumn<>(
         MetadataColumn.FILENAME_HEADER);
@@ -186,7 +192,10 @@ public class MetadataTableModel {
     };
   }
 
-  public void removeColumn(MetadataColumn<?> metaColumn, TableView<MetadataRow> tableView) {
+  /**
+   * Removes a column from the view and the underlying table.
+   */
+  public void removeColumn(MetadataColumn<?> metaColumn) {
     tableView.getColumns().removeIf(col -> col.getText().equalsIgnoreCase(metaColumn.getTitle()));
     metadataTable.removeColumn(metaColumn);
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/ProjectMetadataPane.fxml
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/ProjectMetadataPane.fxml
@@ -33,7 +33,7 @@
 <BorderPane xmlns="http://javafx.com/javafx/10.0.2-internal" xmlns:fx="http://javafx.com/fxml/1"
   fx:controller="io.github.mzmine.modules.visualization.projectmetadata.ProjectMetadataPaneController">
   <center>
-    <TableView fx:id="parameterTable" prefHeight="350" prefWidth="600">
+    <TableView fx:id="tableView" prefHeight="350" prefWidth="600">
       <placeholder>
         <Label text="No Parameters"/>
       </placeholder>

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/ProjectMetadataPaneController.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/ProjectMetadataPaneController.java
@@ -152,7 +152,7 @@ public class ProjectMetadataPaneController {
     if (result.isPresent() && result.get() == ButtonType.OK) {
       MetadataColumn<?> columnToDelete = metadataTable.getColumnByName(columnName);
       if (columnToDelete != null) {
-        tableModel.removeColumn(columnToDelete, tableView);
+        tableModel.removeColumn(columnToDelete);
       }
     }
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/ProjectMetadataPaneController.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/ProjectMetadataPaneController.java
@@ -27,9 +27,9 @@
 package io.github.mzmine.modules.visualization.projectmetadata;
 
 import io.github.mzmine.datamodel.MZmineProject;
-import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.gui.helpwindow.HelpWindow;
 import io.github.mzmine.javafx.concurrent.threading.FxThread;
+import io.github.mzmine.javafx.dialogs.DialogLoggerUtil;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.visualization.projectmetadata.ProjectMetadataColumnParameters.AvailableTypes;
 import io.github.mzmine.modules.visualization.projectmetadata.io.ProjectMetadataExportModule;
@@ -47,19 +47,11 @@ import io.github.mzmine.util.ExitCode;
 import java.net.URL;
 import java.util.Optional;
 import java.util.logging.Logger;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
-import javafx.scene.control.Label;
-import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
-import javafx.scene.control.Tooltip;
-import javafx.scene.control.cell.TextFieldTableCell;
 import javafx.stage.Stage;
 
 public class ProjectMetadataPaneController {
@@ -69,17 +61,17 @@ public class ProjectMetadataPaneController {
       .getCurrentProject();
   private final MetadataTable metadataTable = currentProject.getProjectMetadata();
   private Stage currentStage;
-  private RawDataFile[] fileList;
 
   @FXML
-  private TableView<ObservableList<StringProperty>> parameterTable;
+  private TableView<MetadataRow> tableView;
+  private MetadataTableModel tableModel;
 
   @FXML
   private void initialize() {
-    parameterTable.setEditable(true);
-    parameterTable.getSelectionModel().setCellSelectionEnabled(true);
+    tableView.setEditable(true);
+    tableView.getSelectionModel().setCellSelectionEnabled(true);
 
-    updateParametersToTable();
+    tableModel = new MetadataTableModel(metadataTable, tableView);
   }
 
   public void setStage(Stage stage) {
@@ -87,125 +79,9 @@ public class ProjectMetadataPaneController {
     stage.setOnCloseRequest(we -> logger.info("Parameters are not updated"));
   }
 
-  /**
-   * Render the table using the data from the project parameters structure.
-   */
-  private void updateParametersToTable() {
-    // get copy of new list of files
-    fileList = currentProject.getDataFiles();
-
-    parameterTable.getItems().clear();
-    parameterTable.getColumns().clear();
-
-    int columnsNumber = metadataTable.getColumns().size();
-    if (columnsNumber == 0) {
-      return;
-    }
-
-    // display the columns
-    TableColumn[] tableColumns = new TableColumn[columnsNumber + 1];
-    tableColumns[0] = createColumn(0, MetadataColumn.FILENAME_HEADER,
-        "These are the names of the RawDataFiles");
-    var columns = metadataTable.getColumns();
-    int columnId = 1;
-    for (var col : columns) {
-      tableColumns[columnId] = createColumn(columnId, col.getTitle(), col.getDescription());
-      columnId++;
-    }
-    parameterTable.getColumns().addAll(tableColumns);
-
-    // display each row of the table
-    ObservableList<ObservableList<StringProperty>> tableRows = FXCollections.observableArrayList();
-    for (RawDataFile rawFile : fileList) {
-      ObservableList<StringProperty> fileParametersValue = FXCollections.observableArrayList();
-      fileParametersValue.add(new SimpleStringProperty(rawFile.getName()));
-      for (MetadataColumn<?> column : columns) {
-        // either convert parameter value to string or display an empty string in case if it's unset
-        Object value = metadataTable.getValue(column, rawFile);
-        fileParametersValue.add(new SimpleStringProperty(value == null ? "" : value.toString()));
-      }
-      tableRows.add(fileParametersValue);
-    }
-    parameterTable.getItems().addAll(tableRows);
-  }
-
-  private TableColumn<ObservableList<StringProperty>, String> createColumn(final int columnIndex,
-      String columnTitle, String columnDescription) {
-    // validate the column title (assign the default value in case if it's empty)
-    TableColumn<ObservableList<StringProperty>, String> column = new TableColumn<>();
-    String title;
-    if (columnTitle == null || columnTitle.trim().length() == 0) {
-      title = "Column " + (columnIndex + 1);
-    } else {
-      title = columnTitle;
-    }
-
-    // add the tooltips
-    Label descriptionLabel = new Label(title);
-    descriptionLabel.setTooltip(new Tooltip(columnDescription));
-    descriptionLabel.setMaxSize(Double.MAX_VALUE, Double.MAX_VALUE);
-    column.setGraphic(descriptionLabel);
-
-    // define what the cell value would be
-    column.setCellValueFactory(cellDataFeatures -> {
-      ObservableList<StringProperty> values = cellDataFeatures.getValue();
-      if (columnIndex >= values.size()) {
-        return new SimpleStringProperty("");
-      } else {
-        return cellDataFeatures.getValue().get(columnIndex);
-      }
-    });
-
-    // won't be applied for the first column, because it contains the file name
-    if (columnIndex != 0) {
-      column.setCellFactory(TextFieldTableCell.forTableColumn());
-      column.setOnEditCommit(event -> {
-        String parameterValueNew = event.getNewValue();
-        // this complication in extracting the value is caused by using labels as the cells values
-        String parameterName = ((Label) event.getTableColumn().getGraphic()).getText();
-        MetadataColumn parameter = metadataTable.getColumnByName(parameterName);
-
-        // define RawDataFile name
-        int rowNumber = parameterTable.getSelectionModel().selectedIndexProperty().get();
-        String fileName = parameterTable.getItems().get(rowNumber).get(0).getValue();
-        RawDataFile rawDataFile = null;
-        for (RawDataFile file : fileList) {
-          if (file.getName().equals(fileName)) {
-            rawDataFile = file;
-            break;
-          }
-        }
-
-        // if the parameter value is in the right format then save it to the metadata table,
-        // otherwise show alert dialog
-        Object convertedParameterInput = parameter.convertOrElse(parameterValueNew,
-            parameter.defaultValue());
-        // the first check allows us to unset an already set parameter's value
-        if ((convertedParameterInput == null && parameterValueNew.isBlank())
-            || parameter.checkInput(convertedParameterInput)) {
-          metadataTable.setValue(parameter, rawDataFile, convertedParameterInput);
-        } else {
-          Alert alert = new Alert(Alert.AlertType.INFORMATION);
-          alert.setTitle("Wrong parameter value format");
-          alert.setHeaderText(null);
-          alert.setContentText(
-              "Please respect the " + parameter.getType() + " parameter value format, e.g. "
-              + parameter.exampleValue());
-          alert.showAndWait();
-        }
-        // need to render
-        updateParametersToTable();
-      });
-    }
-
-    column.setMinWidth(175.0);
-
-    return column;
-  }
-
   @FXML
   public void addParameter(ActionEvent actionEvent) {
-    ProjectMetadataColumnParameters projectMetadataColumnParameters = new ProjectMetadataColumnParameters();
+    ProjectMetadataColumnParameters projectMetadataColumnParameters = (ProjectMetadataColumnParameters) new ProjectMetadataColumnParameters().cloneParameterSet();
     ExitCode exitCode = projectMetadataColumnParameters.showSetupDialog(true);
 
     StringParameter parameterTitle = projectMetadataColumnParameters.getParameter(
@@ -230,16 +106,12 @@ public class ProjectMetadataPaneController {
       String parameterDescriptionVal = parameterDescription.getValue().replace("\t", " ");
 
       // add the new column to the parameters table
-      switch (parameterType.getValue()) {
-        case TEXT -> metadataTable.addColumn(
-            new StringMetadataColumn(parameterTitle.getValue(), parameterDescriptionVal));
-        case NUMBER -> metadataTable.addColumn(
-            new DoubleMetadataColumn(parameterTitle.getValue(), parameterDescriptionVal));
-        case DATETIME -> metadataTable.addColumn(
-            new DateMetadataColumn(parameterTitle.getValue(), parameterDescriptionVal));
-      }
-      // need to render
-      updateParametersToTable();
+      MetadataColumn<?> col = switch (parameterType.getValue()) {
+        case TEXT -> new StringMetadataColumn(parameterTitle.getValue(), parameterDescriptionVal);
+        case NUMBER -> new DoubleMetadataColumn(parameterTitle.getValue(), parameterDescriptionVal);
+        case DATETIME -> new DateMetadataColumn(parameterTitle.getValue(), parameterDescriptionVal);
+      };
+      tableModel.createAndAddNewColumn(col);
     }
   }
 
@@ -248,7 +120,7 @@ public class ProjectMetadataPaneController {
     final ExitCode exitCode = MZmineCore.setupAndRunModule(ProjectMetadataImportModule.class,
         () -> {
           logger.info("Successfully imported parameters from file");
-          FxThread.runLater(this::updateParametersToTable);
+          FxThread.runLater(() -> tableModel.createAndSetExistingColumns());
         }, () -> logger.warning("Importing parameters from file failed"));
     if (exitCode == ExitCode.ERROR) {
       logger.warning("Setup of metadata import failed");
@@ -262,35 +134,26 @@ public class ProjectMetadataPaneController {
 
   @FXML
   public void removeParameters(ActionEvent ev) {
-    TableColumn column = parameterTable.getFocusModel().getFocusedCell().getTableColumn();
+    final var column = tableView.getFocusModel().getFocusedCell().getTableColumn();
     if (column == null) {
-      Alert alert = new Alert(Alert.AlertType.INFORMATION);
-      alert.setTitle("No cell selected");
-      alert.setHeaderText(null);
-      alert.setContentText("Please select at least one cell.");
-      alert.showAndWait();
+      DialogLoggerUtil.showMessageDialog("No cell selected.", "Please select at least one cell");
       return;
     }
-    String parameterName = ((Label) column.getGraphic()).getText();
-    if (parameterName.equals(MetadataColumn.FILENAME_HEADER)) {
-      Alert alert = new Alert(Alert.AlertType.INFORMATION);
-      alert.setTitle("Cannot remove Raw Data File Column");
-      alert.setHeaderText(null);
-      alert.setContentText("Please select cell from another column.");
-      alert.showAndWait();
+    String columnName = column.getText();
+    if (columnName.equals(MetadataColumn.FILENAME_HEADER)) {
+      DialogLoggerUtil.showErrorDialog("Cannot remove Raw Data File Column",
+          "Cannot remove Raw Data File Column");
       return;
     }
-    Alert alert = new Alert(Alert.AlertType.CONFIRMATION, "Remove parameter " + parameterName);
+    Alert alert = new Alert(Alert.AlertType.CONFIRMATION, "Remove parameter " + columnName);
     alert.setTitle("Remove Parameter?");
     alert.setHeaderText(null);
     Optional<ButtonType> result = alert.showAndWait();
     if (result.isPresent() && result.get() == ButtonType.OK) {
-      MetadataColumn<?> tbdParameter = metadataTable.getColumnByName(
-          parameterName);//ToBeDeletedParameter
-      if (tbdParameter != null) {
-        metadataTable.removeColumn(tbdParameter);
+      MetadataColumn<?> columnToDelete = metadataTable.getColumnByName(columnName);
+      if (columnToDelete != null) {
+        tableModel.removeColumn(columnToDelete, tableView);
       }
-      updateParametersToTable();
     }
   }
 
@@ -304,6 +167,6 @@ public class ProjectMetadataPaneController {
   }
 
   public void reload(final ActionEvent ev) {
-    updateParametersToTable();
+    tableModel.createAndSetExistingColumns();
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataImportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataImportTask.java
@@ -26,9 +26,9 @@
 package io.github.mzmine.modules.visualization.projectmetadata.io;
 
 import io.github.mzmine.gui.DesktopService;
-import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTable;
 import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.project.ProjectService;
 import io.github.mzmine.taskcontrol.AbstractSimpleToolTask;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import java.io.File;
@@ -105,7 +105,7 @@ public class ProjectMetadataImportTask extends AbstractSimpleToolTask {
       return;
     }
     
-    MetadataTable projectMetadata = MZmineCore.getProjectMetadata();
+    MetadataTable projectMetadata = ProjectService.getMetadata();
     projectMetadata.merge(mergedMetadata);
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/MetadataTable.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/MetadataTable.java
@@ -376,10 +376,10 @@ public class MetadataTable {
    */
   @NotNull
   public MetadataTable merge(final MetadataTable newMetadata) {
-    newMetadata.getData().forEach((column, data) -> {
+    newMetadata.getData().forEach((columnInNewTable, data) -> {
       data.forEach((raw, value) -> {
         if (value != null) {
-          setValue((MetadataColumn) column, raw, value);
+          setValue((MetadataColumn) columnInNewTable, raw, value);
         }
       });
     });

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/columns/MetadataColumn.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/columns/MetadataColumn.java
@@ -36,8 +36,42 @@ import org.jetbrains.annotations.Nullable;
  *
  * @param <T> datatype of the project parameter
  */
-public abstract sealed class MetadataColumn<T> permits StringMetadataColumn, DoubleMetadataColumn,
-    DateMetadataColumn {
+public abstract sealed class MetadataColumn<T> implements Comparable<MetadataColumn<T>> permits
+    StringMetadataColumn, DoubleMetadataColumn, DateMetadataColumn {
+
+  @Override
+  public int compareTo(@NotNull MetadataColumn<T> o) {
+    if (o == this) {
+      return 0;
+    }
+
+    // filename first
+    if (this.getTitle().equals(FILENAME_HEADER)) {
+      return -1;
+    }
+    if (o.getTitle().equals(FILENAME_HEADER)) {
+      return 1;
+    }
+
+    // then run data
+    if (this.getTitle().equalsIgnoreCase(DATE_HEADER)) {
+      return -1;
+    }
+    if (o.getTitle().equalsIgnoreCase(DATE_HEADER)) {
+      return 1;
+    }
+
+    // then sample type
+    if (this.getTitle().equalsIgnoreCase(SAMPLE_TYPE_HEADER)) {
+      return -1;
+    }
+    if (o.getTitle().equalsIgnoreCase(SAMPLE_TYPE_HEADER)) {
+      return 1;
+    }
+
+    // then alphabetical order
+    return this.getTitle().toLowerCase().compareTo(o.getTitle().toLowerCase());
+  }
 
   public static final String FILENAME_HEADER = "filename";
   public static final String DATE_HEADER = "run_date";
@@ -176,4 +210,5 @@ public abstract sealed class MetadataColumn<T> permits StringMetadataColumn, Dou
   public String toString() {
     return getTitle();
   }
+
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/columns/MetadataColumn.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/columns/MetadataColumn.java
@@ -39,40 +39,6 @@ import org.jetbrains.annotations.Nullable;
 public abstract sealed class MetadataColumn<T> implements Comparable<MetadataColumn<T>> permits
     StringMetadataColumn, DoubleMetadataColumn, DateMetadataColumn {
 
-  @Override
-  public int compareTo(@NotNull MetadataColumn<T> o) {
-    if (o == this) {
-      return 0;
-    }
-
-    // filename first
-    if (this.getTitle().equals(FILENAME_HEADER)) {
-      return -1;
-    }
-    if (o.getTitle().equals(FILENAME_HEADER)) {
-      return 1;
-    }
-
-    // then run data
-    if (this.getTitle().equalsIgnoreCase(DATE_HEADER)) {
-      return -1;
-    }
-    if (o.getTitle().equalsIgnoreCase(DATE_HEADER)) {
-      return 1;
-    }
-
-    // then sample type
-    if (this.getTitle().equalsIgnoreCase(SAMPLE_TYPE_HEADER)) {
-      return -1;
-    }
-    if (o.getTitle().equalsIgnoreCase(SAMPLE_TYPE_HEADER)) {
-      return 1;
-    }
-
-    // then alphabetical order
-    return this.getTitle().toLowerCase().compareTo(o.getTitle().toLowerCase());
-  }
-
   public static final String FILENAME_HEADER = "filename";
   public static final String DATE_HEADER = "run_date";
   // renamed this from sample_type to mz_sample_type because too standard name that may be overwritten by users metadata
@@ -198,12 +164,12 @@ public abstract sealed class MetadataColumn<T> implements Comparable<MetadataCol
     if (!(o instanceof MetadataColumn<?> that)) {
       return false;
     }
-    return title.equals(that.title) && description.equals(that.description);
+    return Objects.equals(title, that.title);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(title, description);
+    return Objects.hash(title);
   }
 
   @Override
@@ -211,4 +177,37 @@ public abstract sealed class MetadataColumn<T> implements Comparable<MetadataCol
     return getTitle();
   }
 
+  @Override
+  public int compareTo(@NotNull MetadataColumn<T> o) {
+    if (o == this) {
+      return 0;
+    }
+
+    // filename first
+    if (this.getTitle().equals(FILENAME_HEADER)) {
+      return -1;
+    }
+    if (o.getTitle().equals(FILENAME_HEADER)) {
+      return 1;
+    }
+
+    // then run data
+    if (this.getTitle().equalsIgnoreCase(DATE_HEADER)) {
+      return -1;
+    }
+    if (o.getTitle().equalsIgnoreCase(DATE_HEADER)) {
+      return 1;
+    }
+
+    // then sample type
+    if (this.getTitle().equalsIgnoreCase(SAMPLE_TYPE_HEADER)) {
+      return -1;
+    }
+    if (o.getTitle().equalsIgnoreCase(SAMPLE_TYPE_HEADER)) {
+      return 1;
+    }
+
+    // then alphabetical order
+    return this.getTitle().toLowerCase().compareTo(o.getTitle().toLowerCase());
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/TextParameter.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/TextParameter.java
@@ -88,7 +88,7 @@ public class TextParameter implements UserParameter<String, TextArea> {
 
   @Override
   public TextParameter cloneParameter() {
-    TextParameter copy = new TextParameter(name, description);
+    TextParameter copy = new TextParameter(name, description, value, valueRequired);
     copy.setValue(this.getValue());
     return copy;
   }


### PR DESCRIPTION
- fixes #2440 (column duplication on import)
  - MetadataColumn.equals and hash set only use the title of the column now. Description is not always available during import but lead to the columns not being equal. Expected behaviour is for the columns to just be merged. the first imported table defines the description now
- fix reordering of columns on editing a single cell
- created a wrapper to wrap around the metadata table in the view model.