### PR TITLE
Fix npe when using StringConverter and unmodifiable list in ComboBox

### DIFF
--- a/javafx-framework/src/main/java/io/github/mzmine/javafx/components/factories/FxComboBox.java
+++ b/javafx-framework/src/main/java/io/github/mzmine/javafx/components/factories/FxComboBox.java
@@ -66,10 +66,10 @@ public class FxComboBox {
       @Nullable final Property<T> selectedItem, final COMBO combo) {
     if (values instanceof ObservableList<T> ov) {
       combo.setItems(ov);
-    } else if (values instanceof List<T> list) {
-      combo.setItems(FXCollections.observableList(list));
     } else if (values != null) {
-      combo.setItems(FXCollections.observableList(List.copyOf(values)));
+      // needs to be modifiable just in case because StringConverter may return null that is not allowed
+      // null throws many cryptic exceptions otherwise
+      combo.setItems(FXCollections.observableArrayList(values));
     }
     if (selectedItem != null) {
       combo.valueProperty().bindBidirectional(selectedItem);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilogram_summing/MobilogramBinningSetupDialog.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_mobilogram_summing/MobilogramBinningSetupDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -94,7 +94,8 @@ public class MobilogramBinningSetupDialog extends ParameterSetupDialogWithPrevie
             fBox.setItems(FXCollections.observableArrayList(
                 newValue.getFeatures(newValue.getRawDataFile(0))));
           } else {
-            fBox.setItems(FXCollections.emptyObservableList());
+            // needs to be modifiable list when using string converter
+            fBox.setItems(FXCollections.observableArrayList());
           }
         }));
 
@@ -147,15 +148,15 @@ public class MobilogramBinningSetupDialog extends ParameterSetupDialogWithPrevie
             FeatureUtils.featureToString(f))));
 
     final Integer binWidth = switch (((IMSRawDataFile) f.getRawDataFile()).getMobilityType()) {
-      case TIMS -> parameterSet.getParameter(MobilogramBinningParameters.timsBinningWidth)
-          .getValue();
-      case TRAVELING_WAVE -> parameterSet.getParameter(
-          MobilogramBinningParameters.twimsBinningWidth).getValue();
-      case DRIFT_TUBE -> parameterSet.getParameter(MobilogramBinningParameters.dtimsBinningWidth)
-          .getValue();
+      case TIMS ->
+          parameterSet.getParameter(MobilogramBinningParameters.timsBinningWidth).getValue();
+      case TRAVELING_WAVE ->
+          parameterSet.getParameter(MobilogramBinningParameters.twimsBinningWidth).getValue();
+      case DRIFT_TUBE ->
+          parameterSet.getParameter(MobilogramBinningParameters.dtimsBinningWidth).getValue();
       default -> throw new UnsupportedOperationException(
           "Summing of the mobility type in raw data file " + f.getRawDataFile().getName()
-          + " is unsupported.");
+              + " is unsupported.");
     };
     if (binWidth == null || binWidth == 0) {
       return;
@@ -169,7 +170,7 @@ public class MobilogramBinningSetupDialog extends ParameterSetupDialogWithPrevie
           binWidth);
       lbkApproxBinSize.setText(
           mobilityFormat.format(summedMobilogramAccess.getApproximateBinSize()) + " "
-          + summedMobilogramAccess.getDataFile().getMobilityType().getUnit());
+              + summedMobilogramAccess.getDataFile().getMobilityType().getUnit());
     }
 
     summedMobilogramAccess.setMobilogram(series.getSummedMobilogram());

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/SmoothingSetupDialog.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_smoothing/SmoothingSetupDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -94,7 +94,8 @@ public class SmoothingSetupDialog extends ParameterSetupDialogWithPreview {
             fBox.setItems(FXCollections.observableArrayList(
                 newValue.getFeatures(newValue.getRawDataFile(0))));
           } else {
-            fBox.setItems(FXCollections.emptyObservableList());
+            // needs to be modifiable when using stringconverter
+            fBox.setItems(FXCollections.observableArrayList());
           }
         }));
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/ims_mobilitymzplot/SingleIMSFeatureVisualiserPane.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/ims_mobilitymzplot/SingleIMSFeatureVisualiserPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -205,8 +205,9 @@ public class SingleIMSFeatureVisualiserPane extends GridPane {
 //    add(new BorderPane(legendCanvas), 1, 1);
 
     ComboBox<Scan> fragmentScanSelection = new ComboBox<>();
-    fragmentScanSelection.setItems(FXCollections.observableList(feature.getAllMS2FragmentScans()));
-    if (feature.getAllMS2FragmentScans() != null && feature.getMostIntenseFragmentScan() != null) {
+    fragmentScanSelection.setItems(
+        FXCollections.observableArrayList(feature.getAllMS2FragmentScans()));
+    if (feature.getMostIntenseFragmentScan() != null) {
       fragmentScanSelection.setValue(feature.getMostIntenseFragmentScan());
     }
     fragmentScanSelection.valueProperty().addListener((observable, oldValue, newValue) -> {


### PR DESCRIPTION
StringConverter on a combobox may return null and that is not allowed in Unmodifiable list. 

For example can be triggered in IMS mobility mz plot when selecting feature without MS2.

<img width="2191" height="1599" alt="image" src="https://github.com/user-attachments/assets/cebeb245-ee19-496a-ba72-6a08f9da02a2" />
