### PR TITLE
Feature shape column

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/FeatureShapeType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/FeatureShapeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -29,13 +29,16 @@ import com.google.common.util.concurrent.AtomicDouble;
 import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureListRow;
-import io.github.mzmine.datamodel.features.types.graphicalnodes.FeatureShapeChart;
+import io.github.mzmine.datamodel.features.types.graphicalnodes.ChromatogramFeatureShapeCellFactory;
+import io.github.mzmine.datamodel.features.types.modifiers.SubColumnsFactory;
 import io.github.mzmine.javafx.concurrent.threading.FxThread;
 import io.github.mzmine.modules.visualization.chromatogram.ChromatogramVisualizerModule;
 import io.github.mzmine.modules.visualization.featurelisttable_modular.FeatureTableFX;
 import java.util.List;
 import java.util.logging.Logger;
+import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.scene.Node;
+import javafx.scene.control.TreeTableColumn;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -63,15 +66,20 @@ public class FeatureShapeType extends LinkedGraphicalType {
   }
 
   @Override
+  public @Nullable TreeTableColumn<ModularFeatureListRow, Object> createColumn(
+      @Nullable RawDataFile raw, @Nullable SubColumnsFactory parentType) {
+    final TreeTableColumn<ModularFeatureListRow, Object> column = super.createColumn(raw,
+        parentType);
+    column.setCellFactory(new ChromatogramFeatureShapeCellFactory());
+    column.setCellValueFactory(cdf -> new ReadOnlyObjectWrapper<>(cdf.getValue().getValue()));
+    return column;
+  }
+
+  @Override
   public @Nullable Node createCellContent(ModularFeatureListRow row, Boolean cellData,
       RawDataFile raw, AtomicDouble progress) {
-
-    if (row == null || cellData == null || !cellData) {
-      return null;
-    }
-
-    var chart = new FeatureShapeChart(row, progress);
-    return chart;
+    throw new UnsupportedOperationException(
+        "Should use the createColumn method instead of this one.");
   }
 
   @Override
@@ -81,13 +89,12 @@ public class FeatureShapeType extends LinkedGraphicalType {
 
   @Nullable
   @Override
-  public Runnable getDoubleClickAction(final @Nullable FeatureTableFX table, @NotNull ModularFeatureListRow row,
-      @NotNull List<RawDataFile> rawDataFiles, DataType<?> superType,
-      @Nullable final Object value) {
+  public Runnable getDoubleClickAction(final @Nullable FeatureTableFX table,
+      @NotNull ModularFeatureListRow row, @NotNull List<RawDataFile> rawDataFiles,
+      DataType<?> superType, @Nullable final Object value) {
 
     return () -> {
-      FxThread.runLater(
-          () -> ChromatogramVisualizerModule.visualizeFeatureListRows(List.of(row)));
+      FxThread.runLater(() -> ChromatogramVisualizerModule.visualizeFeatureListRows(List.of(row)));
     };
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/ChromatogramFeatureShapeCell.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/ChromatogramFeatureShapeCell.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2004-2025 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.datamodel.features.types.graphicalnodes;
+
+import io.github.mzmine.datamodel.ImagingRawDataFile;
+import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import io.github.mzmine.datamodel.features.types.modifiers.GraphicalColumType;
+import io.github.mzmine.gui.chartbasics.gestures.ChartGesture;
+import io.github.mzmine.gui.chartbasics.gestures.ChartGesture.Entity;
+import io.github.mzmine.gui.chartbasics.gestures.ChartGesture.Event;
+import io.github.mzmine.gui.chartbasics.gestures.ChartGesture.GestureButton;
+import io.github.mzmine.gui.chartbasics.gestures.ChartGestureHandler;
+import io.github.mzmine.gui.chartbasics.simplechart.SimpleXYChart;
+import io.github.mzmine.gui.chartbasics.simplechart.datasets.ColoredXYDataset;
+import io.github.mzmine.gui.chartbasics.simplechart.datasets.RunOption;
+import io.github.mzmine.gui.chartbasics.simplechart.providers.impl.series.IonTimeSeriesToXYProvider;
+import io.github.mzmine.gui.preferences.UnitFormat;
+import io.github.mzmine.javafx.concurrent.threading.FxThread;
+import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.visualization.chromatogram.ChromatogramVisualizerModule;
+import io.github.mzmine.util.MathUtils;
+import io.github.mzmine.util.RangeUtils;
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.logging.Logger;
+import javafx.scene.control.ContentDisplay;
+import javafx.scene.control.TreeTableCell;
+import javafx.scene.control.TreeTableRow;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.Region;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.data.Range;
+
+/**
+ * Generates a chart at creation with a preferred size set. updateItem sets the datasets in one call
+ * so that there is only one call to {@link JFreeChart#fireChartChanged()} and drawing the chart.
+ * The first cell seems to be the measurement cell and is never updated here as there are many calls
+ * to update item on cell 0 and just single calls on all other cells.
+ */
+public class ChromatogramFeatureShapeCell extends TreeTableCell<ModularFeatureListRow, Object> {
+
+  private static final Logger logger = Logger.getLogger(
+      ChromatogramFeatureShapeCell.class.getName());
+
+  private final SimpleXYChart<IonTimeSeriesToXYProvider> plot;
+  private final Region view;
+  private final int id;
+
+  public ChromatogramFeatureShapeCell(int id) {
+    super();
+    this.id = id;
+    setMinWidth(GraphicalColumType.LARGE_GRAPHICAL_CELL_WIDTH);
+    setMinHeight(GraphicalColumType.DEFAULT_GRAPHICAL_CELL_HEIGHT);
+    setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
+
+    plot = createChart();
+    view = new BorderPane(plot);
+
+    graphicProperty().bind(emptyProperty().map(empty -> empty ? null : view));
+  }
+
+  private String getIdentifier(String action) {
+    final TreeTableRow<ModularFeatureListRow> row = getTableRow();
+    return "Chromatogram Cell %d action: %s (%s %s row %s)".formatted(id, action, isEmpty(),
+        getItem(), row == null ? "no table row" : row.getItem());
+  }
+
+  @Override
+  protected void updateItem(Object o, boolean b) {
+    // always need to call super.updateItem
+    super.updateItem(o, b);
+
+    final ModularFeatureListRow row = getTableRow().getItem();
+    // first cell with id 0 seems to be just the measuring cell - no need to put content.
+    // the chart itself already helps measurements
+    if (row == null || isEmpty() || id == 0) {
+      // no need to remove datasets because we will replace once we have a new dataset with setAll
+//      plot.removeAllDatasets();
+      return;
+    }
+    // debugging of updates
+//    logger.info(getIdentifier("updateItem"));
+
+    // for selecting a range
+    com.google.common.collect.Range<Float> featureRTRange = null;
+    Float maxHeight = null;
+
+    //
+    int size = row.getFilesFeatures().size();
+    ArrayList<ColoredXYDataset> datasets = new ArrayList<>(size);
+    for (ModularFeature f : row.getFeatures()) {
+      if (f.getRawDataFile() instanceof ImagingRawDataFile) {
+        continue;
+      }
+      maxHeight = MathUtils.max(f.getHeight(), maxHeight);
+
+//        fwhm = MathUtils.max(fwhm, f.getFWHM());
+      featureRTRange = RangeUtils.span(featureRTRange, f.getRawDataPointsRTRange());
+
+      IonTimeSeries<? extends Scan> dpSeries = f.getFeatureData();
+      if (dpSeries != null) {
+        // IonTimeSeriesToXYProvider is already precomputed and can be set on FXThread directly
+        // therefore no need for caching and other thread
+        ColoredXYDataset dataset = new ColoredXYDataset(new IonTimeSeriesToXYProvider(f),
+            RunOption.THIS_THREAD);
+        datasets.add(dataset);
+      }
+    }
+
+    if (datasets.isEmpty()) {
+      plot.removeAllDatasets();
+      return;
+    }
+
+    datasets.trimToSize();
+
+    featureRTRange = RangeUtils.multiplyGrow(featureRTRange, 1.25f);
+    featureRTRange = RangeUtils.withinBounds(featureRTRange, 0f, null);
+    final Range rtRange = RangeUtils.guavaToJFree(featureRTRange);
+
+    final float finalMaxHeight = maxHeight;
+    plot.applyWithNotifyChanges(false, true, () -> {
+      plot.setDatasets(datasets);
+      try {
+        final XYPlot xyplot = plot.getXYPlot();
+        xyplot.getRangeAxis().setRange(new Range(0, finalMaxHeight), true, false);
+        xyplot.getRangeAxis().setUpperMargin(0.025);
+        xyplot.getDomainAxis().setRange(rtRange, true, false);
+        xyplot.getDomainAxis().setDefaultAutoRange(rtRange);
+      } catch (NullPointerException | NoSuchElementException ex) {
+        // error in jfreechart draw method
+      }
+    });
+  }
+
+  private SimpleXYChart<IonTimeSeriesToXYProvider> createChart() {
+    UnitFormat uf = MZmineCore.getConfiguration().getUnitFormat();
+
+    SimpleXYChart<IonTimeSeriesToXYProvider> chart = new SimpleXYChart<>(
+        uf.format("Retention time" + id, "min"), uf.format("Intensity", "a.u."));
+//        uf.format("Retention time", "min"), uf.format("Intensity", "a.u."));
+    chart.setRangeAxisNumberFormatOverride(MZmineCore.getConfiguration().getIntensityFormat());
+    chart.setDomainAxisNumberFormatOverride(MZmineCore.getConfiguration().getRTFormat());
+    chart.setLegendItemsVisible(false);
+    chart.setPrefWidth(GraphicalColumType.LARGE_GRAPHICAL_CELL_WIDTH);
+
+    chart.getChart().setBackgroundPaint((new Color(0, 0, 0, 0)));
+    chart.getXYPlot().setBackgroundPaint((new Color(0, 0, 0, 0)));
+
+//    chart.addChartDrawDebugListener(() -> logger.info(getIdentifier("CHART DRAW")));
+
+    chart.getMouseAdapter().addGestureHandler(new ChartGestureHandler(
+        new ChartGesture(Entity.ALL, Event.DOUBLE_CLICK, GestureButton.BUTTON1), _ -> {
+      final ModularFeatureListRow row = getTableRow().getItem();
+      FxThread.runLater(() -> ChromatogramVisualizerModule.visualizeFeatureListRows(List.of(row)));
+    }));
+
+    return chart;
+  }
+
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/ChromatogramFeatureShapeCellFactory.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/graphicalnodes/ChromatogramFeatureShapeCellFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2004-2025 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.datamodel.features.types.graphicalnodes;
+
+import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import java.util.concurrent.atomic.AtomicInteger;
+import javafx.scene.control.TreeTableCell;
+import javafx.scene.control.TreeTableColumn;
+import javafx.util.Callback;
+
+public class ChromatogramFeatureShapeCellFactory implements
+    Callback<TreeTableColumn<ModularFeatureListRow, Object>, TreeTableCell<ModularFeatureListRow, Object>> {
+
+  // uses a counter to label the first cell that seems to be the measurement cell
+  public final AtomicInteger counter = new AtomicInteger(0);
+
+  @Override
+  public TreeTableCell<ModularFeatureListRow, Object> call(
+      TreeTableColumn<ModularFeatureListRow, Object> column) {
+    return new ChromatogramFeatureShapeCell(counter.getAndIncrement());
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/gui/javafx/EChartViewer.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/gui/javafx/EChartViewer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -40,13 +40,14 @@ import io.github.mzmine.gui.chartbasics.listener.AxisRangeChangedListener;
 import io.github.mzmine.gui.chartbasics.listener.ZoomHistory;
 import io.github.mzmine.gui.chartbasics.simplechart.datasets.ColoredXYDataset;
 import io.github.mzmine.gui.chartbasics.simplechart.datasets.ColoredXYZDataset;
-import io.github.mzmine.javafx.concurrent.threading.FxThread;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.util.StringUtils;
 import io.github.mzmine.util.dialogs.AxesSetupDialog;
 import io.github.mzmine.util.io.XSSFExcelWriterReader;
 import java.awt.BasicStroke;
 import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -68,6 +69,7 @@ import javafx.scene.input.ClipboardContent;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.NumberAxis;
 import org.jfree.chart.axis.ValueAxis;
+import org.jfree.chart.event.ChartProgressEvent;
 import org.jfree.chart.fx.ChartViewer;
 import org.jfree.chart.fx.interaction.MouseHandlerFX;
 import org.jfree.chart.labels.XYToolTipGenerator;
@@ -576,12 +578,14 @@ public class EChartViewer extends ChartViewer implements DatasetChangeListener {
   }
 
   /**
-   * Disable/enable chart change events that trigger updating the chart.
+   * Disable/enable chart change events that trigger updating the chart. Setting to true will always
+   * trigger a chart update.
    */
   public void setNotifyChange(boolean notifyChange) {
     if (getChart() == null) {
       return;
     }
+    // setting to true will already fire a chart change event automatically
     getChart().setNotify(notifyChange);
 //    final Plot plot = getChart().getPlot();
 //    if(plot!=null) {
@@ -626,10 +630,8 @@ public class EChartViewer extends ChartViewer implements DatasetChangeListener {
       logic.run();
     } finally {
       // reset to old state and run changes if true
+      // setting to true will automatically trigger a draw event
       setNotifyChange(afterRunState);
-      if (afterRunState) {
-        FxThread.runLater(() -> fireChangeEvent());
-      }
     }
   }
 
@@ -666,5 +668,17 @@ public class EChartViewer extends ChartViewer implements DatasetChangeListener {
     marker.setAlpha(alpha);
     getChart().getXYPlot().addDomainMarker(marker, Layer.BACKGROUND);
     return marker;
+  }
+
+  /**
+   * Debugging of draw events. Only runs when {@link JFreeChart#draw(Graphics2D, Rectangle2D)} is
+   * started
+   */
+  public void addChartDrawDebugListener(Runnable eventListener) {
+    getChart().addProgressListener(event -> {
+      if (event.getType() == ChartProgressEvent.DRAWING_STARTED) {
+        eventListener.run();
+      }
+    });
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/SimpleXYChart.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/SimpleXYChart.java
@@ -232,10 +232,8 @@ public class SimpleXYChart<T extends PlotXYDataProvider> extends EChartViewer im
     nextDataSetNum++;
     notifyDatasetChangeListeners(new DatasetChangeEvent(this, dataset));
 
+    // if true this will auto trigger chart changed event and draw update
     setNotifyChange(oldNotify);
-    if (isNotifyChange()) {
-      fireChangeEvent();
-    }
     return nextDataSetNum - 1;
   }
 
@@ -292,11 +290,12 @@ public class SimpleXYChart<T extends PlotXYDataProvider> extends EChartViewer im
     if (notify && ds != null) {
       notifyDatasetChangeListeners(new DatasetChangeEvent(this, ds));
     }
+    // if true this will auto trigger chart changed event and draw update
     setNotifyChange(notify);
-    if (isNotifyChange()) {
-      fireChangeEvent();
+    // both could be true and that would both trigger a chart update
+    if (notify != oldNotify) {
+      setNotifyChange(oldNotify);
     }
-    setNotifyChange(oldNotify);
     return ds;
   }
 
@@ -326,7 +325,15 @@ public class SimpleXYChart<T extends PlotXYDataProvider> extends EChartViewer im
     });
   }
 
-  public void setDatasets(@NotNull List<@NotNull DatasetAndRenderer> datasets) {
+  public void setDatasets(@NotNull Collection<? extends ColoredXYDataset> datasets) {
+    // if old notify state was true this will auto trigger chart changed event and draw update
+    applyWithNotifyChanges(false, () -> {
+      removeAllDatasets();
+      addDatasets(datasets);
+    });
+  }
+
+  public void setDatasetsAndRenderers(@NotNull List<@NotNull DatasetAndRenderer> datasets) {
     applyWithNotifyChanges(false, () -> {
       removeAllDatasets();
       datasets.forEach(ds -> addDataset(ds.dataset(), ds.renderer()));

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/datasets/ColoredXYDataset.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/datasets/ColoredXYDataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -39,11 +39,11 @@ import io.github.mzmine.gui.chartbasics.simplechart.providers.ToolTipTextProvide
 import io.github.mzmine.gui.chartbasics.simplechart.providers.XYItemObjectProvider;
 import io.github.mzmine.gui.chartbasics.simplechart.providers.XYValueProvider;
 import io.github.mzmine.javafx.concurrent.threading.FxThread;
+import io.github.mzmine.javafx.util.FxColorUtil;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.taskcontrol.TaskPriority;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import io.github.mzmine.javafx.util.FxColorUtil;
 import java.util.logging.Logger;
 import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
@@ -156,6 +156,9 @@ public class ColoredXYDataset extends AbstractTaskXYDataset implements IntervalX
    * @return a valid run option.
    */
   protected final RunOption checkRunOption(final RunOption runOption) {
+    if (xyValueProvider.isComputed()) {
+      return RunOption.THIS_THREAD;
+    }
     if (runOption == RunOption.THIS_THREAD && Platform.isFxApplicationThread()) {
       logger.warning(() -> "Calculation of data set values was started on the JavaFX thread."
           + " Creating a new thread instead. Provider: " + xyValueProvider.getClass().getName());

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/ExampleXYProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/ExampleXYProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -26,9 +26,9 @@
 package io.github.mzmine.gui.chartbasics.simplechart.providers;
 
 import io.github.mzmine.datamodel.DataPoint;
+import io.github.mzmine.javafx.util.FxColorUtil;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import io.github.mzmine.javafx.util.FxColorUtil;
 import java.awt.Color;
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -65,6 +65,7 @@ public class ExampleXYProvider implements PlotXYDataProvider {
   private final List<DataPoint> originalDatapoints;
 
   private double finishedPercentage;
+  private boolean isComputed = false;
 
 
   public ExampleXYProvider(List<DataPoint> originalDataPoints) {
@@ -136,10 +137,16 @@ public class ExampleXYProvider implements PlotXYDataProvider {
     }
 
     finishedPercentage = 1.d;
+    isComputed = true;
   }
 
   @Override
   public double getComputationFinishedPercentage() {
     return finishedPercentage;
+  }
+
+  @Override
+  public boolean isComputed() {
+    return isComputed;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/ExampleXYZProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/ExampleXYZProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -53,6 +53,7 @@ public class ExampleXYZProvider implements PlotXYZDataProvider {
 
   private double dataPointWidth;
   private double dataPointHeight;
+  private boolean isComputed = false;
 
   private ExampleXYZProvider(ModularFeatureListRow row, AtomicDouble progress) {
     this.row = row;
@@ -140,6 +141,7 @@ public class ExampleXYZProvider implements PlotXYZDataProvider {
           progress.set((double) fi / size);
         }
       }
+      isComputed = true;
     } catch (Exception ex) {
       ex.printStackTrace();
     }
@@ -216,5 +218,12 @@ public class ExampleXYZProvider implements PlotXYZDataProvider {
       }
     }
     dataPointWidth = Math.abs(medianRt);
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return isComputed;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/SimpleXYProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/SimpleXYProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,8 +25,8 @@
 
 package io.github.mzmine.gui.chartbasics.simplechart.providers;
 
-import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.javafx.util.FxColorUtil;
+import io.github.mzmine.taskcontrol.TaskStatus;
 import java.awt.Color;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
@@ -140,5 +140,12 @@ public class SimpleXYProvider implements PlotXYDataProvider {
   @Override
   public double getComputationFinishedPercentage() {
     return finishedPercentage;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return true;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/XYValueProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/XYValueProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -88,4 +88,9 @@ public interface XYValueProvider {
    * @return a finished percentage. (0.0-1.0)
    */
   double getComputationFinishedPercentage();
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  boolean isComputed();
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/AnyXYProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/AnyXYProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -26,8 +26,8 @@
 package io.github.mzmine.gui.chartbasics.simplechart.providers.impl;
 
 import io.github.mzmine.gui.chartbasics.simplechart.providers.PlotXYDataProvider;
-import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.javafx.util.FxColorUtil;
+import io.github.mzmine.taskcontrol.TaskStatus;
 import java.awt.Color;
 import java.util.function.IntFunction;
 import javafx.beans.property.Property;
@@ -105,5 +105,10 @@ public class AnyXYProvider implements PlotXYDataProvider {
   @Override
   public double getComputationFinishedPercentage() {
     return 1;
+  }
+
+  @Override
+  public boolean isComputed() {
+    return true;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/FeatureImageProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/FeatureImageProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -61,6 +61,7 @@ public class FeatureImageProvider<T extends ImagingScan> implements PlotXYZDataP
   private IonTimeSeries<T> series;
   private double width;
   private double height;
+  private boolean isComputed = false;
 
   public FeatureImageProvider(Feature feature) {
     this(feature, (List<T>) feature.getFeatureList().getSeletedScans(feature.getRawDataFile()),
@@ -146,6 +147,8 @@ public class FeatureImageProvider<T extends ImagingScan> implements PlotXYZDataP
         ImagingPlot.DEFAULT_IMAGING_QUANTILES);
     paintScale = MZmineCore.getConfiguration().getDefaultPaintScalePalette()
         .toPaintScale(PaintScaleTransform.LINEAR, Range.closed(quantiles[0], quantiles[1]));
+
+    isComputed = true;
   }
 
   @Override
@@ -188,5 +191,12 @@ public class FeatureImageProvider<T extends ImagingScan> implements PlotXYZDataP
   @Override
   public T getSpectrum(int index) {
     return series.getSpectrum(index);
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return isComputed;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/IntervalXYProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/IntervalXYProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -27,8 +27,8 @@ package io.github.mzmine.gui.chartbasics.simplechart.providers.impl;
 
 import io.github.mzmine.gui.chartbasics.simplechart.providers.IntervalWidthProvider;
 import io.github.mzmine.gui.chartbasics.simplechart.providers.PlotXYDataProvider;
-import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.javafx.util.FxColorUtil;
+import io.github.mzmine.taskcontrol.TaskStatus;
 import java.awt.Color;
 import javafx.beans.property.Property;
 import org.jetbrains.annotations.NotNull;
@@ -89,7 +89,7 @@ public class IntervalXYProvider implements PlotXYDataProvider, IntervalWidthProv
 
   @Override
   public void computeValues(Property<TaskStatus> status) {
-
+    // nothing to do
   }
 
   @Override
@@ -110,5 +110,12 @@ public class IntervalXYProvider implements PlotXYDataProvider, IntervalWidthProv
   @Override
   public double getComputationFinishedPercentage() {
     return 0;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return true;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/ScanBPCProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/ScanBPCProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -51,7 +51,7 @@ public class ScanBPCProvider implements PlotXYDataProvider, MassSpectrumProvider
   private final NumberFormat mzFormat;
   private final NumberFormat mobilityFormat;
   private final NumberFormat intensityFormat;
-  private double normalizationFactor = 1;
+  private final double normalizationFactor;
 
   public ScanBPCProvider(final List<Scan> scans) {
     this(scans, false);
@@ -71,6 +71,10 @@ public class ScanBPCProvider implements PlotXYDataProvider, MassSpectrumProvider
     mzFormat = MZmineCore.getConfiguration().getMZFormat();
     mobilityFormat = MZmineCore.getConfiguration().getMobilityFormat();
     intensityFormat = MZmineCore.getConfiguration().getIntensityFormat();
+
+    normalizationFactor = 1 / scans.stream()
+        .mapToDouble(scan -> Objects.requireNonNullElse(scan.getBasePeakIntensity(), 0d)).max()
+        .orElse(1d);
   }
 
   @NotNull
@@ -105,9 +109,7 @@ public class ScanBPCProvider implements PlotXYDataProvider, MassSpectrumProvider
 
   @Override
   public void computeValues(Property<TaskStatus> status) {
-    normalizationFactor = 1 / scans.stream()
-        .mapToDouble(scan -> Objects.requireNonNullElse(scan.getBasePeakIntensity(), 0d)).max()
-        .orElse(1d);
+    // nothing to do here
   }
 
   @Override
@@ -137,5 +139,13 @@ public class ScanBPCProvider implements PlotXYDataProvider, MassSpectrumProvider
       return null;
     }
     return scans.get(index);
+  }
+
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return true;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/features/FeatureRawMobilogramProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/features/FeatureRawMobilogramProvider.java
@@ -63,6 +63,7 @@ public class FeatureRawMobilogramProvider implements PlotXYDataProvider {
   private SummedIntensityMobilitySeries rawMobilogram;
   private final Range<Double> mzRange;
   private double percentage = 0d;
+  private boolean isComputed;
 
   public FeatureRawMobilogramProvider(@NotNull final Feature f,
       @NotNull final Range<Double> mzRange) {
@@ -124,6 +125,14 @@ public class FeatureRawMobilogramProvider implements PlotXYDataProvider {
     binner.setMobilogram(mobilograms);
     rawMobilogram = binner.toSummedMobilogram(null);
     percentage = 1d;
+    isComputed = true;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return isComputed;
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/features/OtherFeatureDataProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/features/OtherFeatureDataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -104,6 +104,14 @@ public class OtherFeatureDataProvider implements PlotXYDataProvider {
   @Override
   public void computeValues(Property<TaskStatus> status) {
     // nothing to do
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  @Override
+  public boolean isComputed() {
+    return true;
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/features/RowToCCSMzHeatmapProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/features/RowToCCSMzHeatmapProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -60,6 +60,7 @@ public class RowToCCSMzHeatmapProvider implements PieXYZDataProvider<IMSRawDataF
   private final double minDiameter = 10d;
   private double deltaDiameter = 1d;
   private double deltaValue = 1d;
+  private boolean isComputed;
 
   public RowToCCSMzHeatmapProvider(@NotNull final Collection<ModularFeatureListRow> f) {
     // copy the list, so we don't run into problems in case the flist is modified
@@ -112,8 +113,8 @@ public class RowToCCSMzHeatmapProvider implements PieXYZDataProvider<IMSRawDataF
     final String sb =
         "m/z:" + mzFormat.format(f.getMZRange().lowerEndpoint()) + " - " + mzFormat.format(
             f.getMZRange().upperEndpoint()) + "\n" + "Height: " + intensityFormat.format(
-            f.getMaxHeight()) + "\n" + "Retention time" + ": " + rtFormat.format(
-            f.getAverageRT()) + " min\n" + "CCS: " + ccsFormat.format(f.getAverageCCS());
+            f.getMaxHeight()) + "\n" + "Retention time" + ": " + rtFormat.format(f.getAverageRT())
+            + " min\n" + "CCS: " + ccsFormat.format(f.getAverageCCS());
     return sb;
   }
 
@@ -139,6 +140,15 @@ public class RowToCCSMzHeatmapProvider implements PieXYZDataProvider<IMSRawDataF
     }
     deltaDiameter = maxDiameter - minDiameter;
     deltaValue = maxValue - minValue;
+    isComputed = true;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  @Override
+  public boolean isComputed() {
+    return isComputed;
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/features/RowToMobilityMzHeatmapProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/features/RowToMobilityMzHeatmapProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -59,6 +59,7 @@ public class RowToMobilityMzHeatmapProvider implements PieXYZDataProvider<IMSRaw
   private final double minDiameter = 10d;
   private double deltaDiameter = 1d;
   private double deltaValue = 1d;
+  private boolean isComputed;
 
   public RowToMobilityMzHeatmapProvider(@NotNull final Collection<ModularFeatureListRow> f) {
     // copy the list, so we don't run into problems in case the flist is modified
@@ -111,9 +112,8 @@ public class RowToMobilityMzHeatmapProvider implements PieXYZDataProvider<IMSRaw
     final String sb =
         "m/z:" + mzFormat.format(f.getMZRange().lowerEndpoint()) + " - " + mzFormat.format(
             f.getMZRange().upperEndpoint()) + "\n" + "Height: " + intensityFormat.format(
-            f.getMaxHeight()) + "\n" + "Retention time" + ": " + rtFormat.format(
-            f.getAverageRT()) + " min\n" + "Mobility: " + mobilityFormat.format(
-            f.getAverageMobility());
+            f.getMaxHeight()) + "\n" + "Retention time" + ": " + rtFormat.format(f.getAverageRT())
+            + " min\n" + "Mobility: " + mobilityFormat.format(f.getAverageMobility());
     return sb;
   }
 
@@ -136,6 +136,15 @@ public class RowToMobilityMzHeatmapProvider implements PieXYZDataProvider<IMSRaw
     }
     deltaDiameter = maxDiameter - minDiameter;
     deltaValue = maxValue - minValue;
+    isComputed = true;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  @Override
+  public boolean isComputed() {
+    return isComputed;
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/FeaturesToCCSMzHeatmapProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/FeaturesToCCSMzHeatmapProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -55,6 +55,7 @@ public class FeaturesToCCSMzHeatmapProvider implements PlotXYZDataProvider {
   private final List<ModularFeature> features;
   private double boxWidth;
   private double boxHeight;
+  private boolean isComputed;
 
   public FeaturesToCCSMzHeatmapProvider(@NotNull final List<ModularFeature> f) {
     features = f.stream().filter(feature -> feature.getCCS() != null).collect(Collectors.toList());
@@ -158,6 +159,14 @@ public class FeaturesToCCSMzHeatmapProvider implements PlotXYZDataProvider {
     width /= numSamples;
     boxWidth = width;
     boxHeight /= numSamples;
+    isComputed = true;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return isComputed;
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/FeaturesToMobilityMzHeatmapProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/FeaturesToMobilityMzHeatmapProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -55,6 +55,7 @@ public class FeaturesToMobilityMzHeatmapProvider implements PlotXYZDataProvider 
   private final List<ModularFeature> features;
   private double boxWidth;
   private double boxHeight;
+  private boolean isComputed;
 
   public FeaturesToMobilityMzHeatmapProvider(@NotNull final List<ModularFeature> f) {
     features = f;
@@ -147,6 +148,14 @@ public class FeaturesToMobilityMzHeatmapProvider implements PlotXYZDataProvider 
           ((IMSRawDataFile) features.get(0).getRawDataFile()).getFrame(0)) * 3;
     }
 
+    isComputed = true;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return isComputed;
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/IMSIonTraceHeatmapProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/IMSIonTraceHeatmapProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -66,6 +66,7 @@ public class IMSIonTraceHeatmapProvider implements PlotXYZDataProvider,
   private final NumberFormat mzFormat;
 
   private double finishedPerecentage;
+  private boolean isComputed;
 
   /**
    * Constructs an ion trace with a given mz and rt range from a raw data file. This trace is
@@ -118,6 +119,14 @@ public class IMSIonTraceHeatmapProvider implements PlotXYZDataProvider,
       num++;
       finishedPerecentage = (double) num / numFrames;
     }
+    isComputed = true;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return isComputed;
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/IntensityTimeSeriesToXYProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/IntensityTimeSeriesToXYProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -110,7 +110,14 @@ public class IntensityTimeSeriesToXYProvider implements PlotXYDataProvider {
 
   @Override
   public void computeValues(Property<TaskStatus> status) {
-    return;
+    // nothing to do
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return true;
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/IonMobilogramTimeSeriesToRtMobilityHeatmapProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/IonMobilogramTimeSeriesToRtMobilityHeatmapProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -65,6 +65,7 @@ public class IonMobilogramTimeSeriesToRtMobilityHeatmapProvider implements PlotX
   private final double progress;
   private PaintScale paintScale = null;
   private final List<IonMobilitySeries> mobilograms;
+  private boolean isComputed;
 
   public IonMobilogramTimeSeriesToRtMobilityHeatmapProvider(final ModularFeature f) {
     if (!(f.getFeatureData() instanceof IonMobilogramTimeSeries)) {
@@ -149,6 +150,14 @@ public class IonMobilogramTimeSeriesToRtMobilityHeatmapProvider implements PlotX
       paintScale = new SimpleColorPalette(base, color).toPaintScale(PaintScaleTransform.LINEAR,
           Range.closed(0d, max));
     }
+    isComputed = true;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return isComputed;
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/IonTimeSeriesToXYProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/IonTimeSeriesToXYProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -148,5 +148,12 @@ public class IonTimeSeriesToXYProvider implements PlotXYDataProvider, ColorPrope
       return null;
     }
     return series.getSpectra().get(index);
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return true;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/MzRangeChromatogramProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/MzRangeChromatogramProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -41,6 +41,7 @@ public class MzRangeChromatogramProvider extends SimpleXYProvider {
 
   private final Range<Double> mz;
   private final List<? extends Scan> scans;
+  private boolean isComputed;
 
   public MzRangeChromatogramProvider(Range<Double> mz, List<? extends Scan> scans, String seriesKey,
       Color awt) {
@@ -59,6 +60,14 @@ public class MzRangeChromatogramProvider extends SimpleXYProvider {
       throw new RuntimeException("Could not calculate chromatogram");
     }
     setyValues(result[0].getIntensities());
+    isComputed = true;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return isComputed;
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/SummedIntensityMobilitySeriesToMobilityMzHeatmapProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/SummedIntensityMobilitySeriesToMobilityMzHeatmapProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -139,7 +139,7 @@ public class SummedIntensityMobilitySeriesToMobilityMzHeatmapProvider implements
 
   @Override
   public void computeValues(Property<TaskStatus> status) {
-
+    // nothing to do
   }
 
   @Override
@@ -187,5 +187,12 @@ public class SummedIntensityMobilitySeriesToMobilityMzHeatmapProvider implements
   @Nullable
   public ModularFeature getSourceFeature() {
     return feature;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return true;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/SummedMobilogramXYProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/series/SummedMobilogramXYProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -31,10 +31,10 @@ import io.github.mzmine.datamodel.featuredata.IonTimeSeries;
 import io.github.mzmine.datamodel.featuredata.impl.SummedIntensityMobilitySeries;
 import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.gui.chartbasics.simplechart.providers.PlotXYDataProvider;
+import io.github.mzmine.javafx.util.FxColorUtil;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.IonMobilityUtils;
-import io.github.mzmine.javafx.util.FxColorUtil;
 import java.text.NumberFormat;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.Property;
@@ -58,6 +58,7 @@ public class SummedMobilogramXYProvider implements PlotXYDataProvider {
 
   private final Double normalizationFactor;
   private SummedIntensityMobilitySeries data;
+  private boolean isComputed = false;
 
   public SummedMobilogramXYProvider(final Feature f) {
     this(f, false);
@@ -133,6 +134,7 @@ public class SummedMobilogramXYProvider implements PlotXYDataProvider {
     if (normalize || normalizationFactor != null) {
       data = IonMobilityUtils.normalizeMobilogram(data, normalizationFactor);
     }
+    isComputed = true;
   }
 
   @Override
@@ -159,5 +161,12 @@ public class SummedMobilogramXYProvider implements PlotXYDataProvider {
   @Override
   public double getComputationFinishedPercentage() {
     return 0;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return isComputed;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/FrameHeatmapProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/FrameHeatmapProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -67,6 +67,7 @@ public class FrameHeatmapProvider implements PlotXYZDataProvider {
 
   protected PaintScale paintScale;
   private double finishedPercentage;
+  private boolean isComputed = false;
 
   public FrameHeatmapProvider(Frame frame) {
     this.frame = frame;
@@ -132,9 +133,11 @@ public class FrameHeatmapProvider implements PlotXYZDataProvider {
       finishedPercentage = finishedScans / numScans;
     }
 
-    final double[] quantiles = MathUtils.calcQuantile(zValues.toDoubleArray(), new double[]{0.50, 0.98});
+    final double[] quantiles = MathUtils.calcQuantile(zValues.toDoubleArray(),
+        new double[]{0.50, 0.98});
     paintScale = MZmineCore.getConfiguration().getDefaultPaintScalePalette()
         .toPaintScale(PaintScaleTransform.LINEAR, Range.closed(quantiles[0], quantiles[1]));
+    isComputed = true;
   }
 
   public MobilityScan getMobilityScanAtValueIndex(int index) {
@@ -176,5 +179,12 @@ public class FrameHeatmapProvider implements PlotXYZDataProvider {
   @Override
   public Double getBoxWidth() {
     return null;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return isComputed;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/FrameSummedMobilogramProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/FrameSummedMobilogramProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -57,6 +57,8 @@ public class FrameSummedMobilogramProvider implements PlotXYDataProvider {
   private double[] intensities;
 
   private double finishedPercentage;
+  private boolean isComputed = false;
+
 
   /**
    * @param binWidth Number of mobility scans to be accumulated for mobilogram generation.
@@ -146,5 +148,13 @@ public class FrameSummedMobilogramProvider implements PlotXYDataProvider {
       finishedPercentage = (double) i / numScans;
     }
     finishedPercentage = 1.0;
+    isComputed = true;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return isComputed;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/FrameSummedSpectrumProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/FrameSummedSpectrumProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -108,5 +108,12 @@ public class FrameSummedSpectrumProvider implements PlotXYDataProvider {
   @Override
   public double getComputationFinishedPercentage() {
     return 1;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return true;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/LipidSpectrumProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/LipidSpectrumProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -30,10 +30,10 @@ import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.MassSpectrum;
 import io.github.mzmine.datamodel.MassSpectrumType;
 import io.github.mzmine.gui.chartbasics.simplechart.providers.PlotXYDataProvider;
+import io.github.mzmine.javafx.util.FxColorUtil;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.dataprocessing.id_lipidid.common.lipids.LipidFragment;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import io.github.mzmine.javafx.util.FxColorUtil;
 import java.awt.Color;
 import java.util.Iterator;
 import java.util.List;
@@ -163,7 +163,7 @@ public class LipidSpectrumProvider implements PlotXYDataProvider {
 
   @Override
   public void computeValues(Property<TaskStatus> status) {
-
+    // nothing to do
   }
 
   @Override
@@ -194,5 +194,12 @@ public class LipidSpectrumProvider implements PlotXYDataProvider {
   @Override
   public @org.jetbrains.annotations.Nullable String getToolTipText(int itemIndex) {
     return null;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return true;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/MassSpectrumProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/MassSpectrumProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -30,9 +30,9 @@ import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.MassSpectrum;
 import io.github.mzmine.datamodel.MassSpectrumType;
 import io.github.mzmine.gui.chartbasics.simplechart.providers.PlotXYDataProvider;
+import io.github.mzmine.javafx.util.FxColorUtil;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import io.github.mzmine.javafx.util.FxColorUtil;
 import java.awt.Color;
 import java.text.NumberFormat;
 import java.util.Iterator;
@@ -170,7 +170,7 @@ public class MassSpectrumProvider implements PlotXYDataProvider {
 
   @Override
   public void computeValues(Property<TaskStatus> status) {
-
+    // nothing to do
   }
 
   @Override
@@ -191,5 +191,12 @@ public class MassSpectrumProvider implements PlotXYDataProvider {
   @Override
   public double getComputationFinishedPercentage() {
     return 1d;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return true;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/MergedFrameHeatmapProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/MergedFrameHeatmapProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -55,6 +55,7 @@ public class MergedFrameHeatmapProvider implements PlotXYZDataProvider {
   private double boxHeight;
   private double boxWidth;
   private int numValues = 0;
+  private boolean isComputed = false;
 
   public MergedFrameHeatmapProvider(@NotNull final Collection<Frame> frames,
       @NotNull final MZTolerance tolerance, final int mobilityScanBin) {
@@ -124,6 +125,8 @@ public class MergedFrameHeatmapProvider implements PlotXYZDataProvider {
       final double mzDelta = ArrayUtils.smallestDelta(mzs, scan.getNumberOfDataPoints());
       boxWidth = Math.min(mzDelta, boxWidth);
     }
+
+    isComputed = true;
   }
 
   @Override
@@ -182,5 +185,12 @@ public class MergedFrameHeatmapProvider implements PlotXYZDataProvider {
   @Override
   public Double getBoxWidth() {
     return boxWidth;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return isComputed;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/MobilityScanMobilogramProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/MobilityScanMobilogramProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -34,11 +34,11 @@ import io.github.mzmine.datamodel.featuredata.IonMobilitySeries;
 import io.github.mzmine.datamodel.featuredata.impl.SummedIntensityMobilitySeries;
 import io.github.mzmine.gui.chartbasics.simplechart.providers.PlotXYDataProvider;
 import io.github.mzmine.gui.preferences.NumberFormats;
+import io.github.mzmine.javafx.util.FxColorUtil;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.IonMobilityUtils;
 import io.github.mzmine.util.IonMobilityUtils.MobilogramType;
-import io.github.mzmine.javafx.util.FxColorUtil;
 import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -65,6 +65,7 @@ public class MobilityScanMobilogramProvider implements PlotXYDataProvider {
   private int processed = 0;
   private int totalFrames = 1;
   private SummedIntensityMobilitySeries data;
+  private boolean isComputed = false;
 
   /**
    * Creates a mobilogram from the mobility scans.
@@ -157,6 +158,7 @@ public class MobilityScanMobilogramProvider implements PlotXYDataProvider {
     if (normalize) {
       data = IonMobilityUtils.normalizeMobilogram(data, null);
     }
+    isComputed = true;
   }
 
   @Override
@@ -177,5 +179,12 @@ public class MobilityScanMobilogramProvider implements PlotXYDataProvider {
   @Override
   public double getComputationFinishedPercentage() {
     return processed / (double) totalFrames;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return isComputed;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/SingleMobilityScanProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/SingleMobilityScanProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -94,7 +94,7 @@ public class SingleMobilityScanProvider implements PlotXYDataProvider {
 
   @Override
   public void computeValues(Property<TaskStatus> status) {
-    finishedPercentage = 1.d;
+    // nothing to do
   }
 
   @Override
@@ -115,5 +115,12 @@ public class SingleMobilityScanProvider implements PlotXYDataProvider {
   @Override
   public double getComputationFinishedPercentage() {
     return finishedPercentage;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return true;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/SingleSpectrumProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/SingleSpectrumProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -28,9 +28,9 @@ package io.github.mzmine.gui.chartbasics.simplechart.providers.impl.spectra;
 import io.github.mzmine.datamodel.MassSpectrum;
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.gui.chartbasics.simplechart.providers.PlotXYDataProvider;
+import io.github.mzmine.javafx.util.FxColorUtil;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import io.github.mzmine.javafx.util.FxColorUtil;
 import io.github.mzmine.util.scans.ScanUtils;
 import java.text.NumberFormat;
 import javafx.beans.property.Property;
@@ -111,5 +111,12 @@ public class SingleSpectrumProvider implements PlotXYDataProvider {
   @Override
   public double getComputationFinishedPercentage() {
     return 1d;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return true;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ResolvedPeak.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_chromatogramdeconvolution/ResolvedPeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -39,9 +39,9 @@ import io.github.mzmine.datamodel.impl.SimpleDataPoint;
 import io.github.mzmine.datamodel.impl.SimpleFeatureInformation;
 import io.github.mzmine.datamodel.msms.DDAMsMsInfo;
 import io.github.mzmine.gui.chartbasics.simplechart.providers.PlotXYDataProvider;
+import io.github.mzmine.javafx.util.FxColorUtil;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import io.github.mzmine.javafx.util.FxColorUtil;
 import io.github.mzmine.util.maths.CenterFunction;
 import io.github.mzmine.util.scans.ScanUtils;
 import java.awt.Color;
@@ -439,5 +439,10 @@ public class ResolvedPeak implements PlotXYDataProvider {
   @Override
   public double getComputationFinishedPercentage() {
     return 1d;
+  }
+
+  @Override
+  public boolean isComputed() {
+    return true;
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_rtcalibration2/ScanRtCorrectionPreviewPane.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_rtcalibration2/ScanRtCorrectionPreviewPane.java
@@ -95,7 +95,7 @@ public class ScanRtCorrectionPreviewPane extends AbstractPreviewPane<List<Featur
   @Override
   public void updateChart(@NotNull List<DatasetAndRenderer> datasets,
       @NotNull SimpleXYChart<? extends PlotXYDataProvider> chart) {
-    chart.setDatasets(datasets);
+    chart.setDatasetsAndRenderers(datasets);
 
     getTopTextFlow().getChildren().setAll(messages);
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/image/RawImageProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/image/RawImageProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -87,6 +87,7 @@ public class RawImageProvider implements PlotXYZDataProvider {
   // output
   private IonTimeSeries<Scan> series;
   private double finishedPercentage;
+  private boolean isComputed;
 
   public RawImageProvider(ImagingRawDataFile raw, ParameterSet parameters) {
     this.raw = raw;
@@ -199,6 +200,16 @@ public class RawImageProvider implements PlotXYZDataProvider {
         ImagingPlot.DEFAULT_IMAGING_QUANTILES);
     paintScale = MZmineCore.getConfiguration().getDefaultPaintScalePalette()
         .toPaintScale(transformation, Range.closed(quantiles[0], quantiles[1]));
+
+    isComputed = true;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  @Override
+  public boolean isComputed() {
+    return isComputed;
   }
 
   @NotNull

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/msms/MsMsDataProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/msms/MsMsDataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -34,6 +34,7 @@ import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.datamodel.Scan;
 import io.github.mzmine.gui.chartbasics.simplechart.providers.PlotXYZDataProvider;
 import io.github.mzmine.javafx.concurrent.threading.FxThread;
+import io.github.mzmine.javafx.util.FxColorUtil;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.ComboFieldParameter;
@@ -44,7 +45,6 @@ import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.RangeUtils;
 import io.github.mzmine.util.collections.BinarySearch.DefaultTo;
-import io.github.mzmine.javafx.util.FxColorUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -87,6 +87,7 @@ public class MsMsDataProvider implements PlotXYZDataProvider {
   private double maxProductIntensity = 0;
   private double maxPrecursorIntensity = 0;
   private float maxRt = 0;
+  private boolean isComputed;
 
   public MsMsDataProvider(ParameterSet parameters) {
 
@@ -127,7 +128,7 @@ public class MsMsDataProvider implements PlotXYZDataProvider {
           if (intensityFilterType == IntensityFilteringType.NUM_OF_BEST_FRAGMENTS) {
             intensityFilterValue = Integer.parseInt(intensityFilter);
           } else if (intensityFilterType == IntensityFilteringType.BASE_PEAK_PERCENT
-                     || intensityFilterType == IntensityFilteringType.INTENSITY_THRESHOLD) {
+              || intensityFilterType == IntensityFilteringType.INTENSITY_THRESHOLD) {
             intensityFilterValue = Double.parseDouble(intensityFilter);
           }
         }
@@ -135,9 +136,8 @@ public class MsMsDataProvider implements PlotXYZDataProvider {
         Alert alert = new Alert(AlertType.ERROR);
         alert.setTitle("Invalid intensity filtering value level");
         alert.setHeaderText("Intensity filtering value must be a double number for \""
-                            + IntensityFilteringType.BASE_PEAK_PERCENT
-                            + "\" option and an integer number for \""
-                            + IntensityFilteringType.NUM_OF_BEST_FRAGMENTS + "\" option");
+            + IntensityFilteringType.BASE_PEAK_PERCENT + "\" option and an integer number for \""
+            + IntensityFilteringType.NUM_OF_BEST_FRAGMENTS + "\" option");
         alert.showAndWait();
       }
     }
@@ -203,9 +203,8 @@ public class MsMsDataProvider implements PlotXYZDataProvider {
           Alert alert = new Alert(AlertType.ERROR);
           alert.setTitle("Mass detection issue");
           alert.setHeaderText("Masses are not detected properly for the " + dataFile.getName()
-                              + " data file. Scan #" + scan.getScanNumber()
-                              + " has no mass list. Run"
-                              + " \"Raw data methods\" -> \"Mass detection\", if you haven't done it yet. Scans are marked as profile mode.");
+              + " data file. Scan #" + scan.getScanNumber() + " has no mass list. Run"
+              + " \"Raw data methods\" -> \"Mass detection\", if you haven't done it yet. Scans are marked as profile mode.");
           alert.showAndWait();
         });
         return;
@@ -351,7 +350,7 @@ public class MsMsDataProvider implements PlotXYZDataProvider {
         Alert alert = new Alert(AlertType.WARNING);
         alert.setTitle("Suspicious module parameters");
         alert.setHeaderText("There are no data points in " + dataFile.getName()
-                            + " data file, satisfying module parameters");
+            + " data file, satisfying module parameters");
         alert.showAndWait();
       });
       return;
@@ -360,6 +359,14 @@ public class MsMsDataProvider implements PlotXYZDataProvider {
     // Scale max intensities
     maxProductIntensity = scaleProductIntensity(maxProductIntensity);
     maxPrecursorIntensity = scalePrecursorIntensity(maxPrecursorIntensity);
+    isComputed = true;
+  }
+
+  /**
+   * @return true if computed. Providers that are precomputed may use true always
+   */
+  public boolean isComputed() {
+    return isComputed;
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/spectra/msn_tree/MSnTreeTab.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/spectra/msn_tree/MSnTreeTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -461,8 +461,8 @@ public class MSnTreeTab extends SimpleTab {
 
     // update chart
     for (var spectraPlot : spectraPlots) {
+      // triggers the chart update event internally
       spectraPlot.setNotifyChange(true);
-      spectraPlot.fireChangeEvent();
     }
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/util/MathUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/MathUtils.java
@@ -484,14 +484,14 @@ public class MathUtils {
   }
 
   public static Double requireNonNanElse(@Nullable Double possiblyNaN, @Nullable Double instead) {
-    if(possiblyNaN == null) {
+    if (possiblyNaN == null) {
       return null;
     }
     return Double.isNaN(possiblyNaN) ? instead : possiblyNaN;
   }
 
   public static Float requireNonNanElse(@Nullable Float possiblyNaN, @Nullable Float instead) {
-    if(possiblyNaN == null) {
+    if (possiblyNaN == null) {
       return null;
     }
     return Float.isNaN(possiblyNaN) ? instead : possiblyNaN;
@@ -504,5 +504,61 @@ public class MathUtils {
    */
   public static int capMaxInt(long value) {
     return value > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) value;
+  }
+
+  @Nullable
+  public static Float max(@Nullable Float a, @Nullable Float b) {
+    if (a == null && b == null) {
+      return null;
+    }
+    if (a == null) {
+      return b;
+    }
+    if (b == null) {
+      return a;
+    }
+    return Math.max(a, b);
+  }
+
+  @Nullable
+  public static Double max(@Nullable Double a, @Nullable Double b) {
+    if (a == null && b == null) {
+      return null;
+    }
+    if (a == null) {
+      return b;
+    }
+    if (b == null) {
+      return a;
+    }
+    return Math.max(a, b);
+  }
+
+  @Nullable
+  public static Float min(@Nullable Float a, @Nullable Float b) {
+    if (a == null && b == null) {
+      return null;
+    }
+    if (a == null) {
+      return b;
+    }
+    if (b == null) {
+      return a;
+    }
+    return Math.min(a, b);
+  }
+
+  @Nullable
+  public static Double min(@Nullable Double a, @Nullable Double b) {
+    if (a == null && b == null) {
+      return null;
+    }
+    if (a == null) {
+      return b;
+    }
+    if (b == null) {
+      return a;
+    }
+    return Math.min(a, b);
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/util/RangeUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/RangeUtils.java
@@ -448,4 +448,43 @@ public class RangeUtils {
       NumberFormat format) {
     return formatRange(range, format);
   }
+
+  @Nullable
+  public static <N extends Comparable> Range<N> span(@Nullable Range<N> a, @Nullable Range<N> b) {
+    if (a == null && b == null) {
+      return null;
+    }
+    if (a == null) {
+      return b;
+    }
+    if (b == null) {
+      return a;
+    }
+    return a.span(b);
+  }
+
+  public static Range<Float> multiplyGrow(Range<Float> range, float factor) {
+    final float length = rangeLength(range);
+    final float diff = (length * factor) - length;
+    return Range.closed(range.lowerEndpoint() - diff, range.upperEndpoint() + diff);
+  }
+
+  public static Range<Double> multiplyGrow(Range<Double> range, double factor) {
+    final double length = rangeLength(range);
+    final double diff = (length * factor) - length;
+    return Range.closed(range.lowerEndpoint() - diff, range.upperEndpoint() + diff);
+  }
+
+  /**
+   * @param range original range
+   * @param min   may be null to keep original
+   * @param max   may be null to keep original
+   * @return a closed range within min max bounds
+   */
+  public static <T extends Number & Comparable<T>> Range<T> withinBounds(@NotNull Range<T> range,
+      @Nullable T min, @Nullable T max) {
+    T lower = ArithmeticUtils.max(range.lowerEndpoint(), min);
+    T upper = ArithmeticUtils.min(range.upperEndpoint(), max);
+    return Range.closed(lower, upper);
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/util/maths/ArithmeticUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/maths/ArithmeticUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -26,6 +26,7 @@
 package io.github.mzmine.util.maths;
 
 import java.util.function.BinaryOperator;
+import org.jetbrains.annotations.Nullable;
 
 public class ArithmeticUtils {
 
@@ -130,5 +131,25 @@ public class ArithmeticUtils {
     } else {
       throw new IllegalArgumentException("Illegal operands types.");
     }
+  }
+
+  public static <T extends Number & Comparable<T>> T max(@Nullable T a, @Nullable T b) {
+    if (a == null) {
+      return b;
+    }
+    if (b == null) {
+      return a;
+    }
+    return a.compareTo(b) >= 0 ? a : b;
+  }
+
+  public static <T extends Number & Comparable<T>> T min(@Nullable T a, @Nullable T b) {
+    if (a == null) {
+      return b;
+    }
+    if (b == null) {
+      return a;
+    }
+    return a.compareTo(b) < 0 ? a : b;
   }
 }


### PR DESCRIPTION
- used caching of whole nodes before
- datasets were and are backed by memory mapped data, no calculation needed
- therefore changed to a cell factory and cell class that precreates a chart instance with correct size (fixes the width issue) 
- datasets are set by datasets.setAll
- I tested and optimized to a single draw call

The first cell with index 0 is used for measuring size (as far as I know). And there are many updateItem calls on this cell. I skipped all as the content does not change the size of the cell - the chart defines that already.  