### PR TITLE
Merge alignment scores after duplicate filter

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/NullableDoubleDataColumn.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/NullableDoubleDataColumn.java
@@ -25,9 +25,10 @@
 
 package io.github.mzmine.datamodel.features.columnar_data.columns;
 
+import io.github.mzmine.datamodel.features.columnar_data.columns.general.NullableDouble;
 import org.jetbrains.annotations.Nullable;
 
-public non-sealed interface NullableDoubleDataColumn extends DataColumn<Double> {
+public non-sealed interface NullableDoubleDataColumn extends DataColumn<Double>, NullableDouble {
 
   /**
    * @param index row index
@@ -54,20 +55,6 @@ public non-sealed interface NullableDoubleDataColumn extends DataColumn<Double> 
   default @Nullable Double get(final int index) {
     var value = getDouble(index);
     return isNull(value) ? null : value;
-  }
-
-  /**
-   * @return Double.NaN used as null representative
-   */
-  default double nullValue() {
-    return Double.NaN;
-  }
-
-  /**
-   * @return true if value represents null
-   */
-  default boolean isNull(final double value) {
-    return Double.isNaN(value);
   }
 
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/NullableFloatDataColumn.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/NullableFloatDataColumn.java
@@ -25,9 +25,10 @@
 
 package io.github.mzmine.datamodel.features.columnar_data.columns;
 
+import io.github.mzmine.datamodel.features.columnar_data.columns.general.NullableFloat;
 import org.jetbrains.annotations.Nullable;
 
-public non-sealed interface NullableFloatDataColumn extends DataColumn<Float> {
+public non-sealed interface NullableFloatDataColumn extends DataColumn<Float>, NullableFloat {
 
   /**
    * @param index row index
@@ -56,17 +57,4 @@ public non-sealed interface NullableFloatDataColumn extends DataColumn<Float> {
     return isNull(value) ? null : value;
   }
 
-  /**
-   * @return Float.NaN used as null representative
-   */
-  default float nullValue() {
-    return Float.NaN;
-  }
-
-  /**
-   * @return true if value represents null
-   */
-  default boolean isNull(final float value) {
-    return Float.isNaN(value);
-  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/general/NullableDouble.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/general/NullableDouble.java
@@ -23,38 +23,32 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.mzmine.datamodel.features.columnar_data.columns;
+package io.github.mzmine.datamodel.features.columnar_data.columns.general;
 
-import io.github.mzmine.datamodel.features.columnar_data.columns.general.NullableInteger;
 import org.jetbrains.annotations.Nullable;
 
-public non-sealed interface NullableIntDataColumn extends DataColumn<Integer>, NullableInteger {
+public interface NullableDouble {
+
+  double NULL_VALUE = Double.NaN;
 
   /**
-   * @param index row index
-   * @return the primitive double value or {@link #nullValue()} for null
+   * @return Double.NaN used as null representative
    */
-  int getInt(final int index);
+  default double nullValue() {
+    return NULL_VALUE;
+  }
 
   /**
-   * @param index row index
-   * @param value the primitive value or {@link #nullValue()} for null
+   * @return true if value represents null
    */
-  int setInt(final int index, final int value);
-
-  default void clear(final int index) {
-    setInt(index, nullValue());
+  default boolean isNull(final @Nullable Double value) {
+    return value == null || isNull(value.doubleValue());
   }
 
-  @Override
-  default @Nullable Integer set(final int index, final @Nullable Integer value) {
-    return setInt(index, value == null ? nullValue() : value);
+  /**
+   * @return true if value represents null
+   */
+  default boolean isNull(final double value) {
+    return Double.isNaN(value);
   }
-
-  @Override
-  default @Nullable Integer get(final int index) {
-    var value = getInt(index);
-    return isNull(value) ? null : value;
-  }
-
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/general/NullableFloat.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/general/NullableFloat.java
@@ -23,38 +23,32 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.mzmine.datamodel.features.columnar_data.columns;
+package io.github.mzmine.datamodel.features.columnar_data.columns.general;
 
-import io.github.mzmine.datamodel.features.columnar_data.columns.general.NullableInteger;
 import org.jetbrains.annotations.Nullable;
 
-public non-sealed interface NullableIntDataColumn extends DataColumn<Integer>, NullableInteger {
+public interface NullableFloat {
+
+  float NULL_VALUE = Float.NaN;
 
   /**
-   * @param index row index
-   * @return the primitive double value or {@link #nullValue()} for null
+   * @return Float.NaN used as null representative
    */
-  int getInt(final int index);
+  default float nullValue() {
+    return NULL_VALUE;
+  }
 
   /**
-   * @param index row index
-   * @param value the primitive value or {@link #nullValue()} for null
+   * @return true if value represents null
    */
-  int setInt(final int index, final int value);
-
-  default void clear(final int index) {
-    setInt(index, nullValue());
+  default boolean isNull(final @Nullable Float value) {
+    return value == null || isNull(value.floatValue());
   }
 
-  @Override
-  default @Nullable Integer set(final int index, final @Nullable Integer value) {
-    return setInt(index, value == null ? nullValue() : value);
+  /**
+   * @return true if value represents null
+   */
+  default boolean isNull(final float value) {
+    return Float.isNaN(value);
   }
-
-  @Override
-  default @Nullable Integer get(final int index) {
-    var value = getInt(index);
-    return isNull(value) ? null : value;
-  }
-
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/general/NullableInteger.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/general/NullableInteger.java
@@ -23,38 +23,32 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.mzmine.datamodel.features.columnar_data.columns;
+package io.github.mzmine.datamodel.features.columnar_data.columns.general;
 
-import io.github.mzmine.datamodel.features.columnar_data.columns.general.NullableInteger;
 import org.jetbrains.annotations.Nullable;
 
-public non-sealed interface NullableIntDataColumn extends DataColumn<Integer>, NullableInteger {
+public interface NullableInteger {
+
+  int NULL_VALUE = Integer.MIN_VALUE + 1;
 
   /**
-   * @param index row index
-   * @return the primitive double value or {@link #nullValue()} for null
+   * @return {@link #NULL_VALUE} used as null representative
    */
-  int getInt(final int index);
+  default int nullValue() {
+    return NULL_VALUE;
+  }
 
   /**
-   * @param index row index
-   * @param value the primitive value or {@link #nullValue()} for null
+   * @return true if value represents null
    */
-  int setInt(final int index, final int value);
-
-  default void clear(final int index) {
-    setInt(index, nullValue());
+  default boolean isNull(final @Nullable Integer value) {
+    return value == null || isNull(value.intValue());
   }
 
-  @Override
-  default @Nullable Integer set(final int index, final @Nullable Integer value) {
-    return setInt(index, value == null ? nullValue() : value);
+  /**
+   * @return true if value represents null
+   */
+  default boolean isNull(final int value) {
+    return value == NULL_VALUE;
   }
-
-  @Override
-  default @Nullable Integer get(final int index) {
-    var value = getInt(index);
-    return isNull(value) ? null : value;
-  }
-
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/mmap/AlignmentScoreMemorySegmentColumn.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/mmap/AlignmentScoreMemorySegmentColumn.java
@@ -29,13 +29,14 @@ import static java.lang.foreign.ValueLayout.JAVA_DOUBLE;
 import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
+import io.github.mzmine.datamodel.features.columnar_data.columns.mmap.innercolumns.NullableDoubleInnerColumn;
+import io.github.mzmine.datamodel.features.columnar_data.columns.mmap.innercolumns.NullableFloatInnerColumn;
+import io.github.mzmine.datamodel.features.columnar_data.columns.mmap.innercolumns.NullableIntegerInnerColumn;
 import io.github.mzmine.datamodel.features.types.alignment.AlignmentScores;
 import io.github.mzmine.util.MemoryMapStorage;
 import java.lang.foreign.MemoryLayout;
-import java.lang.foreign.MemoryLayout.PathElement;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.StructLayout;
-import java.lang.invoke.VarHandle;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -56,24 +57,26 @@ public class AlignmentScoreMemorySegmentColumn extends
       MemoryLayout.paddingLayout(4) //
   );
 
-  private static final VarHandle rateHandle = LAYOUT.arrayElementVarHandle(
-      PathElement.groupElement("rate"));
-  private static final VarHandle alignedFeaturesHandle = LAYOUT.arrayElementVarHandle(
-      PathElement.groupElement("alignedFeatures"));
-  private static final VarHandle extraFeaturesHandle = LAYOUT.arrayElementVarHandle(
-      PathElement.groupElement("extraFeatures"));
-  private static final VarHandle weightedDistanceScoreHandle = LAYOUT.arrayElementVarHandle(
-      PathElement.groupElement("weightedDistanceScore"));
-  private static final VarHandle mzPpmDeltaHandle = LAYOUT.arrayElementVarHandle(
-      PathElement.groupElement("mzPpmDelta"));
-  private static final VarHandle maxMzDeltaHandle = LAYOUT.arrayElementVarHandle(
-      PathElement.groupElement("maxMzDelta"));
-  private static final VarHandle maxRtDeltaHandle = LAYOUT.arrayElementVarHandle(
-      PathElement.groupElement("maxRtDelta"));
-  private static final VarHandle maxMobilityDeltaHandle = LAYOUT.arrayElementVarHandle(
-      PathElement.groupElement("maxMobilityDelta"));
+  private static final NullableDoubleInnerColumn maxMzDelta = new NullableDoubleInnerColumn(LAYOUT,
+      "maxMzDelta");
 
-  public AlignmentScoreMemorySegmentColumn(final @NotNull MemoryMapStorage storage, int initialCapacity) {
+  private static final NullableFloatInnerColumn rateHandle = new NullableFloatInnerColumn(LAYOUT,
+      "rate");
+  private static final NullableFloatInnerColumn weightedDistanceScore = new NullableFloatInnerColumn(
+      LAYOUT, "weightedDistanceScore");
+  private static final NullableFloatInnerColumn mzPpmDelta = new NullableFloatInnerColumn(LAYOUT,
+      "mzPpmDelta");
+  private static final NullableFloatInnerColumn maxRtDelta = new NullableFloatInnerColumn(LAYOUT,
+      "maxRtDelta");
+  private static final NullableFloatInnerColumn maxMobilityDelta = new NullableFloatInnerColumn(
+      LAYOUT, "maxMobilityDelta");
+  private static final NullableIntegerInnerColumn alignedFeatures = new NullableIntegerInnerColumn(
+      LAYOUT, "alignedFeatures");
+  private static final NullableIntegerInnerColumn extraFeatures = new NullableIntegerInnerColumn(
+      LAYOUT, "extraFeatures");
+
+  public AlignmentScoreMemorySegmentColumn(final @NotNull MemoryMapStorage storage,
+      int initialCapacity) {
     super(storage, initialCapacity);
   }
 
@@ -84,38 +87,39 @@ public class AlignmentScoreMemorySegmentColumn extends
 
   @Override
   public @Nullable AlignmentScores get(final int index) {
-    float rate = (float) rateHandle.get(data, 0L, index);
-    if (Float.isNaN(rate)) {
+    // rate null means the whole alignmentscore is null
+    Float rate = rateHandle.get(data, index);
+    if (rate == null) {
       return null;
     }
 
     return new AlignmentScores( //
         rate, //
-        (int) alignedFeaturesHandle.get(data, 0L, index), //
-        (int) extraFeaturesHandle.get(data, 0L, index), //
-        (float) weightedDistanceScoreHandle.get(data, 0L, index), //
-        (float) mzPpmDeltaHandle.get(data, 0L, index), //
-        (double) maxMzDeltaHandle.get(data, 0L, index), //
-        (float) maxRtDeltaHandle.get(data, 0L, index), //
-        (float) maxMobilityDeltaHandle.get(data, 0L, index) //
+        alignedFeatures.get(data, index), //
+        extraFeatures.get(data, index), //
+        weightedDistanceScore.get(data, index), //
+        mzPpmDelta.get(data, index), //
+        maxMzDelta.get(data, index), //
+        maxRtDelta.get(data, index), //
+        maxMobilityDelta.get(data, index) //
     );
   }
 
   @Override
   public void set(@NotNull final MemorySegment data, final int index, final AlignmentScores value) {
     if (value == null) {
-      rateHandle.set(data, 0L, index, Float.NaN);
+      rateHandle.clear(data, index);
       return;
     }
 
-    rateHandle.set(data, 0L, index, value.rate());
-    mzPpmDeltaHandle.set(data, 0L, index, value.mzPpmDelta());
-    alignedFeaturesHandle.set(data, 0L, index, value.alignedFeatures());
-    extraFeaturesHandle.set(data, 0L, index, value.extraFeatures());
-    weightedDistanceScoreHandle.set(data, 0L, index, value.weightedDistanceScore());
-    maxMzDeltaHandle.set(data, 0L, index, value.maxMzDelta());
-    maxRtDeltaHandle.set(data, 0L, index, value.maxRtDelta());
-    maxMobilityDeltaHandle.set(data, 0L, index, value.maxMobilityDelta());
+    rateHandle.set(data, index, value.rate());
+    mzPpmDelta.set(data, index, value.mzPpmDelta());
+    alignedFeatures.set(data, index, value.alignedFeatures());
+    extraFeatures.set(data, index, value.extraFeatures());
+    weightedDistanceScore.set(data, index, value.weightedDistanceScore());
+    maxMzDelta.set(data, index, value.maxMzDelta());
+    maxRtDelta.set(data, index, value.maxRtDelta());
+    maxMobilityDelta.set(data, index, value.maxMobilityDelta());
   }
 
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/mmap/innercolumns/AbstractInnerColumn.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/mmap/innercolumns/AbstractInnerColumn.java
@@ -23,38 +23,19 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.mzmine.datamodel.features.columnar_data.columns;
+package io.github.mzmine.datamodel.features.columnar_data.columns.mmap.innercolumns;
 
-import io.github.mzmine.datamodel.features.columnar_data.columns.general.NullableInteger;
-import org.jetbrains.annotations.Nullable;
+import java.lang.foreign.MemoryLayout.PathElement;
+import java.lang.foreign.StructLayout;
+import java.lang.invoke.VarHandle;
+import org.jetbrains.annotations.NotNull;
 
-public non-sealed interface NullableIntDataColumn extends DataColumn<Integer>, NullableInteger {
+public abstract class AbstractInnerColumn<T> implements InnerColumn<T> {
 
-  /**
-   * @param index row index
-   * @return the primitive double value or {@link #nullValue()} for null
-   */
-  int getInt(final int index);
+  protected final VarHandle varHandle;
 
-  /**
-   * @param index row index
-   * @param value the primitive value or {@link #nullValue()} for null
-   */
-  int setInt(final int index, final int value);
-
-  default void clear(final int index) {
-    setInt(index, nullValue());
-  }
-
-  @Override
-  default @Nullable Integer set(final int index, final @Nullable Integer value) {
-    return setInt(index, value == null ? nullValue() : value);
-  }
-
-  @Override
-  default @Nullable Integer get(final int index) {
-    var value = getInt(index);
-    return isNull(value) ? null : value;
+  public AbstractInnerColumn(@NotNull StructLayout layout, @NotNull String varHandleName) {
+    varHandle = layout.arrayElementVarHandle(PathElement.groupElement(varHandleName));
   }
 
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/mmap/innercolumns/InnerColumn.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/mmap/innercolumns/InnerColumn.java
@@ -23,38 +23,42 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.mzmine.datamodel.features.columnar_data.columns;
+package io.github.mzmine.datamodel.features.columnar_data.columns.mmap.innercolumns;
 
-import io.github.mzmine.datamodel.features.columnar_data.columns.general.NullableInteger;
+import java.lang.foreign.MemorySegment;
+import java.lang.invoke.VarHandle;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public non-sealed interface NullableIntDataColumn extends DataColumn<Integer>, NullableInteger {
+/**
+ * An inner column describes columns within a more complex memory mapped object. It holds a
+ * {@link VarHandle} and allows easy set and get of values.
+ *
+ * @param <T> the value type
+ */
+public interface InnerColumn<T> {
 
   /**
+   * @param data  the memory segment
    * @param index row index
-   * @return the primitive double value or {@link #nullValue()} for null
+   * @return value at row index
    */
-  int getInt(final int index);
+  @Nullable T get(MemorySegment data, int index);
 
   /**
+   * Set value at row index
+   *
+   * @param data  the memory segment
    * @param index row index
-   * @param value the primitive value or {@link #nullValue()} for null
+   * @param value the value
    */
-  int setInt(final int index, final int value);
+  void set(@NotNull MemorySegment data, int index, @Nullable T value);
 
-  default void clear(final int index) {
-    setInt(index, nullValue());
-  }
-
-  @Override
-  default @Nullable Integer set(final int index, final @Nullable Integer value) {
-    return setInt(index, value == null ? nullValue() : value);
-  }
-
-  @Override
-  default @Nullable Integer get(final int index) {
-    var value = getInt(index);
-    return isNull(value) ? null : value;
-  }
-
+  /**
+   * Clear data at row index
+   *
+   * @param data  memory segment
+   * @param index row index
+   */
+  void clear(@NotNull MemorySegment data, int index);
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/mmap/innercolumns/NullableDoubleInnerColumn.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/mmap/innercolumns/NullableDoubleInnerColumn.java
@@ -23,38 +23,39 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.mzmine.datamodel.features.columnar_data.columns;
+package io.github.mzmine.datamodel.features.columnar_data.columns.mmap.innercolumns;
 
-import io.github.mzmine.datamodel.features.columnar_data.columns.general.NullableInteger;
+import io.github.mzmine.datamodel.features.columnar_data.columns.general.NullableDouble;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public non-sealed interface NullableIntDataColumn extends DataColumn<Integer>, NullableInteger {
+public class NullableDoubleInnerColumn extends AbstractInnerColumn<Double> implements
+    NullableDouble {
 
-  /**
-   * @param index row index
-   * @return the primitive double value or {@link #nullValue()} for null
-   */
-  int getInt(final int index);
-
-  /**
-   * @param index row index
-   * @param value the primitive value or {@link #nullValue()} for null
-   */
-  int setInt(final int index, final int value);
-
-  default void clear(final int index) {
-    setInt(index, nullValue());
+  public NullableDoubleInnerColumn(StructLayout layout, String varHandleName) {
+    super(layout, varHandleName);
   }
 
   @Override
-  default @Nullable Integer set(final int index, final @Nullable Integer value) {
-    return setInt(index, value == null ? nullValue() : value);
+  @Nullable
+  public Double get(MemorySegment data, int index) {
+    final double v = (double) varHandle.get(data, 0L, index);
+    return isNull(v) ? null : v;
   }
 
   @Override
-  default @Nullable Integer get(final int index) {
-    var value = getInt(index);
-    return isNull(value) ? null : value;
+  public void clear(@NotNull MemorySegment data, int index) {
+    set(data, index, nullValue());
   }
 
+  @Override
+  public void set(@NotNull MemorySegment data, int index, @Nullable Double value) {
+    set(data, index, value == null ? nullValue() : value);
+  }
+
+  public void set(@NotNull MemorySegment data, int index, double value) {
+    varHandle.set(data, 0L, index, value);
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/mmap/innercolumns/NullableFloatInnerColumn.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/mmap/innercolumns/NullableFloatInnerColumn.java
@@ -23,38 +23,38 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.mzmine.datamodel.features.columnar_data.columns;
+package io.github.mzmine.datamodel.features.columnar_data.columns.mmap.innercolumns;
 
-import io.github.mzmine.datamodel.features.columnar_data.columns.general.NullableInteger;
+import io.github.mzmine.datamodel.features.columnar_data.columns.general.NullableFloat;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public non-sealed interface NullableIntDataColumn extends DataColumn<Integer>, NullableInteger {
+public class NullableFloatInnerColumn extends AbstractInnerColumn<Float> implements NullableFloat {
 
-  /**
-   * @param index row index
-   * @return the primitive double value or {@link #nullValue()} for null
-   */
-  int getInt(final int index);
-
-  /**
-   * @param index row index
-   * @param value the primitive value or {@link #nullValue()} for null
-   */
-  int setInt(final int index, final int value);
-
-  default void clear(final int index) {
-    setInt(index, nullValue());
+  public NullableFloatInnerColumn(StructLayout layout, String varHandleName) {
+    super(layout, varHandleName);
   }
 
   @Override
-  default @Nullable Integer set(final int index, final @Nullable Integer value) {
-    return setInt(index, value == null ? nullValue() : value);
+  @Nullable
+  public Float get(MemorySegment data, int index) {
+    final float v = (float) varHandle.get(data, 0L, index);
+    return isNull(v) ? null : v;
   }
 
   @Override
-  default @Nullable Integer get(final int index) {
-    var value = getInt(index);
-    return isNull(value) ? null : value;
+  public void clear(@NotNull MemorySegment data, int index) {
+    set(data, index, nullValue());
   }
 
+  @Override
+  public void set(@NotNull MemorySegment data, int index, @Nullable Float value) {
+    set(data, index, value == null ? nullValue() : value);
+  }
+
+  public void set(@NotNull MemorySegment data, int index, float value) {
+    varHandle.set(data, 0L, index, value);
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/mmap/innercolumns/NullableIntegerInnerColumn.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/columnar_data/columns/mmap/innercolumns/NullableIntegerInnerColumn.java
@@ -23,38 +23,39 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.github.mzmine.datamodel.features.columnar_data.columns;
+package io.github.mzmine.datamodel.features.columnar_data.columns.mmap.innercolumns;
 
 import io.github.mzmine.datamodel.features.columnar_data.columns.general.NullableInteger;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public non-sealed interface NullableIntDataColumn extends DataColumn<Integer>, NullableInteger {
+public class NullableIntegerInnerColumn extends AbstractInnerColumn<Integer> implements
+    NullableInteger {
 
-  /**
-   * @param index row index
-   * @return the primitive double value or {@link #nullValue()} for null
-   */
-  int getInt(final int index);
-
-  /**
-   * @param index row index
-   * @param value the primitive value or {@link #nullValue()} for null
-   */
-  int setInt(final int index, final int value);
-
-  default void clear(final int index) {
-    setInt(index, nullValue());
+  public NullableIntegerInnerColumn(StructLayout layout, String varHandleName) {
+    super(layout, varHandleName);
   }
 
   @Override
-  default @Nullable Integer set(final int index, final @Nullable Integer value) {
-    return setInt(index, value == null ? nullValue() : value);
+  @Nullable
+  public Integer get(MemorySegment data, int index) {
+    final int v = (int) varHandle.get(data, 0L, index);
+    return isNull(v) ? null : v;
   }
 
   @Override
-  default @Nullable Integer get(final int index) {
-    var value = getInt(index);
-    return isNull(value) ? null : value;
+  public void clear(@NotNull MemorySegment data, int index) {
+    set(data, index, nullValue());
   }
 
+  @Override
+  public void set(@NotNull MemorySegment data, int index, @Nullable Integer value) {
+    set(data, index, value == null ? nullValue() : value);
+  }
+
+  public void set(@NotNull MemorySegment data, int index, int value) {
+    varHandle.set(data, 0L, index, value);
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/alignment/AlignmentScores.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/alignment/AlignmentScores.java
@@ -27,7 +27,10 @@ package io.github.mzmine.datamodel.features.types.alignment;
 
 import static java.util.Objects.requireNonNullElse;
 
+import io.github.mzmine.datamodel.FeatureStatus;
+import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularDataRecord;
+import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.SimpleModularDataModel;
 import io.github.mzmine.datamodel.features.columnar_data.columns.mmap.AlignmentScoreMemorySegmentColumn;
 import io.github.mzmine.datamodel.features.types.DataType;
@@ -38,7 +41,10 @@ import io.github.mzmine.datamodel.features.types.numbers.MzPpmDifferenceType;
 import io.github.mzmine.datamodel.features.types.numbers.RtAbsoluteDifferenceType;
 import io.github.mzmine.datamodel.features.types.numbers.scores.RateType;
 import io.github.mzmine.datamodel.features.types.numbers.scores.WeightedDistanceScore;
+import io.github.mzmine.modules.dataprocessing.filter_duplicatefilter.DuplicateFilterModule;
+import java.util.DoubleSummaryStatistics;
 import java.util.List;
+import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -163,15 +169,68 @@ public record AlignmentScores(float rate, int alignedFeatures, int extraFeatures
     int otherTotal = Math.round(other.rate * other.alignedFeatures);
     int totalFeatures = total + otherTotal;
 
-    return new AlignmentScores(average(rate, other.rate, total, otherTotal, totalFeatures),
+    return new AlignmentScores(average(rate, other.rate, total, otherTotal),
         alignedFeatures + other.alignedFeatures, extraFeatures + other.extraFeatures,
-        average(weightedDistanceScore, other.weightedDistanceScore, total, otherTotal,
-            totalFeatures), //
-        average(mzPpmDelta, other.mzPpmDelta, total, otherTotal, totalFeatures),
+        average(weightedDistanceScore, other.weightedDistanceScore, total, otherTotal), //
+        average(mzPpmDelta, other.mzPpmDelta, total, otherTotal),
         // maximum distances
         max(maxMzDelta, other.maxMzDelta), //
         max(maxRtDelta, other.maxRtDelta), //
         max(maxMobilityDelta, other.maxMobilityDelta));
+  }
+
+
+  /**
+   * Recalculate alignment. Some fields cannot fully be recalculated like the extra features and the
+   * alignment scores as the alignment parameters are missing. But this can provide better insights
+   * into the final feature list after {@link DuplicateFilterModule}.
+   *
+   * @param row        the row to recalculate
+   * @param rowScore   the row score
+   * @param otherScore an optional other score like when two rows are merged into row and the second
+   *                   alignment score will be used to calculate averages and maxima of properties
+   * @return A merged alignment score
+   */
+  @NotNull
+  public static AlignmentScores recalculateForRow(@NotNull FeatureListRow row,
+      @NotNull AlignmentScores rowScore, @Nullable AlignmentScores otherScore) {
+    final List<ModularFeature> detected = row.streamFeatures()
+        .filter(f -> f.getFeatureStatus() == FeatureStatus.DETECTED).toList();
+
+    final int detectedFeatures = detected.size();
+    final int totalFeatures = row.getNumberOfFeatures();
+
+    final float rate = (float) detectedFeatures / totalFeatures;
+    int maxExtraFeatures = rowScore.extraFeatures();
+    float avgDistanceScore = rowScore.weightedDistanceScore();
+
+    final DoubleSummaryStatistics rtSummary = detected.stream().filter(f -> f.getRT() != null)
+        .mapToDouble(ModularFeature::getRT).summaryStatistics();
+    Float maxRtDelta =
+        rtSummary.getCount() == 0 ? null : (float) (rtSummary.getMax() - rtSummary.getMin());
+
+    final DoubleSummaryStatistics mobilitySummary = detected.stream()
+        .map(ModularFeature::getMobility).filter(Objects::nonNull).mapToDouble(Float::doubleValue)
+        .summaryStatistics();
+    final Float maxMobilityDelta = mobilitySummary.getCount() == 0 ? null
+        : (float) (mobilitySummary.getMax() - mobilitySummary.getMin());
+
+    final DoubleSummaryStatistics mzSummary = detected.stream().filter(f -> f.getMZ() != null)
+        .mapToDouble(ModularFeature::getMZ).summaryStatistics();
+    final Double maxMzDelta =
+        mzSummary.getCount() == 0 ? null : (mzSummary.getMax() - mzSummary.getMin());
+    final Float ppmMzDelta =
+        maxMzDelta == null ? null : (float) (maxMzDelta / row.getAverageMZ() * 1_000_000f);
+
+    if (otherScore != null) {
+      maxExtraFeatures = Math.max(maxExtraFeatures, otherScore.extraFeatures());
+      // average of distance score
+      avgDistanceScore = average(avgDistanceScore, otherScore.weightedDistanceScore(),
+          rowScore.alignedFeatures, otherScore.alignedFeatures);
+    }
+
+    return new AlignmentScores(rate, detectedFeatures, maxExtraFeatures, avgDistanceScore,
+        ppmMzDelta, maxMzDelta, maxRtDelta, maxMobilityDelta);
   }
 
   public static Double max(final Double a, final Double b) {
@@ -226,8 +285,8 @@ public record AlignmentScores(float rate, int alignedFeatures, int extraFeatures
     return Math.min(a, b);
   }
 
-  private Double average(final Double a, final Double b, final int total, final int otherTotal,
-      final int totalFeatures) {
+  private static Double average(final Double a, final Double b, final int total,
+      final int otherTotal) {
     if (a == null && b == null) {
       return null;
     }
@@ -237,11 +296,11 @@ public record AlignmentScores(float rate, int alignedFeatures, int extraFeatures
     if (b == null) {
       return a;
     }
-    return (a * total + b * otherTotal) / totalFeatures;
+    return (a * total + b * otherTotal) / (total + otherTotal);
   }
 
-  private Float average(final Float a, final Float b, final int total, final int otherTotal,
-      final int totalFeatures) {
+  private static Float average(final Float a, final Float b, final int total,
+      final int otherTotal) {
     if (a == null && b == null) {
       return null;
     }
@@ -251,6 +310,6 @@ public record AlignmentScores(float rate, int alignedFeatures, int extraFeatures
     if (b == null) {
       return a;
     }
-    return (a * total + b * otherTotal) / totalFeatures;
+    return (a * total + b * otherTotal) / (total + otherTotal);
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/alignment/AlignmentScores.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/alignment/AlignmentScores.java
@@ -207,20 +207,19 @@ public record AlignmentScores(float rate, int alignedFeatures, int extraFeatures
     final DoubleSummaryStatistics rtSummary = detected.stream().filter(f -> f.getRT() != null)
         .mapToDouble(ModularFeature::getRT).summaryStatistics();
     Float maxRtDelta =
-        rtSummary.getCount() == 0 ? null : (float) (rtSummary.getMax() - rtSummary.getMin());
+        rtSummary.getCount() == 0 ? 0f : (float) (rtSummary.getMax() - rtSummary.getMin());
 
     final DoubleSummaryStatistics mobilitySummary = detected.stream()
         .map(ModularFeature::getMobility).filter(Objects::nonNull).mapToDouble(Float::doubleValue)
         .summaryStatistics();
-    final Float maxMobilityDelta = mobilitySummary.getCount() == 0 ? null
+    final Float maxMobilityDelta = mobilitySummary.getCount() == 0 ? 0f
         : (float) (mobilitySummary.getMax() - mobilitySummary.getMin());
 
     final DoubleSummaryStatistics mzSummary = detected.stream().filter(f -> f.getMZ() != null)
         .mapToDouble(ModularFeature::getMZ).summaryStatistics();
-    final Double maxMzDelta =
-        mzSummary.getCount() == 0 ? null : (mzSummary.getMax() - mzSummary.getMin());
-    final Float ppmMzDelta =
-        maxMzDelta == null ? null : (float) (maxMzDelta / row.getAverageMZ() * 1_000_000f);
+    final double maxMzDelta =
+        mzSummary.getCount() == 0 ? 0d : (mzSummary.getMax() - mzSummary.getMin());
+    final Float ppmMzDelta = (float) (maxMzDelta / row.getAverageMZ() * 1_000_000f);
 
     if (otherScore != null) {
       maxExtraFeatures = Math.max(maxExtraFeatures, otherScore.extraFeatures());

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/filter_duplicatefilter/DuplicateFilterTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/filter_duplicatefilter/DuplicateFilterTask.java
@@ -40,6 +40,8 @@ import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
+import io.github.mzmine.datamodel.features.types.alignment.AlignmentMainType;
+import io.github.mzmine.datamodel.features.types.alignment.AlignmentScores;
 import io.github.mzmine.modules.dataprocessing.filter_duplicatefilter.DuplicateFilterParameters.FilterMode;
 import io.github.mzmine.modules.dataprocessing.filter_rowsfilter.RowsFilterParameters;
 import io.github.mzmine.parameters.ParameterSet;
@@ -459,6 +461,15 @@ public class DuplicateFilterTask extends AbstractTask {
           }
           break;
       }
+    }
+
+    // recalculate alignmentscores
+    final AlignmentScores score1 = firstRow.get(AlignmentMainType.class);
+    final AlignmentScores score2 = secondRow.get(AlignmentMainType.class);
+    if (score1 != null) {
+      // only condition is that score1 is not null
+      final AlignmentScores merged = AlignmentScores.recalculateForRow(firstRow, score1, score2);
+      firstRow.set(AlignmentMainType.class, merged);
     }
   }
 


### PR DESCRIPTION
- the alignment score so far was not updated as this is supposed to reflect on alignment 
- after duplicate filter it makes sense to merge the two alignment scores from both rows to recaluclate at least the maxRT distance, alignment rate and other values that are not dependent on the alignment parameters
- for the other we just estimate with the maximum extra features as the worst case or average alignment score

This revealed that the MemorySegmentColumn in the new datamodel did not allow null values for Nullable fields. 
I added InnerColumns classes for an easier get/setValue compared to the bare use of VarHandle. 
This also makes it more type safe with less casting.

fixes #2700