### PR TITLE
Color by date or numeric metadata value as gradient

### DIFF
--- a/javafx-framework/src/main/java/io/github/mzmine/javafx/util/FxColorUtil.java
+++ b/javafx-framework/src/main/java/io/github/mzmine/javafx/util/FxColorUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -43,12 +43,17 @@ public class FxColorUtil {
     return new java.awt.Color(r, g, b, opacity);
   }
 
-  public static Color awtColorToFX(final java.awt.Color color) {
-    final double r = color.getRed() / 255d;
-    final double g = color.getGreen() / 255d;
-    final double b = color.getBlue() / 255d;
-    final double opacity = color.getAlpha() / 255d;
-    return Color.color(r, g, b, opacity);
+  public static Color awtColorToFX(final java.awt.Paint paint) {
+    if (paint instanceof java.awt.Color color) {
+      final double r = color.getRed() / 255d;
+      final double g = color.getGreen() / 255d;
+      final double b = color.getBlue() / 255d;
+      final double opacity = color.getAlpha() / 255d;
+      return Color.color(r, g, b, opacity);
+    } else if (paint instanceof java.awt.GradientPaint c) {
+      return awtColorToFX(c.getColor1());
+    }
+    throw new IllegalArgumentException("Unsupported paint type: " + paint.getClass().getName());
   }
 
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/ZCategoryProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/ZCategoryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,8 +25,13 @@
 
 package io.github.mzmine.gui.chartbasics.simplechart.providers;
 
+import java.awt.Paint;
+
 public interface ZCategoryProvider extends XYZValueProvider {
+
   int getNumberOfCategories();
 
   String getLegendLabel(int category);
+
+  Paint getLegendItemColor(int category);
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/renderers/ColoredXYShapeRenderer.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/renderers/ColoredXYShapeRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -270,7 +270,7 @@ public class ColoredXYShapeRenderer extends XYShapeRenderer {
     final int numCategories = zcat.getNumberOfCategories();
     for (int i = 0; i < numCategories; i++) {
       final String labelText = zcat.getLegendLabel(i);
-      final Paint paint = zds.getPaintScale().getPaint(i);
+      final Paint paint = zcat.getLegendItemColor(i);
       final LegendItem item = new LegendItem(labelText, null, null, null, dataPointsShape,
           !drawOutlinesOnly ? paint : ColorUtils.TRANSPARENT_AWT, outlineStroke,
           drawOutlinesOnly ? paint : ColorUtils.TRANSPARENT_AWT);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/pca_new/PCALoadingsProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/pca_new/PCALoadingsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -38,6 +38,7 @@ import io.github.mzmine.util.annotations.CompoundAnnotationUtils;
 import io.github.mzmine.util.collections.SortOrder;
 import io.github.mzmine.util.color.SimpleColorPalette;
 import java.awt.Color;
+import java.awt.Paint;
 import java.util.Map;
 import javafx.beans.property.Property;
 import org.apache.commons.math3.linear.RealMatrix;
@@ -147,6 +148,11 @@ public class PCALoadingsProvider extends SimpleXYProvider implements PlotXYZData
   @Override
   public String getLegendLabel(int category) {
     return legendNames[category];
+  }
+
+  @Override
+  public Paint getLegendItemColor(int category) {
+    return paintScale.getPaint(category);
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/rowsboxplot/RowBoxPlotDataset.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/rowsboxplot/RowBoxPlotDataset.java
@@ -29,16 +29,21 @@ import io.github.mzmine.datamodel.AbundanceMeasure;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.main.ConfigService;
 import io.github.mzmine.modules.visualization.projectmetadata.color.ColorByMetadataGroup;
 import io.github.mzmine.modules.visualization.projectmetadata.color.ColorByMetadataResults;
 import io.github.mzmine.modules.visualization.projectmetadata.color.ColorByMetadataUtils;
 import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
+import io.github.mzmine.util.color.SimpleColorPalette;
 import java.util.List;
 import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jfree.data.statistics.DefaultBoxAndWhiskerCategoryDataset;
 
 public class RowBoxPlotDataset extends DefaultBoxAndWhiskerCategoryDataset {
+
+  private final @NotNull SimpleColorPalette colorPalette;
 
   public RowBoxPlotDataset(FeatureListRow row, @Nullable MetadataColumn<?> groupingColumn,
       AbundanceMeasure abundance) {
@@ -47,15 +52,17 @@ public class RowBoxPlotDataset extends DefaultBoxAndWhiskerCategoryDataset {
       final List<Float> values = row.getFeatures().stream().map(abundance::get)
           .filter(Objects::nonNull).toList();
       add(values, 0, row.toString());
+      colorPalette = ConfigService.getDefaultColorPalette().clone(true);
       return;
     }
 
     // use the same method for grouping like ColorByMetadataTask and PCAScoresProvider
-    // TODO where is the color of this plot / dataset/ renderer defined? it should use the colors of the groups
-    // for now it is correct as it uses standard colors
+    // colors for this plot / dataset are defined by theme so need to apply colors to the theme and reapply theme to chart
     final List<RawDataFile> files = row.getFeatureList().getRawDataFiles();
     final ColorByMetadataResults grouping = ColorByMetadataUtils.colorByColumn(groupingColumn,
         files);
+
+    colorPalette = grouping.createColorPalette();
 
     for (ColorByMetadataGroup group : grouping.groups()) {
       final String groupName = group.valueString();
@@ -66,4 +73,7 @@ public class RowBoxPlotDataset extends DefaultBoxAndWhiskerCategoryDataset {
     }
   }
 
+  public @NotNull SimpleColorPalette getColorPalette() {
+    return colorPalette;
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/rowsboxplot/RowBoxPlotDataset.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/rowsboxplot/RowBoxPlotDataset.java
@@ -29,8 +29,9 @@ import io.github.mzmine.datamodel.AbundanceMeasure;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.modules.visualization.projectmetadata.color.ColorByMetadataGroup;
+import io.github.mzmine.modules.visualization.projectmetadata.color.ColorByMetadataResults;
 import io.github.mzmine.modules.visualization.projectmetadata.color.ColorByMetadataUtils;
-import io.github.mzmine.modules.visualization.projectmetadata.color.ColoredMetadataGroup;
 import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
 import java.util.List;
 import java.util.Objects;
@@ -53,10 +54,10 @@ public class RowBoxPlotDataset extends DefaultBoxAndWhiskerCategoryDataset {
     // TODO where is the color of this plot / dataset/ renderer defined? it should use the colors of the groups
     // for now it is correct as it uses standard colors
     final List<RawDataFile> files = row.getFeatureList().getRawDataFiles();
-    final List<ColoredMetadataGroup> groups = ColorByMetadataUtils.colorByColumn(groupingColumn,
+    final ColorByMetadataResults grouping = ColorByMetadataUtils.colorByColumn(groupingColumn,
         files);
 
-    for (ColoredMetadataGroup group : groups) {
+    for (ColorByMetadataGroup group : grouping.groups()) {
       final String groupName = group.valueString();
       final List<Float> values = group.files().stream()
           .map(file -> abundance.get((ModularFeature) row.getFeature(file)))

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/rowsboxplot/RowsBoxplotViewBuilder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/rowsboxplot/RowsBoxplotViewBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -31,6 +31,7 @@ import io.github.mzmine.gui.chartbasics.gui.javafx.EChartViewer;
 import io.github.mzmine.gui.preferences.NumberFormats;
 import io.github.mzmine.javafx.mvci.FxViewBuilder;
 import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.util.color.SimpleColorPalette;
 import java.util.List;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Region;
@@ -63,11 +64,23 @@ public class RowsBoxplotViewBuilder extends FxViewBuilder<RowsBoxplotModel> {
     barChart.getCategoryPlot().setRenderer(0, boxAndWhiskerRenderer);
 
     model.datasetProperty().addListener((_, _, n) -> {
-      final List<FeatureListRow> selectedRows = model.getSelectedRows();
-      if (selectedRows != null && !selectedRows.isEmpty()) {
-        final FeatureListRow row = selectedRows.getFirst();
-        barChart.setTitle(row.toString());
-      }
+      viewer.applyWithNotifyChanges(false, () -> {
+        final List<FeatureListRow> selectedRows = model.getSelectedRows();
+        if (selectedRows != null && !selectedRows.isEmpty()) {
+          final FeatureListRow row = selectedRows.getFirst();
+          barChart.setTitle(row.toString());
+        }
+        if (n != null) {
+          final SimpleColorPalette colors = n.getColorPalette();
+          colors.applyToChart(barChart);
+          // need to set a new renderer otherwise the old will keep the colors
+          boxAndWhiskerRenderer.clearSeriesPaints(false);
+          boxAndWhiskerRenderer.clearSeriesStrokes(false);
+//          final BoxAndWhiskerRenderer boxAndWhiskerRenderer2 = new BoxAndWhiskerRenderer();
+//          boxAndWhiskerRenderer2.setMeanVisible(false);
+//          barChart.getCategoryPlot().setRenderer(0, boxAndWhiskerRenderer2, false);
+        }
+      });
       barChart.getCategoryPlot().setDataset(0, n);
     });
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/rowsboxplot/RowsBoxplotViewBuilder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataanalysis/rowsboxplot/RowsBoxplotViewBuilder.java
@@ -73,12 +73,9 @@ public class RowsBoxplotViewBuilder extends FxViewBuilder<RowsBoxplotModel> {
         if (n != null) {
           final SimpleColorPalette colors = n.getColorPalette();
           colors.applyToChart(barChart);
-          // need to set a new renderer otherwise the old will keep the colors
+          // need to reset the renderer otherwise the old will keep the colors
           boxAndWhiskerRenderer.clearSeriesPaints(false);
           boxAndWhiskerRenderer.clearSeriesStrokes(false);
-//          final BoxAndWhiskerRenderer boxAndWhiskerRenderer2 = new BoxAndWhiskerRenderer();
-//          boxAndWhiskerRenderer2.setMeanVisible(false);
-//          barChart.getCategoryPlot().setRenderer(0, boxAndWhiskerRenderer2, false);
         }
       });
       barChart.getCategoryPlot().setDataset(0, n);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/charts/ChartUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_masscalibration/charts/ChartUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -37,7 +37,14 @@ import java.awt.geom.Ellipse2D;
 import java.text.NumberFormat;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
+import org.jfree.chart.JFreeChart;
 import org.jfree.chart.labels.XYToolTipGenerator;
+import org.jfree.chart.plot.CombinedDomainCategoryPlot;
+import org.jfree.chart.plot.CombinedDomainXYPlot;
+import org.jfree.chart.plot.CombinedRangeCategoryPlot;
+import org.jfree.chart.plot.CombinedRangeXYPlot;
+import org.jfree.chart.plot.Plot;
 import org.jfree.chart.plot.ValueMarker;
 import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.renderer.xy.XYLineAndShapeRenderer;
@@ -95,7 +102,7 @@ public class ChartUtils {
     NumberFormat ppmFormat = MZmineCore.getConfiguration().getPPMFormat();
     String tooltipText = String.format(
         "Measured-matched m/z: %s-%s" + "\nMeasured-matched RT: %s-%s" + "\nMass error: %s %s"
-        + "\nMass peak intensity: %s" + "\nScan number: %s",
+            + "\nMass peak intensity: %s" + "\nScan number: %s",
         mzFormat.format(match.getMeasuredMzRatio()), mzFormat.format(match.getMatchedMzRatio()),
         rtFormat.format(match.getMeasuredRetentionTime()),
         match.getMatchedRetentionTime() == -1 ? "none"
@@ -154,4 +161,20 @@ public class ChartUtils {
     trendRenderer.setAutoPopulateSeriesPaint(false);
     return trendRenderer;
   }
+
+  public static Stream<Plot> streamPlots(JFreeChart chart) {
+    return streamPlots(chart.getPlot());
+  }
+
+  public static Stream<Plot> streamPlots(Plot plot) {
+    final Stream<? extends Plot> subplots = switch (plot) {
+      case CombinedDomainXYPlot p -> p.getSubplots().stream();
+      case CombinedRangeXYPlot p -> p.getSubplots().stream();
+      case CombinedDomainCategoryPlot p -> p.getSubplots().stream();
+      case CombinedRangeCategoryPlot p -> p.getSubplots().stream();
+      default -> Stream.empty();
+    };
+    return Stream.concat(Stream.of(plot), subplots);
+  }
+
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataColumnParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataColumnParameters.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2004-2025 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.visualization.projectmetadata.color;
+
+import io.github.mzmine.gui.chartbasics.chartutils.paintscales.PaintScaleTransform;
+import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.ComboParameter;
+import io.github.mzmine.parameters.parametertypes.metadata.MetadataGroupingParameter;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class ColorByMetadataColumnParameters extends SimpleParameterSet {
+
+  public static final MetadataGroupingParameter colorByColumn = new MetadataGroupingParameter();
+
+  public static final ComboParameter<ColorByNumericOption> colorNumericValues = new ComboParameter<>(
+      "Handle numeric values", """
+      Dates and numbers can be sorted and handled by gradient style paint scales or by distinct colors.
+      """ + Arrays.stream(ColorByNumericOption.values()).map(ColorByNumericOption::getDescription)
+      .collect(Collectors.joining("\n")), ColorByNumericOption.values(), ColorByNumericOption.AUTO);
+
+  public static final ComboParameter<PaintScaleTransform> gradientTransform = new ComboParameter<>(
+      "Gradient transform", """
+      Dates and numbers can be sorted and handled by gradient style paint scales. This is the transform used.""",
+      PaintScaleTransform.values(), PaintScaleTransform.LINEAR);
+
+  public ColorByMetadataColumnParameters() {
+    super(colorByColumn, colorNumericValues, gradientTransform);
+  }
+
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataConfig.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataConfig.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2004-2025 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.visualization.projectmetadata.color;
+
+import io.github.mzmine.gui.chartbasics.chartutils.paintscales.PaintScaleTransform;
+import io.github.mzmine.main.ConfigService;
+import io.github.mzmine.main.MZmineConfiguration;
+import io.github.mzmine.util.color.SimpleColorPalette;
+
+public record ColorByMetadataConfig(ColorByNumericOption handleNumericOption,
+                                    PaintScaleTransform transform,
+                                    SimpleColorPalette categoryPalette,
+                                    SimpleColorPalette transformPalette) {
+
+  public ColorByMetadataConfig(ColorByNumericOption handleNumericOption,
+      PaintScaleTransform transform, SimpleColorPalette categoryPalette,
+      SimpleColorPalette transformPalette) {
+    this.handleNumericOption = handleNumericOption;
+    this.transform = transform;
+    this.categoryPalette = categoryPalette;
+    this.transformPalette = transformPalette;
+  }
+
+  public ColorByMetadataConfig(ColorByNumericOption handleNumericOption,
+      PaintScaleTransform transform) {
+    final MZmineConfiguration config = ConfigService.getConfiguration();
+    this(handleNumericOption, transform, config.getDefaultColorPalette().clone(true),
+        config.getDefaultPaintScalePalette().clone(true));
+  }
+
+  public static ColorByMetadataConfig createDefault() {
+    return new ColorByMetadataConfig(ColorByNumericOption.AUTO, PaintScaleTransform.LINEAR);
+  }
+
+  public boolean isUseGradient(int size) {
+    return handleNumericOption.isUseGradient(size);
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataConfig.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataConfig.java
@@ -31,27 +31,45 @@ import io.github.mzmine.main.MZmineConfiguration;
 import io.github.mzmine.util.color.SimpleColorPalette;
 
 /**
- * @param handleNumericOption an option how to handle numeric and date values. Either gradient or
- *                            distinct colors or automatic gradient for large sample sets.
- * @param transform           transformation for the transformPalette paint scale to interpolate
- *                            colors between each step.
- * @param categoryPalette     For {@link ColorByNumericOption#DISCRETE}: this palette holds distinct
- *                            colors for categories without interpolation. Usually:
- *                            {@link MZmineConfiguration#getDefaultColorPalette()}
- * @param transformPalette    For {@link ColorByNumericOption#GRADIENT}: this palette holds colors
- *                            for interpolation PaintScales and applies the transform. Usually
- *                            {@link MZmineConfiguration#getDefaultPaintScalePalette()}
+ * @param handleNumericOption        an option how to handle numeric and date values. Either
+ *                                   gradient or distinct colors or automatic gradient for large
+ *                                   sample sets.
+ * @param transform                  transformation for the transformPalette paint scale to
+ *                                   interpolate colors between each step.
+ * @param cloneResetCategoryPalette  For {@link ColorByNumericOption#DISCRETE}: this palette holds
+ *                                   distinct colors for categories without interpolation. Usually:
+ *                                   {@link MZmineConfiguration#getDefaultColorPalette()}. Notice:
+ *                                   this will always return a clone with reset index!
+ * @param cloneResetTransformPalette For {@link ColorByNumericOption#GRADIENT}: this palette holds
+ *                                   colors for interpolation PaintScales and applies the transform.
+ *                                   Usually
+ *                                   {@link MZmineConfiguration#getDefaultPaintScalePalette()}
+ *                                   Notice: this will always return a clone with reset index!
  */
 public record ColorByMetadataConfig(ColorByNumericOption handleNumericOption,
                                     PaintScaleTransform transform,
-                                    SimpleColorPalette categoryPalette,
-                                    SimpleColorPalette transformPalette) {
+                                    SimpleColorPalette cloneResetCategoryPalette,
+                                    SimpleColorPalette cloneResetTransformPalette) {
 
   public ColorByMetadataConfig(ColorByNumericOption handleNumericOption,
       PaintScaleTransform transform) {
     final MZmineConfiguration config = ConfigService.getConfiguration();
     this(handleNumericOption, transform, config.getDefaultColorPalette().clone(true),
         config.getDefaultPaintScalePalette().clone(true));
+  }
+
+  /**
+   * @return always a clone with reset index
+   */
+  public SimpleColorPalette cloneResetCategoryPalette() {
+    return cloneResetCategoryPalette.clone(true);
+  }
+
+  /**
+   * @return always a clone with reset index
+   */
+  public SimpleColorPalette cloneResetTransformPalette() {
+    return cloneResetTransformPalette.clone(true);
   }
 
   public static ColorByMetadataConfig createDefault() {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataConfig.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataConfig.java
@@ -30,19 +30,22 @@ import io.github.mzmine.main.ConfigService;
 import io.github.mzmine.main.MZmineConfiguration;
 import io.github.mzmine.util.color.SimpleColorPalette;
 
+/**
+ * @param handleNumericOption an option how to handle numeric and date values. Either gradient or
+ *                            distinct colors or automatic gradient for large sample sets.
+ * @param transform           transformation for the transformPalette paint scale to interpolate
+ *                            colors between each step.
+ * @param categoryPalette     For {@link ColorByNumericOption#DISCRETE}: this palette holds distinct
+ *                            colors for categories without interpolation. Usually:
+ *                            {@link MZmineConfiguration#getDefaultColorPalette()}
+ * @param transformPalette    For {@link ColorByNumericOption#GRADIENT}: this palette holds colors
+ *                            for interpolation PaintScales and applies the transform. Usually
+ *                            {@link MZmineConfiguration#getDefaultPaintScalePalette()}
+ */
 public record ColorByMetadataConfig(ColorByNumericOption handleNumericOption,
                                     PaintScaleTransform transform,
                                     SimpleColorPalette categoryPalette,
                                     SimpleColorPalette transformPalette) {
-
-  public ColorByMetadataConfig(ColorByNumericOption handleNumericOption,
-      PaintScaleTransform transform, SimpleColorPalette categoryPalette,
-      SimpleColorPalette transformPalette) {
-    this.handleNumericOption = handleNumericOption;
-    this.transform = transform;
-    this.categoryPalette = categoryPalette;
-    this.transformPalette = transformPalette;
-  }
 
   public ColorByMetadataConfig(ColorByNumericOption handleNumericOption,
       PaintScaleTransform transform) {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataGroup.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataGroup.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2004-2025 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.visualization.projectmetadata.color;
+
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.javafx.util.FxColorUtil;
+import io.github.mzmine.modules.visualization.projectmetadata.table.SamplesGroupedBy;
+import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
+import java.util.List;
+import javafx.scene.paint.Color;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Group by a column with specific color
+ */
+public record ColorByMetadataGroup(SamplesGroupedBy<?> group, Color color,
+                                   @Nullable MetadataColumn<?> column) {
+
+  public int size() {
+    return group.size();
+  }
+
+  public boolean isNullValue() {
+    return group.isNullValue();
+  }
+
+  public String valueString() {
+    return group.valueString();
+  }
+
+  public java.awt.Color colorAWT() {
+    return FxColorUtil.fxColorToAWT(color);
+  }
+
+  public @NotNull List<RawDataFile> files() {
+    return group().files();
+  }
+
+  public @Nullable Object value() {
+    return group.value();
+  }
+
+  /**
+   * @return a double value to enable comparison. Date and numbers are converted and strings usually
+   * just follow the group order as integers.
+   */
+  public double doubleValue() {
+    return group.doubleValue();
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataParameters.java
@@ -37,7 +37,6 @@ import io.github.mzmine.parameters.parametertypes.metadata.MetadataGroupingParam
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesSelection;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesSelectionType;
-import io.github.mzmine.parameters.parametertypes.submodules.EmbeddedComponentOptions;
 import io.github.mzmine.parameters.parametertypes.submodules.OptionalModuleParameter;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +50,7 @@ public class ColorByMetadataParameters extends SimpleParameterSet {
 
   public static OptionalModuleParameter<ColorByMetadataColumnParameters> columnSelection = new OptionalModuleParameter<>(
       "Metadata selection", "Select column and how to handle coloring",
-      EmbeddedComponentOptions.VIEW_IN_PANEL, new ColorByMetadataColumnParameters(), false);
+      new ColorByMetadataColumnParameters(), false, false);
 
   // use a medium range so that colors are not to light or dark
   public static final PercentParameter brightnessPercentRange = new PercentParameter(

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -26,6 +26,8 @@
 package io.github.mzmine.modules.visualization.projectmetadata.color;
 
 import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.gui.chartbasics.chartutils.paintscales.PaintScaleTransform;
+import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.BooleanParameter;
@@ -35,7 +37,10 @@ import io.github.mzmine.parameters.parametertypes.metadata.MetadataGroupingParam
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesSelection;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesSelectionType;
+import io.github.mzmine.parameters.parametertypes.submodules.EmbeddedComponentOptions;
+import io.github.mzmine.parameters.parametertypes.submodules.OptionalModuleParameter;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 
 public class ColorByMetadataParameters extends SimpleParameterSet {
@@ -43,8 +48,10 @@ public class ColorByMetadataParameters extends SimpleParameterSet {
   public static final RawDataFilesParameter rawFiles = new RawDataFilesParameter(
       new RawDataFilesSelection(RawDataFilesSelectionType.ALL_FILES));
 
-  public static final OptionalParameter<MetadataGroupingParameter> colorByColumn = new OptionalParameter<>(
-      new MetadataGroupingParameter());
+
+  public static OptionalModuleParameter<ColorByMetadataColumnParameters> columnSelection = new OptionalModuleParameter<>(
+      "Metadata selection", "Select column and how to handle coloring",
+      EmbeddedComponentOptions.VIEW_IN_PANEL, new ColorByMetadataColumnParameters(), false);
 
   // use a medium range so that colors are not to light or dark
   public static final PercentParameter brightnessPercentRange = new PercentParameter(
@@ -57,18 +64,47 @@ public class ColorByMetadataParameters extends SimpleParameterSet {
   public static final BooleanParameter applySorting = new BooleanParameter("Sort data files",
       "Sort raw data files", true);
 
+  // OLD PARAMETER FOR MAPPING
+  public final OptionalParameter<MetadataGroupingParameter> colorByColumn = new OptionalParameter<>(
+      new MetadataGroupingParameter());
 
   public ColorByMetadataParameters() {
-    super(rawFiles, colorByColumn, brightnessPercentRange, separateBlankQcs, applySorting);
+    super(rawFiles, columnSelection, brightnessPercentRange, separateBlankQcs, applySorting);
   }
 
   public static ParameterSet createDefault(final @NotNull List<RawDataFile> selected) {
     ParameterSet params = new ColorByMetadataParameters().cloneParameterSet();
     params.setParameter(rawFiles, new RawDataFilesSelection(selected.toArray(RawDataFile[]::new)));
-    params.setParameter(colorByColumn, false);
+    params.setParameter(columnSelection, false);
+    final var columnSelect = params.getParameter(columnSelection).getEmbeddedParameters();
+
+    columnSelect.setParameter(ColorByMetadataColumnParameters.gradientTransform,
+        PaintScaleTransform.LINEAR);
+    columnSelect.setParameter(ColorByMetadataColumnParameters.colorNumericValues,
+        ColorByNumericOption.AUTO);
+
     params.setParameter(brightnessPercentRange, 0.4);
     params.setParameter(separateBlankQcs, true);
     params.setParameter(applySorting, true);
     return params;
+  }
+
+
+  @Override
+  public Map<String, Parameter<?>> getNameParameterMap() {
+    var map = super.getNameParameterMap();
+    map.put(colorByColumn.getName(), colorByColumn);
+    return map;
+  }
+
+  @Override
+  public void handleLoadedParameters(Map<String, Parameter<?>> loadedParams) {
+    // transfer old parameter type to new type
+    if (loadedParams.containsKey(colorByColumn.getName())) {
+      getParameter(columnSelection).setValue(colorByColumn.getValue());
+      getParameter(columnSelection).getEmbeddedParameters()
+          .setParameter(ColorByMetadataColumnParameters.colorByColumn,
+              colorByColumn.getEmbeddedParameter().getValue());
+    }
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataResults.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataResults.java
@@ -46,10 +46,18 @@ public record ColorByMetadataResults(List<ColorByMetadataGroup> groups, PaintSca
     return groups.get(groupIndex);
   }
 
+  /**
+   * @return the min double value to enable comparison. Date and numbers are converted and strings
+   * usually just follow the group order as integers.
+   */
   public double getMinValueDouble() {
     return groups.getFirst().doubleValue();
   }
 
+  /**
+   * @return the max double value to enable comparison. Date and numbers are converted and strings
+   * usually just follow the group order as integers.
+   */
   public double getMaxValueDouble() {
     return groups.getLast().doubleValue();
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataResults.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataResults.java
@@ -25,50 +25,29 @@
 
 package io.github.mzmine.modules.visualization.projectmetadata.color;
 
-import io.github.mzmine.datamodel.RawDataFile;
-import io.github.mzmine.javafx.util.FxColorUtil;
-import io.github.mzmine.modules.visualization.projectmetadata.table.SamplesGroupedBy;
-import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
 import java.util.List;
-import javafx.scene.paint.Color;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jfree.chart.renderer.PaintScale;
 
-/**
- * Group by a column with specific color
- */
-public record ColoredMetadataGroup(SamplesGroupedBy<?> group, Color color,
-                                   @Nullable MetadataColumn<?> column) {
+public record ColorByMetadataResults(List<ColorByMetadataGroup> groups, PaintScale paintScale,
+                                     boolean isGradient, ColorByMetadataConfig config) {
+
+  public int numFiles() {
+    return groups.stream().mapToInt(ColorByMetadataGroup::size).sum();
+  }
 
   public int size() {
-    return group.size();
+    return groups.size();
   }
 
-  public boolean isNullValue() {
-    return group.isNullValue();
+  public ColorByMetadataGroup get(int groupIndex) {
+    return groups.get(groupIndex);
   }
 
-  public String valueString() {
-    return group.valueString();
+  public double getMinValueDouble() {
+    return groups.getFirst().doubleValue();
   }
 
-  public java.awt.Color colorAWT() {
-    return FxColorUtil.fxColorToAWT(color);
-  }
-
-  public @NotNull List<RawDataFile> files() {
-    return group().files();
-  }
-
-  public @Nullable Object value() {
-    return group.value();
-  }
-
-  /**
-   * @return a double value to enable comparison. Date and numbers are converted and strings usually
-   * just follow the group order as integers.
-   */
-  public double doubleValue() {
-    return group.doubleValue();
+  public double getMaxValueDouble() {
+    return groups.getLast().doubleValue();
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataResults.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataResults.java
@@ -25,7 +25,10 @@
 
 package io.github.mzmine.modules.visualization.projectmetadata.color;
 
+import io.github.mzmine.main.ConfigService;
+import io.github.mzmine.util.color.SimpleColorPalette;
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
 import org.jfree.chart.renderer.PaintScale;
 
 public record ColorByMetadataResults(List<ColorByMetadataGroup> groups, PaintScale paintScale,
@@ -49,5 +52,18 @@ public record ColorByMetadataResults(List<ColorByMetadataGroup> groups, PaintSca
 
   public double getMaxValueDouble() {
     return groups.getLast().doubleValue();
+  }
+
+  /**
+   * Creates a color palette with the default palette but all colors defined by groups
+   */
+  @NotNull
+  public SimpleColorPalette createColorPalette() {
+    final SimpleColorPalette colors = ConfigService.getDefaultColorPalette().clone(true);
+    colors.clear();
+    for (ColorByMetadataGroup group : groups) {
+      colors.add(group.color());
+    }
+    return colors;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataTask.java
@@ -103,7 +103,7 @@ public class ColorByMetadataTask extends AbstractRawDataFileTask {
     brightnessPercentRange = ColorUtils.maxBrightnessWidth() * parameters.getValue(
         ColorByMetadataParameters.brightnessPercentRange);
 
-    colors = config.categoryPalette();
+    colors = config.cloneResetCategoryPalette();
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataUtils.java
@@ -76,7 +76,7 @@ public class ColorByMetadataUtils {
       final double min = groups.getFirst().doubleValue();
       final double max = Math.max(groups.getLast().doubleValue(), Math.nextUp(min));
 
-      final PaintScale paintScale = config.transformPalette()
+      final PaintScale paintScale = config.cloneResetTransformPalette()
           .toPaintScale(config.transform(), Range.closed(min, max));
       final List<ColorByMetadataGroup> coloredGroups = groups.stream().map(
           group -> new ColorByMetadataGroup(group,
@@ -85,7 +85,7 @@ public class ColorByMetadataUtils {
       return new ColorByMetadataResults(coloredGroups, paintScale, true, config);
     } else {
       // color as categories
-      final SimpleColorPalette colors = config.categoryPalette();
+      final SimpleColorPalette colors = config.cloneResetCategoryPalette();
       final List<ColorByMetadataGroup> coloredGroups = groups.stream()
           .map(group -> new ColorByMetadataGroup(group, colors.getNextColor(), column)).toList();
       final PaintScale paintScale = createPaintScale(coloredGroups);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByMetadataUtils.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2004-2025 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.visualization.projectmetadata.color;
+
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.main.ConfigService;
+import io.github.mzmine.modules.visualization.projectmetadata.MetadataColumnDoesNotExistException;
+import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
+import io.github.mzmine.project.ProjectService;
+import io.github.mzmine.util.color.SimpleColorPalette;
+import java.awt.Color;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jfree.chart.renderer.LookupPaintScale;
+
+public class ColorByMetadataUtils {
+
+  /**
+   * Groups the files by the value in the metadata column. If raw data files have no mapping (null)
+   * they will be put into a group at first index. Sorted by doubleValue ascending.
+   *
+   * @return If the column is null, a list with the input files is returned. If the column is not in
+   * the table, an error is thrown. If values are null - the first entry will be a list for all null
+   * value entries. Each list has at least 1 element.
+   * @throws MetadataColumnDoesNotExistException If the column does not exist. Does not throw if the
+   *                                             column is null.
+   */
+  public static @NotNull List<ColoredMetadataGroup> colorByColumn(
+      final @Nullable MetadataColumn<?> column, final @NotNull List<RawDataFile> raws) {
+    final SimpleColorPalette defaultPalette = ConfigService.getDefaultColorPalette().clone(true);
+    return colorByColumn(defaultPalette, column, raws);
+  }
+
+  /**
+   * Groups the files by the value in the metadata column. If raw data files have no mapping (null)
+   * they will be put into a group at first index. Sorted by doubleValue ascending.
+   *
+   * @return If the column is null, a list with the input files is returned. If the column is not in
+   * the table, an error is thrown. If values are null - the first entry will be a list for all null
+   * value entries. Each list has at least 1 element.
+   * @throws MetadataColumnDoesNotExistException If the column does not exist. Does not throw if the
+   *                                             column is null.
+   */
+  public static @NotNull List<ColoredMetadataGroup> colorByColumn(
+      final @NotNull SimpleColorPalette colors, final @Nullable MetadataColumn<?> column,
+      final @NotNull List<RawDataFile> raws) {
+    var groups = ProjectService.getMetadata().groupFilesByColumnIncludeNull(raws, column);
+    return groups.stream()
+        .map(group -> new ColoredMetadataGroup(group, colors.getNextColor(), column)).toList();
+  }
+
+  /**
+   * Creates paint scale from groups that are already sorted by doubleValue
+   *
+   * @param groups sorted groups
+   * @return paint scale with all groups
+   */
+  public static LookupPaintScale createPaintScale(List<ColoredMetadataGroup> groups) {
+    // already sorted by doubleValue
+    final double min = groups.getFirst().doubleValue();
+    final double max = groups.getLast().doubleValue();
+
+    // should never be visible as all colors are used
+    Color defaultColor = Color.RED;
+
+    // upper end is excluded so need to add a tiny fraction to the upper bound
+    var paintScale = new LookupPaintScale(min, Math.nextUp(max), defaultColor);
+    for (ColoredMetadataGroup group : groups) {
+      paintScale.add(group.doubleValue(), group.colorAWT());
+    }
+    return paintScale;
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByNumericOption.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColorByNumericOption.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2004-2025 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.visualization.projectmetadata.color;
+
+import io.github.mzmine.datamodel.utils.UniqueIdSupplier;
+import org.jetbrains.annotations.NotNull;
+
+public enum ColorByNumericOption implements UniqueIdSupplier {
+  AUTO, GRADIENT, DISCRETE;
+
+  public static final int AUTO_GRADIENT_ABOVE_N_SAMPLES = 6;
+
+  @Override
+  public @NotNull String getUniqueID() {
+    return switch (this) {
+      case AUTO -> "AUTO";
+      case GRADIENT -> "GRADIENT";
+      case DISCRETE -> "DISCRETE";
+    };
+  }
+
+  @Override
+  public String toString() {
+    return switch (this) {
+      case AUTO -> "Auto";
+      case GRADIENT -> "Gradient";
+      case DISCRETE -> "Discrete";
+    };
+  }
+
+  public String getDescription() {
+    return this + switch (this) {
+      case AUTO -> ": Uses Gradient above %d samples".formatted(AUTO_GRADIENT_ABOVE_N_SAMPLES);
+      case DISCRETE -> ": Uses separate colors from default colors";
+      case GRADIENT -> ": Uses Gradient colors from default paint scale";
+    };
+
+  }
+
+  public boolean isUseGradient(int size) {
+    return switch (this) {
+      case AUTO -> size > ColorByNumericOption.AUTO_GRADIENT_ABOVE_N_SAMPLES;
+      case DISCRETE -> false;
+      case GRADIENT -> size > 1;
+    };
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColoredMetadataGroup.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/color/ColoredMetadataGroup.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2004-2025 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.visualization.projectmetadata.color;
+
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.javafx.util.FxColorUtil;
+import io.github.mzmine.modules.visualization.projectmetadata.table.SamplesGroupedBy;
+import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
+import java.util.List;
+import javafx.scene.paint.Color;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Group by a column with specific color
+ */
+public record ColoredMetadataGroup(SamplesGroupedBy<?> group, Color color,
+                                   @Nullable MetadataColumn<?> column) {
+
+  public int size() {
+    return group.size();
+  }
+
+  public boolean isNullValue() {
+    return group.isNullValue();
+  }
+
+  public String valueString() {
+    return group.valueString();
+  }
+
+  public java.awt.Color colorAWT() {
+    return FxColorUtil.fxColorToAWT(color);
+  }
+
+  public @NotNull List<RawDataFile> files() {
+    return group().files();
+  }
+
+  public @Nullable Object value() {
+    return group.value();
+  }
+
+  /**
+   * @return a double value to enable comparison. Date and numbers are converted and strings usually
+   * just follow the group order as integers.
+   */
+  public double doubleValue() {
+    return group.doubleValue();
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/MetadataTable.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/MetadataTable.java
@@ -380,7 +380,13 @@ public class MetadataTable {
         nonNullMap.size() + (hasNulls ? 1 : 0));
 
     int counter = hasNulls ? 1 : 0;
-    for (Entry<Object, @NotNull List<RawDataFile>> e : nonNullMap.entrySet()) {
+
+    // in case we have string values - sort by toString as we will then just number each group.
+    // numbers and dates will be sorted after the convertToDouble conversion
+    final List<Entry<Object, @NotNull List<RawDataFile>>> entries = nonNullMap.entrySet().stream()
+        .sorted(Comparator.comparing(e -> e.getKey().toString())).toList();
+    
+    for (Entry<Object, @NotNull List<RawDataFile>> e : entries) {
       final List<RawDataFile> rawFiles = e.getValue();
       final Object value = e.getKey();
       final double doubleValue = convertValueToDouble(value, counter);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/MetadataTable.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/MetadataTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -37,11 +37,17 @@ import io.github.mzmine.modules.visualization.projectmetadata.table.columns.Date
 import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
 import io.github.mzmine.modules.visualization.projectmetadata.table.columns.StringMetadataColumn;
 import io.github.mzmine.project.ProjectService;
+import io.github.mzmine.util.StringUtils;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -314,6 +320,104 @@ public class MetadataTable {
     return raws.stream().filter(raw -> fileValueMap.get(raw) != null)
         .collect(Collectors.groupingBy(raw -> (T) fileValueMap.get(raw)));
   }
+
+  /**
+   * Groups the files by the value in the metadata column. If raw data files have no mapping (null)
+   * they will be put into a group at first index. Sorted by doubleValue ascending.
+   *
+   * @param <T>
+   * @return If the column is null, a list with the input files is returned. If the column is not in
+   * the table, an error is thrown. If values are null - the first entry will be a list for all null
+   * value entries. Each list has at least 1 element.
+   * @throws MetadataColumnDoesNotExistException If the column does not exist. Does not throw if the
+   *                                             column is null.
+   */
+  @NotNull
+  public <T> List<SamplesGroupedBy<T>> groupFilesByColumnIncludeNull(
+      @Nullable MetadataColumn<T> column) throws MetadataColumnDoesNotExistException {
+    final List<RawDataFile> files = ProjectService.getProject().getCurrentRawDataFiles();
+    return groupFilesByColumnIncludeNull(files, column);
+  }
+
+  /**
+   * Groups the files by the value in the metadata column. If raw data files have no mapping (null)
+   * they will be put into a group at first index. Sorted by doubleValue ascending.
+   *
+   * @param <T>
+   * @return If the column is null, a list with the input files is returned. If the column is not in
+   * the table, an error is thrown. If values are null - the first entry will be a list for all null
+   * value entries. Each list has at least 1 element.
+   * @throws MetadataColumnDoesNotExistException If the column does not exist. Does not throw if the
+   *                                             column is null.
+   */
+  @NotNull
+  public <T> List<SamplesGroupedBy<T>> groupFilesByColumnIncludeNull(
+      @NotNull Collection<RawDataFile> raws, @Nullable MetadataColumn<T> column)
+      throws MetadataColumnDoesNotExistException {
+    if (column == null) {
+      return List.of(new SamplesGroupedBy<>(null, List.copyOf(raws), 0));
+    }
+    final Map<RawDataFile, Object> fileValueMap = data.get(column);
+    if (fileValueMap == null) {
+      throw new MetadataColumnDoesNotExistException(column.getTitle());
+    }
+
+    final Map<Object, @NotNull List<RawDataFile>> nonNullMap = new HashMap<>();
+    List<RawDataFile> nullsList = new ArrayList<>();
+    for (RawDataFile raw : raws) {
+      final Object value = fileValueMap.get(raw);
+      if (value == null || StringUtils.isBlank(value.toString())) {
+        nullsList.add(raw);
+      } else {
+        // add to specific list
+        final List<RawDataFile> list = nonNullMap.computeIfAbsent(value, _ -> new ArrayList<>());
+        list.add(raw);
+      }
+    }
+    boolean hasNulls = !nullsList.isEmpty();
+    final List<SamplesGroupedBy<T>> groups = new ArrayList<>(
+        nonNullMap.size() + (hasNulls ? 1 : 0));
+
+    double minValue = Double.MAX_VALUE;
+    int counter = hasNulls ? 1 : 0;
+    for (Entry<Object, @NotNull List<RawDataFile>> e : nonNullMap.entrySet()) {
+      final List<RawDataFile> rawFiles = e.getValue();
+      final Object value = e.getKey();
+      final double doubleValue = convertValueToDouble(value, counter);
+      groups.add(new SamplesGroupedBy<>((T) value, rawFiles, doubleValue));
+      counter++;
+
+      if (doubleValue < minValue) {
+        minValue = doubleValue;
+      }
+    }
+    // requires sorting by value which is always comparable in table
+    groups.sort(Comparator.comparing(SamplesGroupedBy::doubleValue));
+
+    if (hasNulls) {
+      // always first if present
+      groups.addFirst(new SamplesGroupedBy<>(null, nullsList, minValue - 1));
+    }
+
+    return groups;
+  }
+
+  /**
+   * Date or number value is converted to double and other objects will use default
+   *
+   * @return Double.NaN for null values, doubles for dates and number, and string default for not
+   * empty strings (blank strings are handled like null as NaN)
+   */
+  public static double convertValueToDouble(@Nullable Object value, double stringDefaultValue) {
+    return switch (value) {
+      case null -> Double.NaN;
+      case Number n -> n.doubleValue();
+      case LocalDateTime date -> date.toEpochSecond(ZoneOffset.UTC);
+      case String s -> s.isBlank() ? Double.NaN : stringDefaultValue;
+      default -> stringDefaultValue;
+    };
+  }
+
 
   /**
    * @param column The column

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/SamplesGroupedBy.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/SamplesGroupedBy.java
@@ -72,16 +72,6 @@ public final class SamplesGroupedBy<T> {
     return value;
   }
 
-  public @Nullable Comparable getComparableValueOrString() {
-    if (value == null) {
-      return null;
-    }
-    if (value instanceof Comparable<?>) {
-      return (Comparable<?>) value;
-    }
-    return value.toString();
-  }
-
   public @NotNull List<RawDataFile> files() {
     return files;
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/SamplesGroupedBy.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/SamplesGroupedBy.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2004-2025 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.visualization.projectmetadata.table;
+
+import io.github.mzmine.datamodel.RawDataFile;
+import java.util.List;
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This allows nullable value for grouping by
+ */
+public final class SamplesGroupedBy<T> {
+
+  private final @Nullable T value;
+  private final @NotNull List<RawDataFile> files;
+  private final double doubleValue;
+
+  /**
+   * @param value       the value grouped by
+   * @param files
+   * @param doubleValue a double value to enable comparison. Date and numbers are converted and
+   *                    strings usually just follow the group order as integers.
+   */
+  public SamplesGroupedBy(@Nullable T value, @NotNull List<RawDataFile> files, double doubleValue) {
+    this.value = value;
+    this.files = files;
+    this.doubleValue = doubleValue;
+  }
+
+  /**
+   * @return a double value to enable comparison. Date and numbers are converted and strings usually
+   * just follow the group order as integers.
+   */
+  public double doubleValue() {
+    return doubleValue;
+  }
+
+  public boolean isNullValue() {
+    return value == null;
+  }
+
+  public int size() {
+    return files.size();
+  }
+
+  public @Nullable T value() {
+    return value;
+  }
+
+  public @Nullable Comparable getComparableValueOrString() {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof Comparable<?>) {
+      return (Comparable<?>) value;
+    }
+    return value.toString();
+  }
+
+  public @NotNull List<RawDataFile> files() {
+    return files;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj == null || obj.getClass() != this.getClass()) {
+      return false;
+    }
+    var that = (SamplesGroupedBy) obj;
+    return Objects.equals(this.value, that.value) && Objects.equals(this.files, that.files)
+        && Objects.equals(this.doubleValue, that.doubleValue);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value, files);
+  }
+
+  @Override
+  public String toString() {
+    return "SamplesGroupedBy[" + "value=" + value + ", " + "files=" + files + ']';
+  }
+
+
+  /**
+   * @return N/A for null or toString otherwise
+   */
+  public String valueString() {
+    if (value == null) {
+      return "unnamed";
+    }
+    return value.toString();
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/columns/MetadataColumn.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/columns/MetadataColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -209,5 +209,17 @@ public abstract sealed class MetadataColumn<T> implements Comparable<MetadataCol
 
     // then alphabetical order
     return this.getTitle().toLowerCase().compareTo(o.getTitle().toLowerCase());
+  }
+
+  /**
+   * Date and number column have a natural order like the acquisition or concentration
+   *
+   * @return true if date or number
+   */
+  public boolean hasNaturalOrder() {
+    return switch (this) {
+      case DoubleMetadataColumn _, DateMetadataColumn _ -> true;
+      default -> false;
+    };
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/submodules/OptionalModuleComponent.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/submodules/OptionalModuleComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -62,12 +62,24 @@ public class OptionalModuleComponent extends BorderPane implements EstimatedComp
 
   public OptionalModuleComponent(ParameterSet embeddedParameters,
       EmbeddedComponentOptions viewOption, boolean alwaysActive) {
-    this(embeddedParameters, viewOption, "", alwaysActive, alwaysActive);
+    this(embeddedParameters, viewOption, alwaysActive, true);
+  }
+
+  public OptionalModuleComponent(ParameterSet embeddedParameters,
+      EmbeddedComponentOptions viewOption, boolean alwaysActive, boolean hidden) {
+    this(embeddedParameters, viewOption, "", alwaysActive, alwaysActive, hidden);
   }
 
   public OptionalModuleComponent(ParameterSet embeddedParameters,
       EmbeddedComponentOptions viewOption, String title, boolean alwaysActive, boolean active) {
+    this(embeddedParameters, viewOption, title, alwaysActive, active, true);
+  }
+
+  public OptionalModuleComponent(ParameterSet embeddedParameters,
+      EmbeddedComponentOptions viewOption, String title, boolean alwaysActive, boolean active,
+      boolean openHidden) {
     super();
+    this.hidden.set(openHidden);
     checkBox = new CheckBox(title);
     setSelected(active);
     checkBox.selectedProperty().addListener((ob, ov, nv) -> applyCheckBoxState());
@@ -79,25 +91,23 @@ public class OptionalModuleComponent extends BorderPane implements EstimatedComp
       // use internal parameter pane
       paramPane = ParameterSetupPane.createEmbedded(true, embeddedParameters, null);
 
-      setButton = new Button("Show");
-      setButton.setOnAction(e -> {
-        boolean toggledHidden = !hidden.get();
+      setButton = new Button("");
+      setButton.setOnAction(e -> hidden.set(!hidden.get()));
+      setButton.setDisable(!active);
+
+      hidden.subscribe(hidden -> {
         // change text
-        setButton.setText(toggledHidden ? "Show" : "Hide");
-        setCenter(toggledHidden ? null : paramPane);
-        // events
-        hidden.set(toggledHidden);
+        setButton.setText(hidden ? "Show" : "Hide");
+        setCenter(hidden ? null : paramPane);
 
         // estimate new height
-        var params =
-            toggledHidden ? 0 : getEmbeddedParameterPane().getParametersAndComponents().size();
+        var params = hidden ? 0 : getEmbeddedParameterPane().getParametersAndComponents().size();
         setEstimatedHeight(params);
 
         setEstimatedDefaultWidth(params == 0);
 
-        onViewStateChange(toggledHidden);
+        onViewStateChange(hidden);
       });
-      setButton.setDisable(!active);
     }
     topPane = new FlowPane();
     topPane.setHgap(5d);

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/submodules/OptionalModuleParameter.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/submodules/OptionalModuleParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -48,6 +48,7 @@ public class OptionalModuleParameter<T extends ParameterSet> implements
   private final EmbeddedComponentOptions componentViewOption;
   private T embeddedParameters;
   private boolean value;
+  private final boolean openHidden;
 
   public OptionalModuleParameter(String name, String description, T embeddedParameters) {
     this(name, description, EmbeddedComponentOptions.VIEW_IN_PANEL, embeddedParameters);
@@ -60,17 +61,30 @@ public class OptionalModuleParameter<T extends ParameterSet> implements
 
   public OptionalModuleParameter(String name, String description, T embeddedParameters,
       boolean defaultVal) {
-    this(name, description, EmbeddedComponentOptions.VIEW_IN_PANEL, embeddedParameters, defaultVal);
+    this(name, description, embeddedParameters, defaultVal, true);
+  }
+
+  public OptionalModuleParameter(String name, String description, T embeddedParameters,
+      boolean defaultVal, boolean openHidden) {
+    this(name, description, EmbeddedComponentOptions.VIEW_IN_PANEL, embeddedParameters, defaultVal,
+        openHidden);
   }
 
   public OptionalModuleParameter(String name, String description,
       EmbeddedComponentOptions componentViewOption, T embeddedParameters, boolean defaultVal) {
+    this(name, description, componentViewOption, embeddedParameters, defaultVal, true);
+  }
+
+  public OptionalModuleParameter(String name, String description,
+      EmbeddedComponentOptions componentViewOption, T embeddedParameters, boolean defaultVal,
+      boolean openHidden) {
     this.name = name;
     this.description = description;
     this.componentViewOption = componentViewOption;
     // requires cloning to avoid usage of static parameters
     this.embeddedParameters = (T) embeddedParameters.cloneParameterSet();
     value = defaultVal;
+    this.openHidden = openHidden;
   }
 
   public T getEmbeddedParameters() {
@@ -98,7 +112,8 @@ public class OptionalModuleParameter<T extends ParameterSet> implements
 
   @Override
   public OptionalModuleComponent createEditingComponent() {
-    return new OptionalModuleComponent(embeddedParameters, componentViewOption, "", false, value);
+    return new OptionalModuleComponent(embeddedParameters, componentViewOption, "", false, value,
+        openHidden);
   }
 
   @Override
@@ -115,7 +130,7 @@ public class OptionalModuleParameter<T extends ParameterSet> implements
   public OptionalModuleParameter<T> cloneParameter() {
     final T embeddedParametersClone = (T) embeddedParameters.cloneParameterSet();
     return new OptionalModuleParameter<>(name, description, componentViewOption,
-        embeddedParametersClone, getValue());
+        embeddedParametersClone, getValue(), openHidden);
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/util/color/SimpleColorPalette.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/color/SimpleColorPalette.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -34,6 +34,7 @@ import io.github.mzmine.gui.chartbasics.chartutils.paintscales.PaintScaleTransfo
 import io.github.mzmine.javafx.util.FxColorUtil;
 import io.github.mzmine.javafx.util.color.ColorsFX;
 import io.github.mzmine.javafx.util.color.Vision;
+import io.github.mzmine.modules.dataprocessing.featdet_masscalibration.charts.ChartUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -42,7 +43,9 @@ import java.util.logging.Logger;
 import javafx.collections.ModifiableObservableListBase;
 import javafx.scene.paint.Color;
 import org.jetbrains.annotations.NotNull;
+import org.jfree.chart.JFreeChart;
 import org.jfree.chart.plot.DefaultDrawingSupplier;
+import org.jfree.chart.plot.Plot;
 import org.w3c.dom.Element;
 
 /**
@@ -155,15 +158,28 @@ public class SimpleColorPalette extends ModifiableObservableListBase<Color> impl
   }
 
   public void applyToChartTheme(EStandardChartTheme theme) {
+    final DefaultDrawingSupplier drawingSupplier = createDrawingSupplier();
+    theme.setDrawingSupplier(drawingSupplier);
+  }
 
+  private @NotNull DefaultDrawingSupplier createDrawingSupplier() {
     List<java.awt.Color> awtColors = new ArrayList<>();
     this.forEach(c -> awtColors.add(FxColorUtil.fxColorToAWT(c)));
     java.awt.Color colors[] = awtColors.toArray(new java.awt.Color[0]);
 
-    theme.setDrawingSupplier(new DefaultDrawingSupplier(colors, colors, colors,
-        DefaultDrawingSupplier.DEFAULT_STROKE_SEQUENCE,
+    final DefaultDrawingSupplier drawingSupplier = new DefaultDrawingSupplier(colors, colors,
+        colors, DefaultDrawingSupplier.DEFAULT_STROKE_SEQUENCE,
         DefaultDrawingSupplier.DEFAULT_OUTLINE_STROKE_SEQUENCE,
-        DefaultDrawingSupplier.DEFAULT_SHAPE_SEQUENCE));
+        DefaultDrawingSupplier.DEFAULT_SHAPE_SEQUENCE);
+    return drawingSupplier;
+  }
+
+  public void applyToChart(@NotNull JFreeChart chart) {
+    final DefaultDrawingSupplier drawingSupplier = createDrawingSupplier();
+    final List<Plot> plots = ChartUtils.streamPlots(chart).toList();
+    for (Plot plot : plots) {
+      plot.setDrawingSupplier(drawingSupplier);
+    }
   }
 
   /**
@@ -536,4 +552,5 @@ public class SimpleColorPalette extends ModifiableObservableListBase<Color> impl
     final Color fxColor = FxColorUtil.awtColorToFX(clr);
     return super.indexOf(fxColor);
   }
+
 }


### PR DESCRIPTION
Adds grouping by metadata including null values.

Harmonizes the coloring by metadata used by the module, stats, etc

Two options:
- discrete colors
- gradients for dates or number
- dates are converted to numbers

Automatically sorts by string value or doubleValue 

![image](https://github.com/user-attachments/assets/8d88bbb8-3ce1-4a5d-ad03-8724adc5d2e7)

By injection order:
![image](https://github.com/user-attachments/assets/fa418126-86ad-4bd6-ac2b-2b44f371cacf)


Can also be done by injection date (different dataset)
![image](https://github.com/user-attachments/assets/43b48fcb-c76a-43f4-8668-f7c80d093d35)

