### PR TITLE
Fixed bug in mass voltammogram generation

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/id_ecmscalcpotential/EcmsUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/id_ecmscalcpotential/EcmsUtils.java
@@ -64,7 +64,7 @@ public class EcmsUtils {
    * @return The retention time of a given potential in min.
    */
   public static float getRtAtPotential(final double delayTime, final double rampSpeed,
-      final double potential) {
-    return (float) ((float) (delayTime / 60) + (potential / (rampSpeed * 60d)));
+      final double potential, final double startPotential) {
+    return (float) ((float) (delayTime / 60) + ((potential - startPotential) / (rampSpeed * 60d)));
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/massvoltammogram/utils/Massvoltammogram.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/massvoltammogram/utils/Massvoltammogram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/massvoltammogram/utils/Massvoltammogram.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/massvoltammogram/utils/Massvoltammogram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2025 The mzmine Development Team
+ * Copyright (c) 2004-2022 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -209,7 +209,8 @@ public class Massvoltammogram {
     while (Math.abs(potential) <= Math.abs(endPotential)) {
 
       //Getting the scan for the given potential
-      final float rt = EcmsUtils.getRtAtPotential(delayTime, potentialRampSpeed, potential);
+      final float rt = EcmsUtils.getRtAtPotential(delayTime, potentialRampSpeed, potential,
+          startPotential);
       final Scan scan = scanSelection.getScanAtRt(file, rt);
 
       //Breaking the loop if the calculated rt exceeds the max rt of the data file.
@@ -265,7 +266,8 @@ public class Massvoltammogram {
     while (Math.abs(potential) <= Math.abs(endPotential)) {
 
       //Calculating the rt fot the given applied potential.
-      final float rt = (EcmsUtils.getRtAtPotential(delayTime, potentialRampSpeed, potential));
+      final float rt = (EcmsUtils.getRtAtPotential(delayTime, potentialRampSpeed, potential,
+          startPotential));
 
       //Initializing lists to add the mz-values and the intensity-values to.
       final List<Double> mzs = new ArrayList<>();


### PR DESCRIPTION
Previously, there was a bug in the generation of mass voltammograms when the potential ramp did not start at 0 V. The method .getRtAtPotential did not take the start potential into account and alwas based the calculation on the potential ramp starting at 0 V. In most cases this was not noticable because potential ramps normally start at 0 V. Although, when the potential ramp started at a different voltage, the rt was calculated incorrectly leading to wrong spectra being included in the mass voltammogram.