### PR TITLE
FeatureTableFX, better graphical column width on first show

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/FeatureShapeType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/FeatureShapeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -71,6 +71,7 @@ public class FeatureShapeType extends LinkedGraphicalType {
     }
 
     var chart = new FeatureShapeChart(row, progress);
+    chart.setMinWidth(LARGE_GRAPHICAL_CELL_WIDTH);
     return chart;
   }
 
@@ -81,13 +82,12 @@ public class FeatureShapeType extends LinkedGraphicalType {
 
   @Nullable
   @Override
-  public Runnable getDoubleClickAction(final @Nullable FeatureTableFX table, @NotNull ModularFeatureListRow row,
-      @NotNull List<RawDataFile> rawDataFiles, DataType<?> superType,
-      @Nullable final Object value) {
+  public Runnable getDoubleClickAction(final @Nullable FeatureTableFX table,
+      @NotNull ModularFeatureListRow row, @NotNull List<RawDataFile> rawDataFiles,
+      DataType<?> superType, @Nullable final Object value) {
 
     return () -> {
-      FxThread.runLater(
-          () -> ChromatogramVisualizerModule.visualizeFeatureListRows(List.of(row)));
+      FxThread.runLater(() -> ChromatogramVisualizerModule.visualizeFeatureListRows(List.of(row)));
     };
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/fx/DataTypeGraphicalCellFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/fx/DataTypeGraphicalCellFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -47,7 +47,8 @@ import org.jetbrains.annotations.Nullable;
 public class DataTypeGraphicalCellFactory<S, T extends DataType<S> & GraphicalColumType<S>> implements
     Callback<TreeTableColumn<ModularFeatureListRow, Object>, TreeTableCell<ModularFeatureListRow, Object>> {
 
-  private static final Logger logger = Logger.getLogger(DataTypeGraphicalCellFactory.class.getName());
+  private static final Logger logger = Logger.getLogger(
+      DataTypeGraphicalCellFactory.class.getName());
   @NotNull
   private final DataType type;
   @Nullable
@@ -91,7 +92,9 @@ public class DataTypeGraphicalCellFactory<S, T extends DataType<S> & GraphicalCo
 
           if (type instanceof GraphicalColumType graphicalColumType) {
             Node node = graphicalColumType.getCellNode(this, param, type, item, raw);
-            getTableColumn().setPrefWidth(graphicalColumType.getColumnWidth());
+            // for graphical types with fixed width, set min width to force columns to open with correct size
+            // consider also setting min width to the actual chart node
+            getTableColumn().setMinWidth(graphicalColumType.getColumnWidth());
             setGraphic(node);
           }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXParameters.java
@@ -63,7 +63,7 @@ public class FeatureTableFXParameters extends SimpleParameterSet {
 
   public static final IntegerParameter deactivateShapesGreaterNSamples = new IntegerParameter(
       "Deactivate shapes >N samples", "Deactivate shapes for better performance above N samples.",
-      12);
+      20);
 
   public static final BooleanParameter lockImagesToAspectRatio = new BooleanParameter(
       "Lock images to aspect ratio",


### PR DESCRIPTION
- fixed min width for graphical column types to have them show in full size when they are first added 


Maybe good to try other graphical types and charts in the table how they behave