### PR TITLE
fix feature values null in MsnTreeFeatureDetectionTask

### DIFF
--- a/javafx-framework/src/main/java/io/github/mzmine/javafx/dialogs/DialogLoggerUtil.java
+++ b/javafx-framework/src/main/java/io/github/mzmine/javafx/dialogs/DialogLoggerUtil.java
@@ -28,6 +28,7 @@ package io.github.mzmine.javafx.dialogs;
 import io.github.mzmine.gui.DesktopService;
 import io.github.mzmine.gui.JavaFxDesktop;
 import io.github.mzmine.javafx.concurrent.threading.FxThread;
+import io.github.mzmine.javafx.dialogs.NotificationService.NotificationType;
 import io.github.mzmine.javafx.util.FxTextUtils;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -269,4 +270,25 @@ public class DialogLoggerUtil {
     });
   }
 
+  public static void showNotification(@NotNull NotificationType type, @NotNull String title,
+      @NotNull String message) {
+    logger.info(() -> title + ": " + message);
+    NotificationService.show(type, title, message);
+  }
+
+  public static void showInfoNotification(@NotNull String title, @NotNull String message) {
+    showNotification(NotificationType.INFO, title, message);
+  }
+
+  public static void showWarningNotification(@NotNull String title, @NotNull String message) {
+    showNotification(NotificationType.WARNING, title, message);
+  }
+
+  public static void showErrorNotification(@NotNull String title, @NotNull String message) {
+    showNotification(NotificationType.ERROR, title, message);
+  }
+
+  public static void showPlainNotification(@NotNull String title, @NotNull String message) {
+    showNotification(NotificationType.PLAIN, title, message);
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/Feature.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/Feature.java
@@ -381,4 +381,9 @@ public interface Feature {
   }
 
   boolean isMrm();
+
+  /**
+   * @return A string containing every data type currently present for the feature.
+   */
+  String toFullString();
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/ModularFeature.java
@@ -588,6 +588,12 @@ public class ModularFeature extends ColumnarModularDataModelRow implements Featu
     return FeatureUtils.featureToString(this);
   }
 
+  public String toFullString() {
+    return getFeatureList().getFeatureTypes().stream().sorted(DataType::compareTo).map(
+            type -> "{%s,%s}".formatted(type.getUniqueID(), type.getFormattedString(this.get(type))))
+        .collect(Collectors.joining(","));
+  }
+
   @Override
   public boolean isMrm() {
     return get(MrmTransitionListType.class) != null;

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/FeatureShapeChart.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/FeatureShapeChart.java
@@ -97,8 +97,12 @@ public class FeatureShapeChart extends BufferedChartNode {
       } else {
         // show full RT range
         final float length = Math.max(fullWidth, 0.001f);
-        defaultRange = new org.jfree.data.Range(Math.max(rt - length * 1.05, rawMinRt),
-            Math.min(rt + length * 1.05, rawMaxRt));
+        final double lower = Math.max(rt - length * 1.05, rawMinRt);
+        final double upper = Math.min(rt + length * 1.05, rawMaxRt);
+        // odd possibility for lower > upper in case:
+        // rawMinRt is low and rawMaxRt is high, but rt is 0 and length is small.
+        // (e.g. no data points after msn tree feature list builder)
+        defaultRange = new org.jfree.data.Range(Math.min(lower, upper), Math.max(lower, upper));
       }
     } else {
       defaultRange = new Range(0, 1);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModulesList.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModulesList.java
@@ -276,7 +276,6 @@ public class BatchModeModulesList {
           IonMobilityTraceBuilderModule.class, //
           RecursiveIMSBuilderModule.class, //
           ImageBuilderModule.class, //
-          MsnFeatureDetectionModule.class, //
           TargetedFeatureDetectionModule.class, //
 //      ADAPHierarchicalClusteringModule.class, //
 //      ADAPMultivariateCurveResolutionModule.class, //

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_msn_tree/MsnTreeFeatureDetectionTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_msn_tree/MsnTreeFeatureDetectionTask.java
@@ -113,8 +113,7 @@ public class MsnTreeFeatureDetectionTask extends AbstractTask {
         ScanUtils.getMSnFragmentTrees(dataFile, mzTol));
     trees.sort(Comparator.comparingDouble(PrecursorIonTree::getPrecursorMz));
     List<Range<Double>> mzRangesSorted = trees.stream()
-        .mapToDouble(PrecursorIonTree::getPrecursorMz)
-        .mapToObj(mzTol::getToleranceRange).toList();
+        .mapToDouble(PrecursorIonTree::getPrecursorMz).mapToObj(mzTol::getToleranceRange).toList();
 
     extractorFunction = new ExtractMzRangesIonSeriesFunction(dataFile, scanSelection,
         mzRangesSorted, ScanDataType.MASS_LIST, this);
@@ -140,6 +139,11 @@ public class MsnTreeFeatureDetectionTask extends AbstractTask {
       // need to set mz if data was empty
       if (!hasData) {
         f.setMZ(mstree.getPrecursorMz());
+        f.setHeight(0f);
+        f.setArea(0f);
+        f.setRT(0f);
+        // should we discard the feature in that case? it is possible that the precursor ion is
+        // not found in the ms2 spectra at all but the ms2s still contain information
       }
       f.setAllMS2FragmentScans(mstree.getAllFragmentScans());
       ModularFeatureListRow row = new ModularFeatureListRow(newFeatureList, id, f);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_msn_tree/MsnTreeFeatureDetectionTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_msn_tree/MsnTreeFeatureDetectionTask.java
@@ -35,6 +35,7 @@ import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
+import io.github.mzmine.javafx.dialogs.DialogLoggerUtil;
 import io.github.mzmine.modules.dataprocessing.featdet_extract_mz_ranges.ExtractMzRangesIonSeriesFunction;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
@@ -108,6 +109,8 @@ public class MsnTreeFeatureDetectionTask extends AbstractTask {
       return;
     }
 
+    boolean anyNoDataFeatures = false;
+
     // get trees sorted ascending
     final List<PrecursorIonTree> trees = new ArrayList<>(
         ScanUtils.getMSnFragmentTrees(dataFile, mzTol));
@@ -142,6 +145,7 @@ public class MsnTreeFeatureDetectionTask extends AbstractTask {
         f.setHeight(0f);
         f.setArea(0f);
         f.setRT(0f);
+        anyNoDataFeatures = true;
         // should we discard the feature in that case? it is possible that the precursor ion is
         // not found in the ms2 spectra at all but the ms2s still contain information
       }
@@ -149,6 +153,11 @@ public class MsnTreeFeatureDetectionTask extends AbstractTask {
       ModularFeatureListRow row = new ModularFeatureListRow(newFeatureList, id, f);
       newFeatureList.addRow(row);
       id++;
+    }
+
+    if (anyNoDataFeatures) {
+      DialogLoggerUtil.showWarningNotification("MSn tree feature detection",
+          "For some MSn features no precursor ion signals were detected in the provided scan selection. This may indicate too high noise levels.");
     }
 
     newFeatureList.setSelectedScans(dataFile, scans);


### PR DESCRIPTION
odd coincidence in the msn tree feature detection:
it is possible that the precursor ion is not found in the ms2 spectra at all but the ms2s still contain information

in that case you cannot open the feature table because height is null and we sort by height