### PR TITLE
use semicolon to separate multiple usis in export

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_compoundAnnotations_csv/CompoundAnnotationsCSVExportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_compoundAnnotations_csv/CompoundAnnotationsCSVExportTask.java
@@ -229,7 +229,7 @@ public class CompoundAnnotationsCSVExportTask extends AbstractTask {
             String queryScan = null;
             if (annotation instanceof SpectralDBAnnotation spec) {
               queryScan = ScanUtils.extractCompressedUSIRanges(spec.getQueryScan(), "DATASET_ID_PLACEHOLDER").collect(
-                  Collectors.joining(","));
+                  Collectors.joining(";"));
             }
 
             String result = Stream.of(rowId, compoundName, adductType, scoreType, precursorMZ,


### PR DESCRIPTION
use semicolon here because the compressed usis use comma to separate scans