### PR TITLE
Fix shimadzu mzml

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_all/AllSpectralDataImportModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_all/AllSpectralDataImportModule.java
@@ -398,7 +398,7 @@ public class AllSpectralDataImportModule implements MZmineProcessingModule {
               scanProcessorConfig);
 //      case AIRD -> throw new IllegalStateException("Unexpected value: " + fileType);
       // When adding a new file type, also add to MSConvertImportTask#getSupportedFileTypes()
-      case WATERS_RAW, WATERS_RAW_IMS, SCIEX_WIFF, SCIEX_WIFF2, AGILENT_D, AGILENT_D_IMS ->
+      case WATERS_RAW, WATERS_RAW_IMS, SCIEX_WIFF, SCIEX_WIFF2, AGILENT_D, AGILENT_D_IMS, SHIMADZU_LCD ->
           new MSConvertImportTask(storage, moduleCallDate, file, scanProcessorConfig, project,
               module, parameters);
     };
@@ -442,7 +442,7 @@ public class AllSpectralDataImportModule implements MZmineProcessingModule {
           new BafImportTask(storage, moduleCallDate, file, module, parameters, project,
               scanProcessorConfig);
       // When adding a new file type, also add to MSConvertImportTask#getSupportedFileTypes()
-      case AGILENT_D, AGILENT_D_IMS, SCIEX_WIFF, SCIEX_WIFF2, WATERS_RAW, WATERS_RAW_IMS ->
+      case AGILENT_D, AGILENT_D_IMS, SCIEX_WIFF, SCIEX_WIFF2, WATERS_RAW, WATERS_RAW_IMS, SHIMADZU_LCD ->
           new MSConvertImportTask(storage, moduleCallDate, file, scanProcessorConfig, project,
               module, parameters);
       // all unsupported tasks are wrapped to apply import and mass detection separately

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvertImportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_msconvert/MSConvertImportTask.java
@@ -152,6 +152,7 @@ public class MSConvertImportTask extends AbstractTask implements RawDataImportTa
       case SCIEX_WIFF -> true;
       case SCIEX_WIFF2 -> true;
       case AGILENT_D -> true;
+      case SHIMADZU_LCD -> true;
       case WATERS_RAW_IMS, AGILENT_D_IMS -> false;
     };
   }
@@ -434,7 +435,7 @@ public class MSConvertImportTask extends AbstractTask implements RawDataImportTa
   public static Set<RawDataFileType> getSupportedFileTypes() {
     return Set.of(RawDataFileType.WATERS_RAW, RawDataFileType.WATERS_RAW_IMS,
         RawDataFileType.SCIEX_WIFF, RawDataFileType.SCIEX_WIFF2, RawDataFileType.AGILENT_D,
-        RawDataFileType.AGILENT_D_IMS, RawDataFileType.THERMO_RAW);
+        RawDataFileType.AGILENT_D_IMS, RawDataFileType.THERMO_RAW, RawDataFileType.SHIMADZU_LCD);
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/msdk/data/MzMLPeaksDecoder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/msdk/data/MzMLPeaksDecoder.java
@@ -158,7 +158,7 @@ public class MzMLPeaksDecoder {
         dis.close();
         throw new IllegalArgumentException(
             "Precision MUST be specified and be either 32-bit or 64-bit, "
-            + "if MS-NUMPRESS compression was not used");
+                + "if MS-NUMPRESS compression was not used");
     }
 
     try {
@@ -243,7 +243,13 @@ public class MzMLPeaksDecoder {
       data = new double[numPoints];
     }
 
-    byte[] bytes = Base64.getDecoder().decode(binaryData);
+    byte[] bytes;
+    if (binaryData.charAt(0) == '\n') {
+      // shimadzu's in-house converter uses an illegal linebreak in a binary array
+      bytes = Base64.getDecoder().decode(binaryData.substring(1));
+    } else {
+      bytes = Base64.getDecoder().decode(binaryData);
+    }
 
     if (binaryDataInfo.getCompressionType().isZlibCompressed()) {
       // if CVParam states the data is compressed

--- a/mzmine-community/src/main/java/io/github/mzmine/util/RawDataFileType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/RawDataFileType.java
@@ -57,7 +57,8 @@ public enum RawDataFileType {
   SCIEX_WIFF(ExtensionFilters.WIFF, false), //
   SCIEX_WIFF2(ExtensionFilters.WIFF2, false), //
   AGILENT_D(ExtensionFilters.BRUKER_OR_AGILENT_D, true), //
-  AGILENT_D_IMS(ExtensionFilters.BRUKER_OR_AGILENT_D, true);
+  AGILENT_D_IMS(ExtensionFilters.BRUKER_OR_AGILENT_D, true), //
+  SHIMADZU_LCD(ExtensionFilters.SHIMADZU, false);
 
 
   private final ExtensionFilter extensionFilter;
@@ -82,8 +83,8 @@ public enum RawDataFileType {
 
     return switch (type) {
       case MZML, MZXML, MZML_IMS, MZDATA, NETCDF, THERMO_RAW, MZML_ZIP, MZML_GZIP, ICPMSMS_CSV,
-           BRUKER_TDF, BRUKER_TSF, BRUKER_BAF, AGILENT_D, AGILENT_D_IMS, WATERS_RAW,
-           WATERS_RAW_IMS -> List.of();
+           BRUKER_TDF, BRUKER_TSF, BRUKER_BAF, AGILENT_D, AGILENT_D_IMS, WATERS_RAW, WATERS_RAW_IMS,
+           SHIMADZU_LCD -> List.of();
       case IMZML -> {
         final String extension = FileAndPathUtil.getExtension(file.getName());
         yield List.of(new File(file.getParent(), file.getName().replace(extension, "ibd")));

--- a/mzmine-community/src/main/java/io/github/mzmine/util/RawDataFileTypeDetector.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/RawDataFileTypeDetector.java
@@ -82,6 +82,7 @@ public class RawDataFileTypeDetector {
   public static final String AGILENT_ACQDATATA_FOLDER = "AcqData";
 
   private static final Logger logger = Logger.getLogger(RawDataFileTypeDetector.class.getName());
+  private static final String LCD_SUFFIX = ".lcd";
 
   /**
    * @return Detected file type or null if the file is not of any supported type
@@ -155,6 +156,9 @@ public class RawDataFileTypeDetector {
         }
         if (lowerName.endsWith(TSF_SUFFIX) || lowerName.endsWith(TSF_BIN_SUFFIX)) {
           return RawDataFileType.BRUKER_TSF;
+        }
+        if(lowerName.endsWith(LCD_SUFFIX)) {
+          return RawDataFileType.SHIMADZU_LCD;
         }
 
         // Read the first 1kB of the file into a String

--- a/utils/src/main/java/io/github/mzmine/util/files/ExtensionFilters.java
+++ b/utils/src/main/java/io/github/mzmine/util/files/ExtensionFilters.java
@@ -111,9 +111,10 @@ public class ExtensionFilters {
   public static final ExtensionFilter MZML_ZIP_GZIP = new ExtensionFilter("zip", "*.zip", "*.gz");
   public static final ExtensionFilter WIFF = new ExtensionFilter("wiff", "*.wiff");
   public static final ExtensionFilter WIFF2 = new ExtensionFilter("wiff2", "*.wiff2");
+  public static final ExtensionFilter SHIMADZU = new ExtensionFilter(".lcd", "*.lcd");
   public static final ExtensionFilter ALL_MS_DATA_FILTER = new ExtensionFilter("MS data", "*.mzML",
       "*.mzml", "*.mzXML", "*.mzxml", "*.imzML", "*.imzml", "*.d", "*.tdf", "*.tsf", "*.raw",
-      "*.RAW", "*.mzData", "*.netcdf", "*.mzdata", /*"*.aird",*/ "*.wiff", "*.wiff2");
+      "*.RAW", "*.mzData", "*.netcdf", "*.mzdata", /*"*.aird",*/ "*.wiff", "*.wiff2", "*.lcd");
   public static final List<ExtensionFilter> MS_RAW_DATA = List.of( //
       ALL_MS_DATA_FILTER, //
       MZML, //
@@ -130,6 +131,7 @@ public class ExtensionFilters {
       MZML_ZIP_GZIP, //
       WIFF, //
       WIFF2, //
+      SHIMADZU, //
       ALL_FILES);
   private static final ExtensionFilter ALL_SPECTRAL_LIBRARY_FILTER = new ExtensionFilter(
       "All spectral libraries", "*.json", "*.msp", "*.mgf", "*.jdx");


### PR DESCRIPTION
Shimadzu's own mzml converter starts each binary array with a new line, which is not a legal base 64 character. Thus we check and remove the character now.
Also, added support fir .lcd files via MSConvert

closes #2575 