### PR TITLE
update about tab and dependencies tab

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/AboutTab.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/AboutTab.java
@@ -86,7 +86,7 @@ public class AboutTab extends SimpleTab {
 
     // Copyright Notice
     contentBox.getChildren().add(FxLabels.newBoldLabel("Copyright Notice"));
-    Label copyrightNotice = new Label("©2024 by mzio GmbH and mzmine development team");
+    Label copyrightNotice = new Label("©2025 by mzio GmbH and mzmine development team");
     contentBox.getChildren().add(copyrightNotice);
 
     ScrollPane scrollPane = new ScrollPane(contentBox);

--- a/mzmine-community/src/main/java/io/github/mzmine/util/dependencylicenses/Dependencies.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/dependencylicenses/Dependencies.java
@@ -44,13 +44,7 @@ public record Dependencies(List<Dependency> dependencies) {
           List.of(new ModuleLicense("EULA TDF-SDK (Bruker Daltonics GmbH & Co.KG)", null))),
       new Dependency("Baf2Sql Software Development Kit, Bruker Daltonics GmbH & Co.KG", "2.9.0",
           List.of(),
-          List.of(new ModuleLicense("EULA BAF-SDK (Bruker Daltonics GmbH & Co.KG)", null))),
-      new Dependency("ThermoRawFileParser", "1.4.3",
-          List.of("https://github.com/compomics/ThermoRawFileParser"), List.of(
-          new ModuleLicense("Apache License, Version 2.0",
-              "https://github.com/compomics/ThermoRawFileParser?tab=Apache-2.0-1-ov-file#readme"))),
-      new Dependency("MassLynxRaw library", "2014", List.of(),
-          List.of(new ModuleLicense("Copyright © 2014 Waters, Inc.", null))));
+          List.of(new ModuleLicense("EULA BAF-SDK (Bruker Daltonics GmbH & Co.KG)", null))));
 
   public static List<Dependency> of(String resourcePath) {
     final ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
About tab still showed 2024.
The dependencies tab still showed the waters library and the thermo library, both are not shipped with mzmine anymore.