### PR TITLE
dia: fix unnecessary interpolation

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/filter_diams2/DiaMs2CorrTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/filter_diams2/DiaMs2CorrTask.java
@@ -385,6 +385,7 @@ public class DiaMs2CorrTask extends AbstractTask {
     for (IonTimeSeries<?> ms2Eic : eligibleEics) {
       final IonTimeSeries<?> subSeries = ms2Eic.subSeries(getMemoryMapStorage(),
           correlationRange.lowerEndpoint(), correlationRange.upperEndpoint());
+
       if (subSeries.getNumberOfValues() < minCorrPoints) {
         continue;
       }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/group_metacorrelate/correlation/FeatureCorrelationUtil.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/group_metacorrelate/correlation/FeatureCorrelationUtil.java
@@ -614,7 +614,8 @@ public class FeatureCorrelationUtil {
       }
 
       // looks like we have exactly the same values, then we do not need to interpolate
-      if(mainX.length == otherX.length && mainRange.equals(otherRange) && Arrays.equals(mainX, otherX)) {
+      if (mainX.length == otherX.length && mainRange.equals(otherRange) && Arrays.equals(mainX,
+          otherX)) {
         return new double[][]{otherX, otherY};
       }
 
@@ -628,6 +629,13 @@ public class FeatureCorrelationUtil {
       final int mainEnd = mainIndicesEndExclusive[1];
       final int otherStart = otherIndicesEndExclusive[0];
       final int otherEnd = otherIndicesEndExclusive[1];
+
+      final int minLength = Math.min(mainEnd - mainStart, otherEnd - otherStart);
+      if (mainX.length != otherX.length && Arrays.equals(mainX, mainStart, mainStart + minLength,
+          otherX, otherStart, otherStart + minLength)) {
+        // may be exactly the same x values, but range lengths may be different
+        return new double[][]{otherX, otherY};
+      }
 
       // create array for the interpolated data
       // copy the x values of both arrays to the new array


### PR DESCRIPTION
fix unnecessary interpolation for same x axis but different length during correlation

previously we only checked if the x values of both traces were 100% identical, but they may have different lengths. that would lead to an unnecessary interpolation. 
this also checks if only the overlap region is identical

- [x] integration tests done