### PR TITLE
add toString, fix dia ms2 correlation threshold

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilogramTimeSeries.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonMobilogramTimeSeries.java
@@ -420,4 +420,12 @@ public class SimpleIonMobilogramTimeSeries implements IonMobilogramTimeSeries {
   public IonMobilogramTimeSeries emptySeries() {
     return IonMobilogramTimeSeries.EMPTY;
   }
+
+  @Override
+  public String toString() {
+    if(getNumberOfValues() > 0) {
+      return "%.4f, %d".formatted(getMZ(getNumberOfValues() / 2), getNumberOfValues());
+    }
+    return "empty";
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonTimeSeries.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/featuredata/impl/SimpleIonTimeSeries.java
@@ -288,4 +288,12 @@ public class SimpleIonTimeSeries implements IonTimeSeries<Scan> {
   public List<Scan> getSpectraModifiable() {
     return (List<Scan>) scans;
   }
+
+  @Override
+  public String toString() {
+    if(getNumberOfValues() > 0) {
+      return "%.4f, %d".formatted(getMZ(getNumberOfValues() / 2), getNumberOfValues());
+    }
+    return "empty";
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/filter_diams2/DiaMs2CorrTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/filter_diams2/DiaMs2CorrTask.java
@@ -111,7 +111,7 @@ public class DiaMs2CorrTask extends AbstractTask {
   private final int minCorrPoints;
   private final MZTolerance mzTolerance;
   private final double minPearson;
-  private final double correlationThreshold = 0.1d;
+  private final double correlationThreshold = 0.01d;
 
   private final ParameterSet parameters;
   private final ParameterSet adapParameters;


### PR DESCRIPTION
observed an issue where some ions were not correlated due to a hardcoded cutoff at 10% intensity of each peak. sometimes there was only one point per side, leading to no correlation. reduced to 1%.