### PR TITLE
fix IonType and IonModificationParameter allowing 0 charge adducts

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/identities/iontype/IonType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/identities/iontype/IonType.java
@@ -40,6 +40,7 @@ import java.util.Objects;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
+import org.apache.commons.math.MathException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.openscience.cdk.interfaces.IMolecularFormula;
@@ -429,6 +430,10 @@ public class IonType extends NeutralMolecule implements Comparable<IonType> {
    * @return the neutral mass for this m/z calculated for this IonType
    */
   public double getMass(double mz) {
+    if (getAbsCharge() == 0) {
+      throw new IllegalStateException(
+          "Charge of adduct %s is 0. Cannot calculate neutral mass.".formatted(toString()));
+    }
     return ((mz * this.getAbsCharge()) - this.getMassDifference()) / this.getMolecules();
   }
 
@@ -441,6 +446,10 @@ public class IonType extends NeutralMolecule implements Comparable<IonType> {
    * @return the m/z for this neutral ionized by IonType
    */
   public double getMZ(double neutralmass) {
+    if (getAbsCharge() == 0) {
+      throw new IllegalStateException(
+          "Charge of adduct %s is 0. Cannot calculate m/z.".formatted(toString()));
+    }
     return (neutralmass * getMolecules() + getMassDifference()) / getAbsCharge();
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/ionidentity/IonModificationParameter.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/ionidentity/IonModificationParameter.java
@@ -259,6 +259,11 @@ public class IonModificationParameter implements
     }
 
     adducts.checkValue(errorMessages);
+    final List<IonModification> adductsWithNoCharge = Arrays.stream(adducts.getValue())
+        .filter(i -> i.getCharge() == 0).toList();
+    if(!adductsWithNoCharge.isEmpty()) {
+      errorMessages.add("The adduct(s): " + adductsWithNoCharge + " have no charge. Use \"Modifcations\" for neutral modifications.");
+    }
     modification.checkValue(errorMessages);
 
     return errorMessages.isEmpty();


### PR DESCRIPTION
prevents #2449 
Still dont know why it sometimes runs when you open the ion library dialog, but this prevents it from happening