### PR TITLE
Simplify scan, remove ranges, save memory

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/MobilityScan.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/MobilityScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -34,12 +34,14 @@ import org.jetbrains.annotations.Nullable;
  * Mass spectrum acquired during an ion mobility experiment. The main implementation of this
  * interface, ({@link io.github.mzmine.datamodel.impl.StoredMobilityScan}, is created on demand by
  * the respective parent {@link Frame}. This means, that if available, existing instances shall be
- * reused as done in, e.g. {@link io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilogramTimeSeries#copy(MemoryMapStorage)}
+ * reused as done in, e.g.
+ * {@link
+ * io.github.mzmine.datamodel.featuredata.impl.SimpleIonMobilogramTimeSeries#copy(MemoryMapStorage)}
  * and other methods that copy lists of scans.
  * <p></p>
- * During project import, the instances of this interface are cached in a {@link
- * io.github.mzmine.modules.io.projectload.CachedIMSFrame} to minimize ram consumption by using the
- * same instances throughout all feature lists.
+ * During project import, the instances of this interface are cached in a
+ * {@link io.github.mzmine.modules.io.projectload.CachedIMSFrame} to minimize ram consumption by
+ * using the same instances throughout all feature lists.
  *
  * @author https://github.com/SteffenHeu
  */
@@ -47,8 +49,7 @@ public interface MobilityScan extends Scan {
 
   static final double DEFAULT_MOBILITY = -1.0d;
 
-  @NotNull
-  RawDataFile getDataFile();
+  @NotNull RawDataFile getDataFile();
 
   /**
    * @return The mobility of this sub-spectrum. The unit will depend on the respective mass
@@ -95,8 +96,8 @@ public interface MobilityScan extends Scan {
   }
 
   /**
-   * Returns the frame id. The mobility scan number can be accessed via {@link
-   * MobilityScan#getMobilityScanNumber()}.
+   * Returns the frame id. The mobility scan number can be accessed via
+   * {@link MobilityScan#getMobilityScanNumber()}.
    *
    * @return The frame Id. {@link Frame#getScanNumber()}.
    */
@@ -111,9 +112,8 @@ public interface MobilityScan extends Scan {
     return getFrame().getScanDefinition() + " - Mobility scan #" + getMobilityScanNumber();
   }
 
-  @NotNull
   @Override
-  default Range<Double> getScanningMZRange() {
+  default @Nullable Range<Double> getScanningMZRange() {
     return getFrame().getScanningMZRange();
   }
 
@@ -129,7 +129,6 @@ public interface MobilityScan extends Scan {
   }
 
   /**
-   *
    * @return The injection time of the frame or null.
    */
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/Scan.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/Scan.java
@@ -162,7 +162,7 @@ public interface Scan extends MassSpectrum, Comparable<Scan> {
   /**
    * @return The actual scanning range of the instrument
    */
-  @NotNull Range<Double> getScanningMZRange();
+  @Nullable Range<Double> getScanningMZRange();
 
   /**
    * @return The {@link MsMsInfo}. If null, this is not an MSn scan.

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/data_access/ScanDataAccess.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/data_access/ScanDataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -26,17 +26,22 @@
 package io.github.mzmine.datamodel.data_access;
 
 import com.google.common.collect.Range;
-import io.github.mzmine.datamodel.*;
+import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.MassList;
+import io.github.mzmine.datamodel.MassSpectrum;
+import io.github.mzmine.datamodel.MassSpectrumType;
+import io.github.mzmine.datamodel.PolarityType;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.datamodel.data_access.EfficientDataAccess.ScanDataType;
 import io.github.mzmine.datamodel.msms.MsMsInfo;
 import io.github.mzmine.util.exceptions.MissingMassListException;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * The intended use of this memory access is to loop over all scans and access data points via

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/AbstractMassSpectrum.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/AbstractMassSpectrum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -35,9 +35,6 @@ import io.github.mzmine.datamodel.featuredata.impl.StorageUtils;
 import io.github.mzmine.util.DataPointUtils;
 import io.github.mzmine.util.scans.ScanUtils;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
-import java.lang.foreign.ValueLayout.OfDouble;
-import java.nio.DoubleBuffer;
 import java.util.Iterator;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -50,8 +47,7 @@ public abstract class AbstractMassSpectrum implements MassSpectrum {
 
   private final Logger logger = Logger.getLogger(this.getClass().getName());
 
-  protected @Nullable Range<Double> mzRange;
-  protected @Nullable Integer basePeakIndex = null;
+  protected int basePeakIndex = -1;
   protected double totalIonCurrent = 0.0;
   private MassSpectrumType spectrumType = MassSpectrumType.CENTROIDED;
 
@@ -60,12 +56,11 @@ public abstract class AbstractMassSpectrum implements MassSpectrum {
 
     if (getNumberOfDataPoints() == 0) {
       totalIonCurrent = 0.0;
-      mzRange = null;
-      basePeakIndex = null;
+      basePeakIndex = -1;
       return;
     }
 
-    basePeakIndex = 0;
+    int basePeakIndex = 0;
 
     double lastMz = getMzValue(0);
     double maxIntensity = getIntensityValue(0);
@@ -90,8 +85,8 @@ public abstract class AbstractMassSpectrum implements MassSpectrum {
       //
       lastMz = mz;
     }
-    // set range after checking the order
-    mzRange = Range.closed(getMzValue(0), getMzValue(getNumberOfDataPoints() - 1));
+
+    this.basePeakIndex = basePeakIndex;
   }
 
 
@@ -109,7 +104,11 @@ public abstract class AbstractMassSpectrum implements MassSpectrum {
   @Override
   @Nullable
   public Range<Double> getDataPointMZRange() {
-    return mzRange;
+    return switch (getNumberOfDataPoints()) {
+      case 0 -> null;
+      case 1 -> Range.singleton(getMzValue(0));
+      default -> Range.closed(getMzValue(0), getMzValue(getNumberOfDataPoints() - 1));
+    };
   }
 
   /**
@@ -117,7 +116,9 @@ public abstract class AbstractMassSpectrum implements MassSpectrum {
    */
   @Override
   public @Nullable Integer getBasePeakIndex() {
-    return basePeakIndex;
+    // used to be saved as Integer - changed to int to save memory
+    // behavior was null
+    return basePeakIndex < 0 ? null : basePeakIndex;
   }
 
   @Override
@@ -156,7 +157,7 @@ public abstract class AbstractMassSpectrum implements MassSpectrum {
   @Override
   @Nullable
   public Double getBasePeakMz() {
-    if (basePeakIndex == null) {
+    if (basePeakIndex < 0) {
       return null;
     } else {
       return getMzValues().getAtIndex(JAVA_DOUBLE, basePeakIndex);
@@ -166,7 +167,7 @@ public abstract class AbstractMassSpectrum implements MassSpectrum {
   @Override
   @Nullable
   public Double getBasePeakIntensity() {
-    if (basePeakIndex == null) {
+    if (basePeakIndex < 0) {
       return null;
     } else {
       return getIntensityValues().getAtIndex(JAVA_DOUBLE, basePeakIndex);

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/SimpleMergedMassSpectrum.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/SimpleMergedMassSpectrum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -185,9 +185,8 @@ public class SimpleMergedMassSpectrum extends AbstractStorableSpectrum implement
     return retentionTime;
   }
 
-  @NotNull
   @Override
-  public Range<Double> getScanningMZRange() {
+  public @Nullable Range<Double> getScanningMZRange() {
     return scanningMzRange;
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/builders/SimpleBuildingScan.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/builders/SimpleBuildingScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -109,7 +109,7 @@ public class SimpleBuildingScan extends MetadataOnlyScan {
   }
 
   @Override
-  public @NotNull Range<Double> getScanningMZRange() {
+  public @Nullable Range<Double> getScanningMZRange() {
     throw new UnsupportedOperationException("This method is not supported");
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/CachedFrame.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/CachedFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -37,7 +37,6 @@ import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.impl.MobilityScanStorage;
 import io.github.mzmine.datamodel.msms.IonMobilityMsMsInfo;
 import io.github.mzmine.datamodel.msms.MsMsInfo;
-import io.github.mzmine.datamodel.msms.PasefMsMsInfo;
 import io.github.mzmine.util.DataPointUtils;
 import it.unimi.dsi.fastutil.doubles.DoubleImmutableList;
 import java.util.ArrayList;
@@ -246,9 +245,8 @@ public class CachedFrame implements Frame {
     return originalFrame.getRetentionTime();
   }
 
-  @NotNull
   @Override
-  public Range<Double> getScanningMZRange() {
+  public @Nullable Range<Double> getScanningMZRange() {
     return originalFrame.getScanningMZRange();
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/msdk/data/BuildingMzMLMsScan.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/msdk/data/BuildingMzMLMsScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -12,6 +12,7 @@
  *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -29,7 +30,6 @@ import static java.util.Objects.requireNonNullElse;
 import com.google.common.collect.Range;
 import io.github.msdk.MSDKException;
 import io.github.msdk.MSDKRuntimeException;
-import io.github.msdk.datamodel.ActivationInfo;
 import io.github.msdk.datamodel.IsolationInfo;
 import io.github.msdk.datamodel.MsScan;
 import io.github.msdk.datamodel.SimpleIsolationInfo;
@@ -42,7 +42,6 @@ import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.featuredata.impl.StorageUtils;
 import io.github.mzmine.datamodel.impl.DDAMsMsInfoImpl;
 import io.github.mzmine.datamodel.impl.MSnInfoImpl;
-import io.github.mzmine.datamodel.msms.ActivationMethod;
 import io.github.mzmine.datamodel.msms.DDAMsMsInfo;
 import io.github.mzmine.datamodel.msms.DIAMsMsInfoImpl;
 import io.github.mzmine.datamodel.msms.MsMsInfo;
@@ -264,7 +263,7 @@ public class BuildingMzMLMsScan extends MetadataOnlyScan {
   }
 
   @Override
-  public @NotNull Range<Double> getScanningMZRange() {
+  public @Nullable Range<Double> getScanningMZRange() {
     if (mzScanWindowRange == null) {
       if (!getScanList().getScans().isEmpty()) {
         Optional<MzMLScanWindowList> scanWindowList = getScanList().getScans().get(0)

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectload/CachedIMSFrame.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectload/CachedIMSFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -26,18 +26,23 @@
 package io.github.mzmine.modules.io.projectload;
 
 import com.google.common.collect.Range;
-import io.github.mzmine.datamodel.*;
+import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.datamodel.Frame;
+import io.github.mzmine.datamodel.MassList;
+import io.github.mzmine.datamodel.MassSpectrumType;
+import io.github.mzmine.datamodel.MobilityScan;
+import io.github.mzmine.datamodel.MobilityType;
+import io.github.mzmine.datamodel.PolarityType;
+import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.impl.MobilityScanStorage;
 import io.github.mzmine.datamodel.msms.IonMobilityMsMsInfo;
 import io.github.mzmine.datamodel.msms.MsMsInfo;
-import io.github.mzmine.datamodel.msms.PasefMsMsInfo;
 import it.unimi.dsi.fastutil.doubles.DoubleImmutableList;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * This class is used during project import to cache
@@ -228,7 +233,7 @@ public class CachedIMSFrame implements Frame {
   }
 
   @Override
-  public @NotNull Range<Double> getScanningMZRange() {
+  public @Nullable Range<Double> getScanningMZRange() {
     throw new UnsupportedOperationException("Unsupported during project load.");
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/LibraryEntryWrappedScan.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/LibraryEntryWrappedScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -163,7 +163,7 @@ public class LibraryEntryWrappedScan implements Scan {
   }
 
   @Override
-  public @NotNull Range<Double> getScanningMZRange() {
+  public @Nullable Range<Double> getScanningMZRange() {
     return requireNonNullElse(getDataPointMZRange(), Range.singleton(0d));
   }
 


### PR DESCRIPTION
- guava Range is a memory killer so thought to change it to primitives

Together with MSMSInfo shift to primitives it saves a lot. See Ranges, Scan, MassList


## Before
![image](https://github.com/user-attachments/assets/d37d44af-9f51-4266-8968-1fcdd503ce2e)
 
## After
![image](https://github.com/user-attachments/assets/c5d069b5-fc04-4158-baaa-3bd39ae7965d)
