### PR TITLE
MGF adduct parsing from name

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/GnpsMgfParser.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/GnpsMgfParser.java
@@ -215,8 +215,8 @@ public class GnpsMgfParser extends SpectralDBTextParser {
     }
 
     final String adductCandidate = name.substring(lastSpace + 1);
-    // uses matcher.find for substring match
-    // matcher.match requires full match
+    // uses the Pattern.asPredicate() that internally uses matcher.find for substring match
+    // matcher.match requires full match which does not work here
     if (!gnpsNameAdductPattern.test(adductCandidate)) {
       return;
     }


### PR DESCRIPTION
- matcher.match requires a full match
- matcher.find is ok with sub match
- M+H worked but `M-H2O+H` or `[M+H]+` did not work