### PR TITLE
Copy files from FileNameParameter into mzmine project

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectload/RawDataFileOpenHandler.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectload/RawDataFileOpenHandler.java
@@ -25,6 +25,7 @@
 
 package io.github.mzmine.modules.io.projectload;
 
+import com.vdurmont.semver4j.Semver;
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.modules.io.projectload.version_3_0.RawDataFileOpenHandler_3_0;
 import io.github.mzmine.taskcontrol.Task;
@@ -35,7 +36,7 @@ import org.jetbrains.annotations.NotNull;
 
 public interface RawDataFileOpenHandler extends Task {
 
-  public static RawDataFileOpenHandler forVersion(String versionString, @NotNull Instant moduleCallDate) {
+  public static RawDataFileOpenHandler forVersion(Semver versionString, @NotNull Instant moduleCallDate) {
     return new RawDataFileOpenHandler_3_0(moduleCallDate);
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectload/version_3_0/RawDataFileOpenHandler_3_0.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectload/version_3_0/RawDataFileOpenHandler_3_0.java
@@ -26,6 +26,7 @@
 package io.github.mzmine.modules.io.projectload.version_3_0;
 
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.main.ConfigService;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.modules.MZmineProcessingStep;
@@ -36,6 +37,8 @@ import io.github.mzmine.modules.io.projectload.RawDataFileOpenHandler;
 import io.github.mzmine.modules.io.projectsave.RawDataFileSaveHandler;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.parametertypes.OptionalParameter;
+import io.github.mzmine.parameters.parametertypes.filenames.FileNameParameter;
 import io.github.mzmine.parameters.parametertypes.filenames.FileNamesParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilePlaceholder;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
@@ -148,7 +151,7 @@ public class RawDataFileOpenHandler_3_0 extends AbstractTask implements RawDataF
       final XPath xpath = factory.newXPath();
 
       final XPathExpression expr = xpath.compile("//" + RawDataFileSaveHandler.ROOT_ELEMENT + "/"
-                                                 + RawDataFileSaveHandler.BATCH_QUEUES_ROOT);
+          + RawDataFileSaveHandler.BATCH_QUEUES_ROOT);
 
       final NodeList nodes = (NodeList) expr.evaluate(batchQueuesDocument, XPathConstants.NODESET);
       if (nodes.getLength() != 1) {
@@ -195,8 +198,7 @@ public class RawDataFileOpenHandler_3_0 extends AbstractTask implements RawDataF
   @Override
   public String getTaskDescription() {
     return "Importing raw data files from project. Processing import batch step " + (processedSteps
-                                                                                     + 1) + "/"
-           + numSteps + ".";
+        + 1) + "/" + numSteps + ".";
   }
 
   @Override
@@ -216,7 +218,7 @@ public class RawDataFileOpenHandler_3_0 extends AbstractTask implements RawDataF
       Path tempDir = FileAndPathUtil.createTempDirectory(TEMP_RAW_DATA_FOLDER);
 
       for (BatchQueue batchQueue : batchQueues) {
-        final ParameterSet param = MZmineCore.getConfiguration()
+        final ParameterSet param = ConfigService.getConfiguration()
             .getModuleParameters(BatchModeModule.class).cloneParameterSet();
 
         resolvePathsUnpackFiles(batchQueue, tempDir);
@@ -319,6 +321,35 @@ public class RawDataFileOpenHandler_3_0 extends AbstractTask implements RawDataF
               }
             }
             rfp.getValue().setSpecificFiles(newPlaceholders);
+          }
+        } else if ((parameter instanceof FileNameParameter fnp && fnp.getValue() != null) || (
+            parameter instanceof OptionalParameter<?> op
+                && op.getEmbeddedParameter() instanceof FileNameParameter && op.isSelected())) {
+          // eg like metadata
+          final FileNameParameter fnp = switch (parameter) {
+            case FileNameParameter p -> p;
+            case OptionalParameter<?> p -> ((FileNameParameter) p.getEmbeddedParameter());
+            default -> null;
+          };
+          if (fnp == null) {
+            continue;
+          }
+          final File file = fnp.getValue();
+          // check if the file was actually saved in the project
+          final Matcher matcher = RawDataFileSaveHandler.DATA_FILE_PATTERN.matcher(
+              file.getPath());
+          if (matcher.matches()) {
+            String fileInZip = matcher.group(2);
+            ZipUtils.unzipDirectory(fileInZip.replaceAll("\\\\", "/"), zipFile,
+                tempDir.toFile()); // always "/" in zips
+            fileInZip = fileInZip.replace("\\", separator); // appropriate separator afterwards
+
+            final File unzipped = new File(tempDir.toFile(), fileInZip);
+            if (!unzipped.exists()) {
+              throw new IllegalStateException("Expected file " + file.getName()
+                  + " to be included in the project, but file was not found.");
+            }
+            fnp.setValue(unzipped);
           }
         }
       }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectsave/RawDataSavingUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectsave/RawDataSavingUtils.java
@@ -36,6 +36,7 @@ import io.github.mzmine.modules.impl.MZmineProcessingStepImpl;
 import io.github.mzmine.parameters.Parameter;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.ParameterUtils;
+import io.github.mzmine.parameters.parametertypes.filenames.FileNameParameter;
 import io.github.mzmine.parameters.parametertypes.filenames.FileNamesParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilePlaceholder;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
@@ -206,7 +207,9 @@ public class RawDataSavingUtils {
       MZmineProcessingModule module) {
 
     if (!ParameterUtils.equalValues(parameterSet1, parameterSet2, true, true)) {
-      throw new IllegalArgumentException("Parameter sets differ in more than raw/file parameters.");
+      throw new IllegalArgumentException(
+          "Parameter sets differ in more than raw/file parameters.\n1:\n%s\n2:\n%s".formatted(
+              parameterSet1.toString(), parameterSet2.toString()));
     }
 
     final var mergedParameterSet = parameterSet1.cloneParameterSet(true);

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/filenames/FileNameParameter.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/filenames/FileNameParameter.java
@@ -26,6 +26,7 @@
 package io.github.mzmine.parameters.parametertypes.filenames;
 
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.modules.io.projectsave.RawDataFileSaveHandler;
 import io.github.mzmine.parameters.UserParameter;
 import io.github.mzmine.project.ProjectService;
 import java.io.File;
@@ -235,13 +236,17 @@ public class FileNameParameter implements UserParameter<File, FileNameComponent>
 
     if (value != null) {
       Element paramElement = parentDocument.createElement(CURRENT_FILE_ELEMENT);
-      paramElement.setTextContent(value.getAbsolutePath());
-
-      final Path relativePath = project.getRelativePath(value.toPath());
-      if (relativePath != null) {
-        paramElement.setAttribute(FileNamesParameter.XML_RELATIVE_PATH_ATTRIBUTE,
-            relativePath.toString());
+      if(!value.getPath().contains(RawDataFileSaveHandler.DATA_FILES_PREFIX)) {
+        paramElement.setTextContent(value.getAbsolutePath());
+        final Path relativePath = project.getRelativePath(value.toPath());
+        if (relativePath != null) {
+          paramElement.setAttribute(FileNamesParameter.XML_RELATIVE_PATH_ATTRIBUTE,
+              relativePath.toString());
+        }
+      } else {
+        paramElement.setTextContent(value.getPath());
       }
+
       xmlElement.appendChild(paramElement);
     }
 


### PR DESCRIPTION
Copies files from a FileNameParameter (and Optional file name parameters) into the mzmine project when "Standalone" is used. This fixes an issue where standalone projects cannot be opened due to missing metadata files.

#2851 (partial fix)
fixes future occurrences of #2712