### PR TITLE
wizard: set gnps csv export type

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/BaseWizardBatchBuilder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/BaseWizardBatchBuilder.java
@@ -12,7 +12,6 @@
  *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -124,6 +123,7 @@ import io.github.mzmine.modules.io.export_features_all_speclib_matches.ExportAll
 import io.github.mzmine.modules.io.export_features_csv.CSVExportModularModule;
 import io.github.mzmine.modules.io.export_features_csv.CSVExportModularParameters;
 import io.github.mzmine.modules.io.export_features_gnps.fbmn.FeatureListRowsFilter;
+import io.github.mzmine.modules.io.export_features_gnps.fbmn.FeatureTableExportType;
 import io.github.mzmine.modules.io.export_features_gnps.fbmn.GnpsFbmnExportAndSubmitModule;
 import io.github.mzmine.modules.io.export_features_gnps.fbmn.GnpsFbmnExportAndSubmitParameters;
 import io.github.mzmine.modules.io.export_features_sirius.SiriusExportModule;
@@ -489,24 +489,11 @@ public abstract class BaseWizardBatchBuilder extends WizardBatchBuilder {
 
   protected static void makeAndAddIimnGnpsExportStep(final BatchQueue q, final File exportPath,
       final MZTolerance mzTolScans, final String fileNameSuffix) {
-    final ParameterSet param = new GnpsFbmnExportAndSubmitParameters().cloneParameterSet();
 
-    File fileName = FileAndPathUtil.eraseFormat(exportPath);
-    fileName = new File(fileName.getParentFile(), fileName.getName() + fileNameSuffix);
-
-    param.setParameter(GnpsFbmnExportAndSubmitParameters.FEATURE_LISTS,
-        new FeatureListsSelection(FeatureListsSelectionType.BATCH_LAST_FEATURELISTS));
-    param.getParameter(GnpsFbmnExportAndSubmitParameters.spectraMergeSelect)
-        .setSimplePreset(SpectraMergeSelectPresets.SINGLE_MERGED_SCAN, mzTolScans);
-
-    param.setParameter(GnpsFbmnExportAndSubmitParameters.NORMALIZER,
-        IntensityNormalizer.createDefault());
-    param.setParameter(GnpsFbmnExportAndSubmitParameters.SUBMIT, false);
-    param.setParameter(GnpsFbmnExportAndSubmitParameters.OPEN_FOLDER, false);
-    param.setParameter(GnpsFbmnExportAndSubmitParameters.FEATURE_INTENSITY, AbundanceMeasure.Area);
-    param.setParameter(GnpsFbmnExportAndSubmitParameters.FILENAME, fileName);
-    param.setParameter(GnpsFbmnExportAndSubmitParameters.FILTER,
-        FeatureListRowsFilter.MS2_OR_ION_IDENTITY);
+    final ParameterSet param = GnpsFbmnExportAndSubmitParameters.create(exportPath, fileNameSuffix,
+        mzTolScans, new FeatureListsSelection(FeatureListsSelectionType.BATCH_LAST_FEATURELISTS),
+        false, FeatureListRowsFilter.MS2_OR_ION_IDENTITY, false,
+        IntensityNormalizer.createDefault(), FeatureTableExportType.SIMPLE, AbundanceMeasure.Area);
 
     q.add(new MZmineProcessingStepImpl<>(
         MZmineCore.getModuleInstance(GnpsFbmnExportAndSubmitModule.class), param));

--- a/mzmine-community/src/main/resources/dependency/dependency-licenses.json
+++ b/mzmine-community/src/main/resources/dependency/dependency-licenses.json
@@ -34,6 +34,10 @@
             ],
             "moduleLicenses": [
                 {
+                    "moduleLicense": "GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1",
+                    "moduleLicenseUrl": "https://www.gnu.org/licenses/lgpl-2.1"
+                },
+                {
                     "moduleLicense": "GNU LESSER GENERAL PUBLIC LICENSE, Version 3",
                     "moduleLicenseUrl": "https://www.gnu.org/licenses/lgpl-3.0"
                 }
@@ -70,6 +74,19 @@
                 {
                     "moduleLicense": "GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1",
                     "moduleLicenseUrl": "https://www.gnu.org/licenses/lgpl-2.1"
+                }
+            ]
+        },
+        {
+            "moduleName": "com.adobe.xmp:xmpcore",
+            "moduleVersion": "6.1.11",
+            "moduleUrls": [
+                "https://www.adobe.com/devnet/xmp/library/eula-xmp-library-java.html"
+            ],
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "The 3-Clause BSD License",
+                    "moduleLicenseUrl": "https://opensource.org/licenses/BSD-3-Clause"
                 }
             ]
         },
@@ -1776,6 +1793,32 @@
             ]
         },
         {
+            "moduleName": "net.sf.jasperreports:jasperreports",
+            "moduleVersion": "7.0.3",
+            "moduleUrls": [
+                "http://jasperreports.sourceforge.net"
+            ],
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1",
+                    "moduleLicenseUrl": "https://www.gnu.org/licenses/lgpl-2.1"
+                }
+            ]
+        },
+        {
+            "moduleName": "net.sf.jasperreports:jasperreports-pdf",
+            "moduleVersion": "7.0.3",
+            "moduleUrls": [
+                "http://jasperreports.sourceforge.net"
+            ],
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1",
+                    "moduleLicenseUrl": "https://www.gnu.org/licenses/lgpl-2.1"
+                }
+            ]
+        },
+        {
             "moduleName": "net.sf.py4j:py4j",
             "moduleVersion": "0.8.1",
             "moduleUrls": [
@@ -2068,6 +2111,156 @@
         {
             "moduleName": "org.apache.xmlgraphics:batik-all",
             "moduleVersion": "1.19",
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
+            "moduleName": "org.apache.xmlgraphics:batik-anim",
+            "moduleVersion": "1.18",
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
+            "moduleName": "org.apache.xmlgraphics:batik-awt-util",
+            "moduleVersion": "1.18",
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
+            "moduleName": "org.apache.xmlgraphics:batik-bridge",
+            "moduleVersion": "1.18",
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
+            "moduleName": "org.apache.xmlgraphics:batik-constants",
+            "moduleVersion": "1.18",
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
+            "moduleName": "org.apache.xmlgraphics:batik-css",
+            "moduleVersion": "1.18",
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
+            "moduleName": "org.apache.xmlgraphics:batik-dom",
+            "moduleVersion": "1.18",
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
+            "moduleName": "org.apache.xmlgraphics:batik-ext",
+            "moduleVersion": "1.18",
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
+            "moduleName": "org.apache.xmlgraphics:batik-gvt",
+            "moduleVersion": "1.18",
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
+            "moduleName": "org.apache.xmlgraphics:batik-i18n",
+            "moduleVersion": "1.18",
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
+            "moduleName": "org.apache.xmlgraphics:batik-parser",
+            "moduleVersion": "1.18",
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
+            "moduleName": "org.apache.xmlgraphics:batik-script",
+            "moduleVersion": "1.18",
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
+            "moduleName": "org.apache.xmlgraphics:batik-shared-resources",
+            "moduleVersion": "1.18",
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
+            "moduleName": "org.apache.xmlgraphics:batik-svg-dom",
+            "moduleVersion": "1.18",
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
+            "moduleName": "org.apache.xmlgraphics:batik-util",
+            "moduleVersion": "1.18",
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
+            "moduleName": "org.apache.xmlgraphics:batik-xml",
+            "moduleVersion": "1.18",
             "moduleLicenses": [
                 {
                     "moduleLicense": "Apache License, Version 2.0",


### PR DESCRIPTION
Addresses #3022

The csv export type was not set in the wizard. If the user manually exports a comprehensive feature table, the simple file is not exported from the wizard. Since we have an extra step to export the full feature table, always use simple. 