### PR TITLE
Use own parameterset in feature table config + new HashMap

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableColumnMenuHelper.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableColumnMenuHelper.java
@@ -28,6 +28,7 @@ package io.github.mzmine.modules.visualization.featurelisttable_modular;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.types.fx.ColumnID;
 import io.github.mzmine.datamodel.features.types.fx.ColumnType;
+import io.github.mzmine.main.ConfigService;
 import io.github.mzmine.parameters.parametertypes.datatype.DataTypeCheckListParameter;
 import java.util.Comparator;
 import java.util.Map;
@@ -79,6 +80,13 @@ public class FeatureTableColumnMenuHelper extends TableColumnMenuHelper {
   public FeatureTableColumnMenuHelper(FeatureTableFX featureTable) {
     super(featureTable.getTable());
     this.featureTable = featureTable;
+  }
+
+  @Override
+  protected void onPopupClosed() {
+    super.onPopupClosed();
+    ConfigService.getConfiguration().setModuleParameters(FeatureTableFXModule.class,
+        featureTable.getParameters().cloneParameterSet());
   }
 
   /**

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFX.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFX.java
@@ -178,7 +178,7 @@ public class FeatureTableFX extends BorderPane implements ListChangeListener<Fea
   /**
    * Package private to centralize creation in {@link FxFeatureTableController}
    */
-  FeatureTableFX() {
+  FeatureTableFX(@NotNull ParameterSet parameters) {
     dataChangedNotification = new NotificationPane(table);
     setCenter(dataChangedNotification);
 
@@ -200,9 +200,9 @@ public class FeatureTableFX extends BorderPane implements ListChangeListener<Fea
 
     initFeatureListListener();
 
-    parameters = MZmineCore.getConfiguration().getModuleParameters(FeatureTableFXModule.class);
-    rowTypesParameter = parameters.getParameter(FeatureTableFXParameters.showRowTypeColumns);
-    featureTypesParameter = parameters.getParameter(
+    this.parameters = parameters;
+    rowTypesParameter = this.parameters.getParameter(FeatureTableFXParameters.showRowTypeColumns);
+    featureTypesParameter = this.parameters.getParameter(
         FeatureTableFXParameters.showFeatureTypeColumns);
 
     rowItems = FXCollections.observableArrayList();

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFX.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFX.java
@@ -1351,4 +1351,8 @@ public class FeatureTableFX extends BorderPane implements ListChangeListener<Fea
   public TreeTableView<ModularFeatureListRow> getTable() {
     return table;
   }
+
+  public ParameterSet getParameters() {
+    return parameters;
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -47,7 +47,7 @@ public class FeatureTableFXModule implements MZmineModule {
   @NotNull
   @Override
   public String getName() {
-    return "FeatureOld list table";
+    return "Feature table";
   }
 
   @Nullable

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FeatureTableFXParameters.java
@@ -27,20 +27,22 @@ package io.github.mzmine.modules.visualization.featurelisttable_modular;
 
 import io.github.mzmine.datamodel.AbundanceMeasure;
 import io.github.mzmine.datamodel.features.types.modifiers.GraphicalColumType;
+import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.BooleanParameter;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
 import io.github.mzmine.parameters.parametertypes.IntegerParameter;
 import io.github.mzmine.parameters.parametertypes.datatype.DataTypeCheckListParameter;
+import java.util.Map;
 
 public class FeatureTableFXParameters extends SimpleParameterSet {
 
   public static final DataTypeCheckListParameter showRowTypeColumns = new DataTypeCheckListParameter(
-      "Row type columns",
+      "Feature summary columns",
       "Specify which data type columns shall be displayed in the feature list table");
 
   public static final DataTypeCheckListParameter showFeatureTypeColumns = new DataTypeCheckListParameter(
-      "Feature type columns",
+      "Sample-specific columns",
       "Specify which data type columns shall be displayed in the feature list table");
 
   public static final ComboParameter<AbundanceMeasure> defaultAbundanceMeasure = new ComboParameter<>(
@@ -63,7 +65,7 @@ public class FeatureTableFXParameters extends SimpleParameterSet {
 
   public static final IntegerParameter deactivateShapesGreaterNSamples = new IntegerParameter(
       "Deactivate shapes >N samples", "Deactivate shapes for better performance above N samples.",
-      12);
+      35);
 
   public static final BooleanParameter lockImagesToAspectRatio = new BooleanParameter(
       "Lock images to aspect ratio",
@@ -80,4 +82,11 @@ public class FeatureTableFXParameters extends SimpleParameterSet {
         deactivateShapesGreaterNSamples, lockImagesToAspectRatio, hideImageAxes);
   }
 
+  @Override
+  public Map<String, Parameter<?>> getNameParameterMap() {
+    final Map<String, Parameter<?>> map = super.getNameParameterMap();
+    map.put("Feature type columns", getParameter(showFeatureTypeColumns));
+    map.put("Row type columns", getParameter(showRowTypeColumns));
+    return map;
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FxFeatureTableController.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FxFeatureTableController.java
@@ -29,7 +29,7 @@ import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.javafx.mvci.FxCachedViewController;
 import io.github.mzmine.javafx.mvci.FxViewBuilder;
-import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.main.ConfigService;
 import io.github.mzmine.modules.visualization.featurelisttable_modular.FxFeatureTableFilterMenu.FxFeatureTableFilterMenuModel;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -40,7 +40,9 @@ public class FxFeatureTableController extends FxCachedViewController<FxFeatureTa
   private final FxFeatureTableInteractor interactor;
 
   public FxFeatureTableController() {
-    var params = MZmineCore.getConfiguration().getModuleParameters(FeatureTableFXModule.class);
+    // use a clone, will set parameters to module params after tab close
+    var params = ConfigService.getConfiguration().getModuleParameters(FeatureTableFXModule.class)
+        .cloneParameterSet();
     super(new FxFeatureTableModel(params));
 
     // interactor before view is built
@@ -58,6 +60,9 @@ public class FxFeatureTableController extends FxCachedViewController<FxFeatureTa
     super.close();
     final FeatureTableFX table = model.getFeatureTable();
     table.closeTable();
+    // save parameters
+    ConfigService.getConfiguration()
+        .setModuleParameters(FeatureTableFXModule.class, model.getParameters());
   }
 
   public void setFeatureList(@Nullable FeatureList featureList) {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FxFeatureTableFilterMenu.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FxFeatureTableFilterMenu.java
@@ -62,7 +62,7 @@ public class FxFeatureTableFilterMenu extends BorderPane {
 
   private static final Logger logger = Logger.getLogger(FxFeatureTableFilterMenu.class.getName());
   private final FxFeatureTableFilterMenuModel model;
-  @org.jetbrains.annotations.NotNull
+  @NotNull
   private final FxFeatureTableModel parentModel;
   private final FlowPane filterFlow;
   private final HBox rightButtonMenu;

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FxFeatureTableInteractor.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FxFeatureTableInteractor.java
@@ -97,7 +97,8 @@ public class FxFeatureTableInteractor extends FxInteractor<FxFeatureTableModel> 
       if (exitCode == ExitCode.OK) {
         updateWindowToParameterSetValues();
         // set to module
-        ConfigService.getConfiguration().setModuleParameters(FeatureTableFXModule.class, param);
+        ConfigService.getConfiguration()
+            .setModuleParameters(FeatureTableFXModule.class, param.cloneParameterSet());
       }
     });
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FxFeatureTableInteractor.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FxFeatureTableInteractor.java
@@ -28,6 +28,7 @@ package io.github.mzmine.modules.visualization.featurelisttable_modular;
 import io.github.mzmine.javafx.concurrent.threading.FxThread;
 import io.github.mzmine.javafx.mvci.FxInteractor;
 import io.github.mzmine.javafx.properties.PropertyUtils;
+import io.github.mzmine.main.ConfigService;
 import io.github.mzmine.modules.visualization.featurelisttable_modular.FxFeatureTableFilterMenu.FxFeatureTableFilterMenuModel;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.util.ExitCode;
@@ -95,6 +96,8 @@ public class FxFeatureTableInteractor extends FxInteractor<FxFeatureTableModel> 
       ExitCode exitCode = param.showSetupDialog(true);
       if (exitCode == ExitCode.OK) {
         updateWindowToParameterSetValues();
+        // set to module
+        ConfigService.getConfiguration().setModuleParameters(FeatureTableFXModule.class, param);
       }
     });
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FxFeatureTableModel.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/FxFeatureTableModel.java
@@ -54,7 +54,7 @@ public class FxFeatureTableModel {
 
   // for now we need to expose the feature table as it is used in many places
   // usually better to not put view classes into the model
-  private final @NotNull FeatureTableFX featureTable = new FeatureTableFX();
+  private final @NotNull FeatureTableFX featureTable;
 
   // derived properties from feature table
   private final ReadOnlyObjectWrapper<ModularFeatureList> featureList = new ReadOnlyObjectWrapper<>();
@@ -67,6 +67,7 @@ public class FxFeatureTableModel {
 
   public FxFeatureTableModel(@NotNull ParameterSet parameters) {
     this.parameters = parameters;
+    featureTable = new FeatureTableFX(parameters);
 
     internalBindings();
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/TableColumnMenuHelper.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/featurelisttable_modular/TableColumnMenuHelper.java
@@ -198,13 +198,19 @@ public class TableColumnMenuHelper {
     } else {
       // Show the menu
       final ContextMenu newColumnPopupMenu = createContextMenu();
-      newColumnPopupMenu.setOnHidden(ev -> columnPopupMenu = null);
+      newColumnPopupMenu.setOnHidden(ev -> {
+        columnPopupMenu = null;
+        onPopupClosed();
+      });
       columnPopupMenu = newColumnPopupMenu;
       columnPopupMenu.show(buttonNode, Side.BOTTOM, 0, 0);
       // Repositioning the menu to be aligned by its right side (keeping inside the table view)
       columnPopupMenu.setX(buttonNode.localToScreen(buttonNode.getBoundsInLocal()).getMaxX()
           - columnPopupMenu.getWidth());
     }
+  }
+
+  protected void onPopupClosed() {
   }
 
   private void setFixedHeader() {

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/datatype/DataTypeCheckListComponent.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/datatype/DataTypeCheckListComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -64,12 +64,13 @@ public class DataTypeCheckListComponent extends StackPane {
   }
 
   public void setValue(@Nullable Map<String, Boolean> map) {
+    checkList.getCheckModel().clearChecks();
     dataTypes.clear();
     if (map == null) {
       return;
     }
 
-    map.keySet().stream().sorted().forEach(dataTypes::add);
+    dataTypes.setAll(map.keySet().stream().sorted().toList());
     map.forEach((dt, b) -> {
       if (b) {
         checkList.getCheckModel().check(dt);

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/datatype/DataTypeCheckListParameter.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/datatype/DataTypeCheckListParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -168,7 +168,7 @@ public class DataTypeCheckListParameter implements
    * @param map Map containing new data types and their values
    */
   public void setDataTypesAndVisibility(Map<String, Boolean> map) {
-    value = new HashMap<>(map);
+    value.putAll(map);
   }
 
   @Override
@@ -211,7 +211,7 @@ public class DataTypeCheckListParameter implements
 
   @Override
   public void setValue(Map<String, Boolean> newValue) {
-    this.value = newValue;
+    this.value.putAll(newValue);
   }
 
   @Override
@@ -224,7 +224,7 @@ public class DataTypeCheckListParameter implements
       Boolean val = Boolean.valueOf(e.getAttribute(DATA_TYPE_VISIBLE_ATTR));
 
       final String replaced = key.replace("Feature:", "");
-      if(key.contains(" ") || !replaced.equals(replaced.toLowerCase())) {
+      if (key.contains(" ") || !replaced.equals(replaced.toLowerCase())) {
         // may be an old key from the time we were using the column headers
         continue;
       }
@@ -256,8 +256,10 @@ public class DataTypeCheckListParameter implements
   }
 
   @Override
-  public UserParameter cloneParameter() {
-    return null;
+  public DataTypeCheckListParameter cloneParameter() {
+    final DataTypeCheckListParameter clone = new DataTypeCheckListParameter(name, desc);
+    clone.setValue(new HashMap<>(value));
+    return clone;
   }
 
   public void setAll(boolean visible) {

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/datatype/DataTypeCheckListParameter.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/datatype/DataTypeCheckListParameter.java
@@ -168,7 +168,7 @@ public class DataTypeCheckListParameter implements
    * @param map Map containing new data types and their values
    */
   public void setDataTypesAndVisibility(Map<String, Boolean> map) {
-    value.putAll(map);
+    value = new HashMap<>(map);
   }
 
   @Override
@@ -211,7 +211,7 @@ public class DataTypeCheckListParameter implements
 
   @Override
   public void setValue(Map<String, Boolean> newValue) {
-    this.value.putAll(newValue);
+    this.value = new HashMap<>(newValue);
   }
 
   @Override


### PR DESCRIPTION
This PR contains #2818 and reverts to using the new HashMap instead of putAll. 

Not sure what is better up t you. 

Presets may define fewer visible states than columns available. When we apply a preset to a parameterset then:

- this PR will use the default visible state defined in types.
- the #2818 will use the currently set visible state - so the preset would be more like a patch on top of current for this module.

Long term we could think about adding a state to this parameters how to handle unknown columns: default, invisible, visible ...