### PR TITLE
fix headless chart export

### DIFF
--- a/javafx-framework/src/main/java/io/github/mzmine/javafx/concurrent/threading/FxThread.java
+++ b/javafx-framework/src/main/java/io/github/mzmine/javafx/concurrent/threading/FxThread.java
@@ -72,14 +72,24 @@ public class FxThread {
 
   /**
    * Simulates Swing's invokeAndWait(). Based on
-   * https://news.kynosarges.org/2014/05/01/simulating-platform-runandwait/
+   * https://news.kynosarges.org/2014/05/01/simulating-platform-runandwait/. By default this method
+   * does not enforce execution on the java fx thread in headless mode. If that is required use the
+   * overloaded {@link #runOnFxThreadAndWait(Runnable, boolean)} instead.
    */
   public static void runOnFxThreadAndWait(@NotNull Runnable action) {
+    runOnFxThreadAndWait(action, false);
+  }
+
+  /**
+   * @param forceFxThread If true, the action is forced to run on the fx thread, even if in headless
+   *                      mode.
+   */
+  public static void runOnFxThreadAndWait(@NotNull Runnable action, boolean forceFxThread) {
     if (!isFxInitialized) {
       initJavaFxInHeadlessMode();
     }
     // is headless mode or already runs synchronously on JavaFX thread
-    if (DesktopService.isHeadLess() || Platform.isFxApplicationThread()) {
+    if ((DesktopService.isHeadLess() && !forceFxThread) || Platform.isFxApplicationThread()) {
       action.run();
       return;
     }
@@ -99,7 +109,6 @@ public class FxThread {
     } catch (InterruptedException e) {
       logger.log(Level.WARNING, e.getMessage(), e);
     }
-
   }
 
   /**

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_all_speclib_matches/ExportAllIdsGraphicalTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_all_speclib_matches/ExportAllIdsGraphicalTask.java
@@ -275,7 +275,7 @@ public class ExportAllIdsGraphicalTask extends AbstractTask {
         dialog.setParameterValuesToComponents();
         dialog.export();
       }
-    });
+    }, true);
   }
 
   private void exportSpectralLibraryMatches(File flistFolder, FeatureListRow row) {
@@ -420,7 +420,7 @@ public class ExportAllIdsGraphicalTask extends AbstractTask {
           dialog.setParameterValuesToComponents();
           dialog.export();
         }
-      });
+      }, true);
     }
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/dialogs/EmptyParameterSetupDialogBase.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/dialogs/EmptyParameterSetupDialogBase.java
@@ -25,6 +25,7 @@
 
 package io.github.mzmine.parameters.dialogs;
 
+import io.github.mzmine.gui.DesktopService;
 import io.github.mzmine.javafx.dialogs.DialogLoggerUtil;
 import io.github.mzmine.javafx.util.FxIconUtil;
 import io.github.mzmine.main.MZmineCore;
@@ -146,8 +147,11 @@ public class EmptyParameterSetupDialogBase extends Stage {
     });
 
     // Use main CSS
-    scene.getStylesheets()
-        .addAll(MZmineCore.getDesktop().getMainWindow().getScene().getStylesheets());
+    if(DesktopService.isGUI()) {
+      // may be called in headless mode for graphics export
+      scene.getStylesheets()
+          .addAll(MZmineCore.getDesktop().getMainWindow().getScene().getStylesheets());
+    }
     setScene(scene);
 
     setTitle(parameterSet.getModuleNameAttribute());

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/dialogs/ParameterSetupPane.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/dialogs/ParameterSetupPane.java
@@ -25,6 +25,7 @@
 
 package io.github.mzmine.parameters.dialogs;
 
+import io.github.mzmine.gui.DesktopService;
 import io.github.mzmine.gui.helpwindow.HelpWindow;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.parameters.EmbeddedParameterComponentProvider;
@@ -152,7 +153,10 @@ public class ParameterSetupPane extends BorderPane implements EmbeddedParameterC
     mainPane = this;
 
     // Use main CSS
-    getStylesheets().addAll(MZmineCore.getDesktop().getMainWindow().getScene().getStylesheets());
+    if(DesktopService.isGUI()) {
+      // may be called in headless mode for graphics export
+      getStylesheets().addAll(MZmineCore.getDesktop().getMainWindow().getScene().getStylesheets());
+    }
 
     centerPane = new BorderPane();
 


### PR DESCRIPTION
runOnFxThread did not run on the fx thread in headless mode. i guess it is not strictly necessary, but lead to unwanted behaviour.