### PR TITLE
Sorting of Number Metadata columns

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/MetadataRow.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/MetadataRow.java
@@ -1,14 +1,41 @@
+/*
+ * Copyright (c) 2004-2025 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package io.github.mzmine.modules.visualization.projectmetadata;
 
 import io.github.mzmine.datamodel.RawDataFile;
-import io.github.mzmine.javafx.dialogs.DialogLoggerUtil;
 import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTable;
+import io.github.mzmine.modules.visualization.projectmetadata.table.columns.DateMetadataColumn;
+import io.github.mzmine.modules.visualization.projectmetadata.table.columns.DoubleMetadataColumn;
 import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
+import io.github.mzmine.modules.visualization.projectmetadata.table.columns.StringMetadataColumn;
+import java.util.Objects;
 import java.util.logging.Logger;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.value.ObservableValue;
-import java.util.Objects;
 
 /**
  * Represents a single row in the TableView, linked to a RawDataFile.
@@ -38,7 +65,7 @@ public class MetadataRow {
    * @param column The MetadataColumn definition.
    * @return An ObservableValue containing the data for the cell.
    */
-  public ObservableValue<String> getCellValueProperty(MetadataColumn<?> column) {
+  public ObservableValue<?> getCellValueProperty(MetadataColumn<?> column) {
     // We use SimpleStringProperty to wrap the value.
     // It reads directly from the underlying sourceTable.
     // NOTE: This doesn't automatically update if the underlying table changes
@@ -46,7 +73,14 @@ public class MetadataRow {
     // MetadataTable would need to support listeners, which is much more complex.
     // This implementation focuses on displaying and *editing* via the TableView.
     Object value = sourceTable.getValue(column, this.rawDataFile);
-    return new SimpleStringProperty(Objects.requireNonNullElse(value, "").toString());
+
+    return switch (column) {
+      case StringMetadataColumn _, DateMetadataColumn _ ->
+          new SimpleStringProperty(Objects.requireNonNullElse(value, "").toString());
+      case DoubleMetadataColumn _ -> new SimpleObjectProperty<Double>((Double) value) {
+      };
+    };
+
   }
 
   /**
@@ -63,7 +97,7 @@ public class MetadataRow {
     // Update the underlying map
     sourceTable.setValue(column, this.rawDataFile, castedValue);
     logger.finest("Updated Model: [" + rawDataFile.getName() + ", " + column.getTitle() + "] = "
-        + castedValue); // For debugging
+                  + castedValue); // For debugging
   }
 
   // equals/hashCode based on the unique identifier RawDataFile

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/MetadataTableModel.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/MetadataTableModel.java
@@ -1,21 +1,50 @@
-package io.github.mzmine.modules.visualization.projectmetadata;
+/*
+ * Copyright (c) 2004-2025 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
 
-import static io.github.mzmine.util.StringUtils.inQuotes;
+package io.github.mzmine.modules.visualization.projectmetadata;
 
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.javafx.dialogs.DialogLoggerUtil;
 import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTable;
 import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
+import io.github.mzmine.util.StringUtils;
+import static io.github.mzmine.util.StringUtils.inQuotes;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
+import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.cell.TextFieldTableCell;
 import javafx.util.StringConverter;
-
-
-import java.util.*;
-import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -76,7 +105,7 @@ public class MetadataTableModel {
    * {@link MetadataTable} as well use {@link MetadataTableModel#createAndAddNewColumn}
    */
   private void createAndAddColumnToTableView(MetadataColumn<?> metaColumn) {
-    final TableColumn<MetadataRow, String> fxColumn = createColumn(metaColumn);
+    final TableColumn<MetadataRow, ?> fxColumn = createColumn(metaColumn);
     tableView.getColumns().add(fxColumn);
   }
 
@@ -91,32 +120,32 @@ public class MetadataTableModel {
   /**
    * Creates the java fx column from an existing metadata column
    */
-  private @NotNull TableColumn<MetadataRow, String> createColumn(MetadataColumn<?> metaColumn) {
+  private @NotNull TableColumn<MetadataRow, ?> createColumn(MetadataColumn<?> metaColumn) {
     // Create a JavaFX TableColumn for each MetadataColumn
-    TableColumn<MetadataRow, String> fxColumn = new TableColumn<>(metaColumn.getTitle());
+    TableColumn<MetadataRow, ?> fxColumn = new TableColumn<>(metaColumn.getTitle());
 
     // --- Cell Value Factory ---
     // Tells the column how to get the data for a cell from a MetadataRow object
     fxColumn.setCellValueFactory(cellDataFeatures -> {
       MetadataRow row = cellDataFeatures.getValue();
       // Use the helper method in MetadataRow to get an ObservableValue
-      return row.getCellValueProperty(metaColumn);
+      return (ObservableValue) row.getCellValueProperty(metaColumn);
     });
 
     // --- Cell Factory (for editing) ---
     // Use appropriate cell factories and converters based on MetadataColumn type
-    fxColumn.setCellFactory(column -> createEditingCell(metaColumn));
+    fxColumn.setCellFactory(column -> (TableCell) createEditingCell(metaColumn));
 
     // --- On Edit Commit ---
     // Tells the column what to do when a cell edit is committed
     fxColumn.setOnEditCommit(event -> {
       MetadataRow row = event.getRowValue(); // Get the row that was edited
-      String newValue = event.getNewValue(); // Get the new value from the editor
+      Object newValue = event.getNewValue(); // Get the new value from the editor
 
       // Ask the MetadataRow object to update the underlying MetadataTable
       // Pass the specific MetadataColumn definition to ensure correct update
       // (Need to capture metaColumn in the lambda scope)
-      row.updateValue(metaColumn, newValue);
+      row.updateValue(metaColumn, newValue != null ? newValue.toString() : null);
 
       // Optional: Refresh the specific cell or row visually if needed,
       // though the change should ideally be reflected via the
@@ -156,9 +185,8 @@ public class MetadataTableModel {
    * Helper method to create an appropriate TextFieldTableCell with a StringConverter based on the
    * target data type defined in the MetadataColumn.
    */
-  private <T> TextFieldTableCell<MetadataRow, String> createEditingCell(
-      MetadataColumn<T> metaColumn) {
-    StringConverter<String> converter = getConverterForType(metaColumn);
+  private TextFieldTableCell<MetadataRow, ?> createEditingCell(MetadataColumn<?> metaColumn) {
+    StringConverter<?> converter = getConverterForType(metaColumn);
     // Cast needed because forTableColumn expects TableColumn<S, T>, CellFactory<S, T, U>
     // Here S=MetadataRow, T=Object. The converter handles String <-> String and validation.
     return new TextFieldTableCell<>(converter);
@@ -167,18 +195,22 @@ public class MetadataTableModel {
   /**
    * Use the string converter as a validator
    */
-  private StringConverter<String> getConverterForType(MetadataColumn<?> column) {
+  private StringConverter<?> getConverterForType(MetadataColumn<?> column) {
     return new StringConverter<>() {
       @Override
-      public String toString(String o) {
+      public String toString(Object o) {
         if (o == null) {
           return "";
         }
-        return o;
+        return o.toString();
       }
 
       @Override
-      public String fromString(String s) {
+      public Object fromString(String s) {
+        if (StringUtils.isBlank(s)) {
+          return "";
+        }
+
         final var converted = column.convertOrElse(s, null);
         if (converted == null) {
           DialogLoggerUtil.showErrorDialog("Cannot convert input",


### PR DESCRIPTION
addresses the comments in #2500

Not the best solution... but something like this could fix the sorting of number values. 

I think it is best to use the actual values of cells instead of StringProperties. Like ObjectProperty<Double> will automatically handle the sorting. 
Using the original value instead of a string might be better than using a custom comparator on the column.