### PR TITLE
csvdb: fix compound not loaded on case mismatch

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/ImportType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/ImportType.java
@@ -170,7 +170,7 @@ public class ImportType<T> {
   }
 
   public T apply(Map<DataType<?>, @Nullable String> csvValues) {
-    final String s = csvValues.get(dataType);
+    final String s = csvValues.get(dataType.get());
     return apply(s);
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/util/CSVParsingUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/CSVParsingUtils.java
@@ -164,6 +164,7 @@ public class CSVParsingUtils {
                 () -> "Library file contains two columns called \"" + columnName + "\".");
           }
           importType.setColumnIndex(i);
+          importType.setCsvColumnName(columnName); // need to set to the specific upper/lower case for getCompoundFromLine
         }
       }
     }
@@ -490,7 +491,7 @@ public class CSVParsingUtils {
       @NotNull String[] values, @NotNull List<ImportType<?>> linesWithIndices,
       @NotNull final ExtraColumnHandler extraColumnHandler) {
 
-    final Map<@NotNull String, @Nullable String> data = new HashMap<>(csvHeaders.length, 1f);
+    final Map<@NotNull String, @Nullable String> data = HashMap.newHashMap(csvHeaders.length);
     for (int i = 0; i < csvHeaders.length; i++) {
       data.put(csvHeaders[i], values[i]);
     }


### PR DESCRIPTION
recent refactoring caused csv database to be loaded incorrectly if there was a case mistmatch if what the header should be and what it was.

the stored header still matched due to equalsIgnoreCase, but was not updated and used as key in a hash map. now the key is updated to what is stored in the csv file.