### PR TITLE
Component wrapper layout

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/ComponentWrapperParameterComponent.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/ComponentWrapperParameterComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -29,10 +29,7 @@ import io.github.mzmine.parameters.UserParameter;
 import java.util.function.Supplier;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
-import javafx.scene.control.CheckBox;
-import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
 import org.jetbrains.annotations.NotNull;
 
 public class ComponentWrapperParameterComponent<EmbeddedComponent extends Node> extends HBox {
@@ -48,7 +45,9 @@ public class ComponentWrapperParameterComponent<EmbeddedComponent extends Node> 
     getChildren().add(embeddedComponent);
     getChildren().add(nodeSupplier.get());
     setAlignment(Pos.CENTER_LEFT);
-    HBox.setHgrow(embeddedComponent, Priority.ALWAYS);
+    // growing set to SOMETIMES or ALWAYS broke the layout combined with embedded OptionalModuleComponent
+    // the wrapper node was then pushed to the side
+//    HBox.setHgrow(embeddedComponent, Priority.NEVER);
   }
 
   public EmbeddedComponent getEmbeddedComponent() {

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/submodules/OptionalModuleComponent.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/parametertypes/submodules/OptionalModuleComponent.java
@@ -25,6 +25,7 @@
 
 package io.github.mzmine.parameters.parametertypes.submodules;
 
+import io.github.mzmine.javafx.components.util.FxLayout;
 import io.github.mzmine.parameters.EmbeddedParameterComponentProvider;
 import io.github.mzmine.parameters.EstimatedComponentHeightProvider;
 import io.github.mzmine.parameters.EstimatedComponentWidthProvider;
@@ -35,12 +36,13 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
+import javafx.geometry.Insets;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.BorderPane;
-import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -57,7 +59,7 @@ public class OptionalModuleComponent extends BorderPane implements EstimatedComp
   private final BooleanProperty hidden = new SimpleBooleanProperty(true);
   private final DoubleProperty estimatedHeightProperty = new SimpleDoubleProperty(0);
   private final DoubleProperty estimatedWidthProperty = new SimpleDoubleProperty(0);
-  protected final FlowPane topPane;
+  protected final HBox topPane;
   private final ParameterSet embeddedParameters;
 
 
@@ -111,15 +113,12 @@ public class OptionalModuleComponent extends BorderPane implements EstimatedComp
         onViewStateChange(hidden);
       });
     }
-    topPane = new FlowPane();
-    topPane.setHgap(5d);
-    topPane.setVgap(5d);
-
     // just leave out checkbox if always active
     if (alwaysActive) {
-      topPane.getChildren().addAll(setButton);
+      // use HBox, FlowPane by default grew and had bad layout in combination with ComponentWrapperParameterComponent
+      topPane = FxLayout.newHBox(Insets.EMPTY, setButton);
     } else {
-      topPane.getChildren().addAll(checkBox, setButton);
+      topPane = FxLayout.newHBox(Insets.EMPTY, checkBox, setButton);
     }
 
     setTop(topPane);


### PR DESCRIPTION
In #3013 the layout of the component wrapper param is pushing the button to the side. 

The issue was the flow pane in OptionalModuleComponent always growing. And also the wrapper demanding a grow. 

## Before:

<img width="1011" height="102" alt="image" src="https://github.com/user-attachments/assets/2419f3f3-4e7c-4197-a307-ed3c8bf4325c" />

## After:
<img width="881" height="221" alt="image" src="https://github.com/user-attachments/assets/b7a585b5-405d-4562-b929-ce85701356af" />

<img width="1466" height="285" alt="image" src="https://github.com/user-attachments/assets/023b8656-73d9-41cb-bd23-e72614a501c1" />
