### PR TITLE
Auto update selected FeatureLists, RawDataFile, Libraries in components

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/dialogs/ParameterSetupPane.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/dialogs/ParameterSetupPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -34,6 +34,9 @@ import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.UserParameter;
 import io.github.mzmine.parameters.parametertypes.HiddenParameter;
+import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsComponent;
+import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesComponent;
+import io.github.mzmine.parameters.parametertypes.selectors.SpectralLibrarySelectionComponent;
 import io.github.mzmine.parameters.parametertypes.submodules.ModuleOptionsEnumComponent;
 import java.net.URL;
 import java.util.HashMap;
@@ -124,7 +127,8 @@ public class ParameterSetupPane extends BorderPane implements EmbeddedParameterC
    * @param message: html-formatted text
    */
   public ParameterSetupPane(boolean valueCheckRequired, ParameterSet parameters,
-      boolean addOkButton, boolean addCancelButton, @Nullable Region message, boolean addParamComponents) {
+      boolean addOkButton, boolean addCancelButton, @Nullable Region message,
+      boolean addParamComponents) {
     this(valueCheckRequired, parameters, addOkButton, addCancelButton, message, addParamComponents,
         true);
   }
@@ -133,8 +137,8 @@ public class ParameterSetupPane extends BorderPane implements EmbeddedParameterC
    * Method to display setup dialog with a html-formatted footer message at the bottom.
    */
   public ParameterSetupPane(boolean valueCheckRequired, ParameterSet parameters,
-      boolean addOkButton, boolean addCancelButton, @Nullable Region message, boolean addParamComponents,
-      boolean addHelp) {
+      boolean addOkButton, boolean addCancelButton, @Nullable Region message,
+      boolean addParamComponents, boolean addHelp) {
     this(valueCheckRequired, parameters, addOkButton, addCancelButton, message, addParamComponents,
         addHelp, true);
   }
@@ -143,8 +147,8 @@ public class ParameterSetupPane extends BorderPane implements EmbeddedParameterC
    * Method to display setup dialog with a html-formatted footer message at the bottom.
    */
   public ParameterSetupPane(boolean valueCheckRequired, ParameterSet parameters,
-      boolean addOkButton, boolean addCancelButton, @Nullable Region message, boolean addParamComponents,
-      boolean addHelp, boolean addScrollPane) {
+      boolean addOkButton, boolean addCancelButton, @Nullable Region message,
+      boolean addParamComponents, boolean addHelp, boolean addScrollPane) {
     this.valueCheckRequired = valueCheckRequired;
     this.parameterSet = parameters;
     this.helpURL = parameters.getClass().getResource("help/help.html");
@@ -154,7 +158,7 @@ public class ParameterSetupPane extends BorderPane implements EmbeddedParameterC
     mainPane = this;
 
     // Use main CSS
-    if(DesktopService.isGUI()) {
+    if (DesktopService.isGUI()) {
       // may be called in headless mode for graphics export
       getStylesheets().addAll(MZmineCore.getDesktop().getMainWindow().getScene().getStylesheets());
     }
@@ -456,18 +460,20 @@ public class ParameterSetupPane extends BorderPane implements EmbeddedParameterC
 
   protected void addListenersToNode(Node node) {
     if (node instanceof TextField textField) {
-      textField.textProperty()
-          .addListener(((_, _, _) -> parametersChanged()));
+      textField.textProperty().addListener(((_, _, _) -> parametersChanged()));
+    } else if (node instanceof FeatureListsComponent fselect) {
+      fselect.getNumPeakListsLabel().textProperty().addListener(((_, _, _) -> parametersChanged()));
+    } else if (node instanceof RawDataFilesComponent rselect) {
+      rselect.getNumFilesLabel().textProperty().addListener(((_, _, _) -> parametersChanged()));
+    } else if (node instanceof SpectralLibrarySelectionComponent rselect) {
+      rselect.getNumFilesLabel().textProperty().addListener(((_, _, _) -> parametersChanged()));
     } else if (node instanceof ComboBox<?> comboComp) {
-      comboComp.valueProperty()
-          .addListener(((_, _, _) -> parametersChanged()));
+      comboComp.valueProperty().addListener(((_, _, _) -> parametersChanged()));
     } else if (node instanceof ChoiceBox) {
       ChoiceBox<?> choiceBox = (ChoiceBox) node;
-      choiceBox.valueProperty()
-          .addListener(((_, _, _) -> parametersChanged()));
+      choiceBox.valueProperty().addListener(((_, _, _) -> parametersChanged()));
     } else if (node instanceof CheckBox checkBox) {
-      checkBox.selectedProperty()
-          .addListener(((_, _, _) -> parametersChanged()));
+      checkBox.selectedProperty().addListener(((_, _, _) -> parametersChanged()));
     } else if (node instanceof ListView listview) {
       listview.getItems().addListener((ListChangeListener) _ -> parametersChanged());
     } else if (node instanceof CheckComboBox<?> checkCombo) {

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/dialogs/ParameterSetupPane.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/dialogs/ParameterSetupPane.java
@@ -462,11 +462,11 @@ public class ParameterSetupPane extends BorderPane implements EmbeddedParameterC
     if (node instanceof TextField textField) {
       textField.textProperty().addListener(((_, _, _) -> parametersChanged()));
     } else if (node instanceof FeatureListsComponent fselect) {
-      fselect.getNumPeakListsLabel().textProperty().addListener(((_, _, _) -> parametersChanged()));
+      fselect.currentlySelectedProperty().addListener(((_, _, _) -> parametersChanged()));
     } else if (node instanceof RawDataFilesComponent rselect) {
-      rselect.getNumFilesLabel().textProperty().addListener(((_, _, _) -> parametersChanged()));
+      rselect.currentlySelectedProperty().addListener(((_, _, _) -> parametersChanged()));
     } else if (node instanceof SpectralLibrarySelectionComponent rselect) {
-      rselect.getNumFilesLabel().textProperty().addListener(((_, _, _) -> parametersChanged()));
+      rselect.currentlySelectedProperty().addListener(((_, _, _) -> parametersChanged()));
     } else if (node instanceof ComboBox<?> comboComp) {
       comboComp.valueProperty().addListener(((_, _, _) -> parametersChanged()));
     } else if (node instanceof ChoiceBox) {

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/FeatureListsComponent.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/FeatureListsComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -34,12 +34,14 @@ import io.github.mzmine.parameters.parametertypes.MultiChoiceParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.project.ProjectService;
 import io.github.mzmine.util.ExitCode;
+import javafx.animation.PauseTransition;
 import javafx.collections.FXCollections;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
+import javafx.util.Duration;
 import org.jetbrains.annotations.Nullable;
 
 public class FeatureListsComponent extends HBox {
@@ -104,6 +106,20 @@ public class FeatureListsComponent extends HBox {
       updateNumPeakLists();
     });
 
+    PauseTransition autoUpdate = new PauseTransition(Duration.seconds(1));
+    autoUpdate.setOnFinished(_ -> {
+      // only if actually shown on screen
+      if (!isVisible() || getScene() == null || getScene().getWindow() == null
+          || !getScene().getWindow().isShowing()) {
+        return;
+      }
+      
+      // auto update the number of files in the component to react to changes from As selected in GUI
+      // this only changes the component
+      updateNumPeakLists();
+      autoUpdate.playFromStart();
+    });
+    autoUpdate.playFromStart();
   }
 
   void setValue(@Nullable FeatureListsSelection newValue) {
@@ -118,6 +134,9 @@ public class FeatureListsComponent extends HBox {
     return currentValue;
   }
 
+  public Label getNumPeakListsLabel() {
+    return numPeakListsLabel;
+  }
 
   public void setToolTipText(String toolTip) {
     typeCombo.setTooltip(new Tooltip(toolTip));

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/FeatureListsComponent.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/FeatureListsComponent.java
@@ -45,6 +45,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 import javafx.util.Duration;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class FeatureListsComponent extends HBox {
@@ -53,8 +54,8 @@ public class FeatureListsComponent extends HBox {
   private final ComboBox<FeatureListsSelectionType> typeCombo;
   private final Button detailsButton;
   private final Label numPeakListsLabel;
-  private FeatureListsSelection currentValue = new FeatureListsSelection();
   private final ReadOnlyObjectWrapper<List<FeatureList>> currentlySelected = new ReadOnlyObjectWrapper<>();
+  private @NotNull FeatureListsSelection currentValue = new FeatureListsSelection();
 
   public FeatureListsComponent() {
     setSpacing(5);
@@ -127,9 +128,9 @@ public class FeatureListsComponent extends HBox {
   }
 
   void setValue(@Nullable FeatureListsSelection newValue) {
-    currentValue = newValue != null ? newValue.clone() : null;
-    if (newValue != null && newValue.getSelectionType() != null) {
-      typeCombo.getSelectionModel().select(newValue.getSelectionType());
+    currentValue = newValue != null ? newValue.clone() : new FeatureListsSelection();
+    if (currentValue.getSelectionType() != null) {
+      typeCombo.getSelectionModel().select(currentValue.getSelectionType());
     }
     updateNumPeakLists();
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/RawDataFilesComponent.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/RawDataFilesComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -33,12 +33,14 @@ import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.project.ProjectService;
 import io.github.mzmine.util.ExitCode;
 import java.util.Objects;
+import javafx.animation.PauseTransition;
 import javafx.collections.FXCollections;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.GridPane;
+import javafx.util.Duration;
 import org.jetbrains.annotations.Nullable;
 
 public class RawDataFilesComponent extends GridPane {
@@ -58,30 +60,29 @@ public class RawDataFilesComponent extends GridPane {
     detailsButton = new Button("Select");
     add(detailsButton, 2, 0);
 
-    typeCombo =
-        new ComboBox<>(FXCollections.observableArrayList(RawDataFilesSelectionType.values()));
+    typeCombo = new ComboBox<>(
+        FXCollections.observableArrayList(RawDataFilesSelectionType.values()));
     typeCombo.getSelectionModel().selectFirst();
 
-    typeCombo.getSelectionModel().selectedItemProperty().addListener((options, oldValue, newValue) -> {
-      currentValue.setSelectionType(newValue);
-      detailsButton.setDisable(newValue != RawDataFilesSelectionType.NAME_PATTERN
-          && newValue != RawDataFilesSelectionType.SPECIFIC_FILES);
-      updateNumFiles();
-    });
+    typeCombo.getSelectionModel().selectedItemProperty()
+        .addListener((options, oldValue, newValue) -> {
+          currentValue.setSelectionType(newValue);
+          detailsButton.setDisable(newValue != RawDataFilesSelectionType.NAME_PATTERN
+              && newValue != RawDataFilesSelectionType.SPECIFIC_FILES);
+          updateNumFiles();
+        });
 
     add(typeCombo, 1, 0);
-
 
     detailsButton.setOnAction(e -> {
       RawDataFilesSelectionType type = typeCombo.getSelectionModel().getSelectedItem();
 
       if (type == RawDataFilesSelectionType.SPECIFIC_FILES) {
-        final MultiChoiceParameter<RawDataFile> filesParameter =
-            new MultiChoiceParameter<RawDataFile>("Select files", "Select files",
-                ProjectService.getProjectManager().getCurrentProject().getDataFiles(),
-                currentValue.getSpecificFiles());
-        final SimpleParameterSet paramSet =
-            new SimpleParameterSet(new Parameter[] {filesParameter});
+        final MultiChoiceParameter<RawDataFile> filesParameter = new MultiChoiceParameter<RawDataFile>(
+            "Select files", "Select files",
+            ProjectService.getProjectManager().getCurrentProject().getDataFiles(),
+            currentValue.getSpecificFiles());
+        final SimpleParameterSet paramSet = new SimpleParameterSet(new Parameter[]{filesParameter});
         final ExitCode exitCode = paramSet.showSetupDialog(true);
         if (exitCode == ExitCode.OK) {
           RawDataFile files[] = paramSet.getParameter(filesParameter).getValue();
@@ -92,7 +93,7 @@ public class RawDataFilesComponent extends GridPane {
         final StringParameter nameParameter = new StringParameter("Name pattern",
             "Set name pattern that may include wildcards (*), e.g. *mouse* matches any name that contains mouse",
             Objects.requireNonNullElse(currentValue.getNamePattern(), ""));
-        final SimpleParameterSet paramSet = new SimpleParameterSet(new Parameter[] {nameParameter});
+        final SimpleParameterSet paramSet = new SimpleParameterSet(new Parameter[]{nameParameter});
         final ExitCode exitCode = paramSet.showSetupDialog(true);
         if (exitCode == ExitCode.OK) {
           String namePattern = paramSet.getParameter(nameParameter).getValue();
@@ -102,13 +103,29 @@ public class RawDataFilesComponent extends GridPane {
       updateNumFiles();
     });
 
-
     setMinWidth(getPrefWidth());
 
+    PauseTransition autoUpdate = new PauseTransition(Duration.seconds(1));
+    autoUpdate.setOnFinished(_ -> {
+      // only if actually shown on screen
+      if (!isVisible() || getScene() == null || getScene().getWindow() == null
+          || !getScene().getWindow().isShowing()) {
+        return;
+      }
+      // auto update the number of files in the component to react to changes from As selected in GUI
+      // this only changes the component
+      updateNumFiles();
+      autoUpdate.playFromStart();
+    });
+    autoUpdate.playFromStart();
+  }
+
+  public Label getNumFilesLabel() {
+    return numFilesLabel;
   }
 
   void setValue(@Nullable RawDataFilesSelection newValue) {
-    if(newValue==null) {
+    if (newValue == null) {
       currentValue = null;
       typeCombo.getSelectionModel().clearSelection();
       updateNumFiles();
@@ -116,8 +133,9 @@ public class RawDataFilesComponent extends GridPane {
     }
     currentValue = newValue.clone();
     RawDataFilesSelectionType type = newValue.getSelectionType();
-    if (type != null)
+    if (type != null) {
       typeCombo.getSelectionModel().select(type);
+    }
     updateNumFiles();
   }
 
@@ -140,8 +158,9 @@ public class RawDataFilesComponent extends GridPane {
       RawDataFile files[] = currentValue.getMatchingRawDataFiles();
       if (files.length == 1) {
         String fileName = files[0].getName();
-        if (fileName.length() > 22)
+        if (fileName.length() > 22) {
           fileName = fileName.substring(0, 20) + "...";
+        }
         numFilesLabel.setText(fileName);
       } else {
         numFilesLabel.setText(files.length + " selected");

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/RawDataFilesComponent.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/RawDataFilesComponent.java
@@ -44,6 +44,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.GridPane;
 import javafx.util.Duration;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class RawDataFilesComponent extends GridPane {
@@ -51,8 +52,8 @@ public class RawDataFilesComponent extends GridPane {
   private final ComboBox<RawDataFilesSelectionType> typeCombo;
   private final Button detailsButton;
   private final Label numFilesLabel;
-  private RawDataFilesSelection currentValue = new RawDataFilesSelection();
   private final ReadOnlyObjectWrapper<List<RawDataFile>> currentlySelected = new ReadOnlyObjectWrapper<>();
+  private @NotNull RawDataFilesSelection currentValue = new RawDataFilesSelection();
 
   public RawDataFilesComponent() {
 
@@ -125,14 +126,8 @@ public class RawDataFilesComponent extends GridPane {
   }
 
   void setValue(@Nullable RawDataFilesSelection newValue) {
-    if (newValue == null) {
-      currentValue = null;
-      typeCombo.getSelectionModel().clearSelection();
-      updateNumFiles();
-      return;
-    }
-    currentValue = newValue.clone();
-    RawDataFilesSelectionType type = newValue.getSelectionType();
+    currentValue = newValue == null ? new RawDataFilesSelection() : newValue.clone();
+    RawDataFilesSelectionType type = currentValue.getSelectionType();
     if (type != null) {
       typeCombo.getSelectionModel().select(type);
     }

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/RawDataFilesSelection.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/RawDataFilesSelection.java
@@ -127,8 +127,10 @@ public class RawDataFilesSelection implements Cloneable {
       RawDataFile matchingFile = matchingFiles[i];
       evaluatedSelection[i] = new RawDataFilePlaceholder(matchingFile);
     }
-    logger.finest(
-        () -> "Setting file selection. Evaluated files: " + Arrays.toString(evaluatedSelection));
+    // only debugging
+    // the RawDataFilesComponent auto updates the selection every second so this would spam
+//    logger.finest(
+//        () -> "Setting file selection. Evaluated files: " + Arrays.toString(evaluatedSelection));
 
     return matchingFiles;
   }
@@ -142,11 +144,11 @@ public class RawDataFilesSelection implements Cloneable {
   }
 
   public void resetSelection() {
-    if (evaluatedSelection != null) {
-      logger.finest(
-          () -> "Resetting file selection. Previously evaluated files: " + Arrays.toString(
-              evaluatedSelection));
-    }
+//    if (evaluatedSelection != null) {
+//      logger.finest(
+//          () -> "Resetting file selection. Previously evaluated files: " + Arrays.toString(
+//              evaluatedSelection));
+//    }
     evaluatedSelection = null;
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/SpectralLibrarySelectionComponent.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/SpectralLibrarySelectionComponent.java
@@ -43,6 +43,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.GridPane;
 import javafx.util.Duration;
+import org.jetbrains.annotations.Nullable;
 
 public class SpectralLibrarySelectionComponent extends GridPane {
 
@@ -112,7 +113,7 @@ public class SpectralLibrarySelectionComponent extends GridPane {
         specificFiles == null ? List.of() : List.of(specificFiles));
   }
 
-  void setValue(SpectralLibrarySelection newValue) {
+  void setValue(@Nullable SpectralLibrarySelection newValue) {
     if (newValue == null) {
       newValue = new SpectralLibrarySelection();
     }

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/SpectralLibrarySelectionComponent.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/SpectralLibrarySelectionComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -32,12 +32,14 @@ import io.github.mzmine.parameters.parametertypes.filenames.FileNamesParameter;
 import io.github.mzmine.util.ExitCode;
 import java.io.File;
 import java.util.List;
+import javafx.animation.PauseTransition;
 import javafx.collections.FXCollections;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.GridPane;
+import javafx.util.Duration;
 
 public class SpectralLibrarySelectionComponent extends GridPane {
 
@@ -84,6 +86,25 @@ public class SpectralLibrarySelectionComponent extends GridPane {
     });
 
     setMinWidth(getPrefWidth());
+
+    PauseTransition autoUpdate = new PauseTransition(Duration.seconds(1));
+    autoUpdate.setOnFinished(_ -> {
+      // only if actually shown on screen
+      if (!isVisible() || getScene() == null || getScene().getWindow() == null
+          || !getScene().getWindow().isShowing()) {
+        return;
+      }
+
+      // auto update the number of files in the component to react to changes from As selected in GUI
+      // this only changes the component
+      updateNumFiles();
+      autoUpdate.playFromStart();
+    });
+    autoUpdate.playFromStart();
+  }
+
+  public Label getNumFilesLabel() {
+    return numFilesLabel;
   }
 
   public SpectralLibrarySelection getValue() {

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/SpectralLibrarySelectionComponent.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/selectors/SpectralLibrarySelectionComponent.java
@@ -30,9 +30,12 @@ import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.filenames.FileNamesParameter;
 import io.github.mzmine.util.ExitCode;
+import io.github.mzmine.util.spectraldb.entry.SpectralLibrary;
 import java.io.File;
 import java.util.List;
 import javafx.animation.PauseTransition;
+import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.collections.FXCollections;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
@@ -46,6 +49,7 @@ public class SpectralLibrarySelectionComponent extends GridPane {
   private final ComboBox<SpectralLibrarySelectionType> typeCombo;
   private final Button detailsButton;
   private final Label numFilesLabel;
+  private final ReadOnlyObjectWrapper<List<SpectralLibrary>> currentlySelected = new ReadOnlyObjectWrapper<>();
   // the latest directly specified files
   private File[] specificFiles;
 
@@ -103,10 +107,6 @@ public class SpectralLibrarySelectionComponent extends GridPane {
     autoUpdate.playFromStart();
   }
 
-  public Label getNumFilesLabel() {
-    return numFilesLabel;
-  }
-
   public SpectralLibrarySelection getValue() {
     return new SpectralLibrarySelection(typeCombo.getValue(),
         specificFiles == null ? List.of() : List.of(specificFiles));
@@ -126,6 +126,28 @@ public class SpectralLibrarySelectionComponent extends GridPane {
   }
 
   private void updateNumFiles() {
-    numFilesLabel.setText("" + getValue().getMatchingLibraries().size());
+    final List<SpectralLibrary> matching = getValue().getMatchingLibraries();
+
+    if (currentlySelected.get() == null || !currentlySelected.get().equals(matching)) {
+      currentlySelected.set(matching);
+    }
+    numFilesLabel.setText("" + matching.size());
+  }
+
+  /**
+   * The currently selected property is auto updated every second
+   *
+   * @return a property that holds the currently selected elements
+   */
+  public ReadOnlyObjectProperty<List<SpectralLibrary>> currentlySelectedProperty() {
+    return currentlySelected.getReadOnlyProperty();
+  }
+
+  /**
+   * calls an update of the selection first
+   */
+  public List<SpectralLibrary> getCurrentlySelected() {
+    updateNumFiles();
+    return currentlySelected.get();
   }
 }


### PR DESCRIPTION
- listen to changes to selected feature lists etc without listener to not create potential leak
- auto shuts down listener when the dialog is closed
- only updates the component and keeps a ReadOnlyProperty of the currently selected files/featurelists/libraries
- triggers updates to previews like retention time correction
- mass detection, local minimum and other also get that update but they do not use the selected files or featurelists but all - so does not matter there