### PR TITLE
tdf: more descriptive error messages

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFImportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFImportTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2025 The mzmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -12,6 +12,7 @@
  *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -339,7 +340,7 @@ public class TDFImportTask extends AbstractTask implements RawDataImportTask {
       assignTimsAutoMsMsInfo(newMZmineFile, frameTable, frameMsMsInfoTable);
 
     } catch (RuntimeException e) {
-      error("Error importing file %s".formatted(fileNameToOpen.getName()), e);
+      error("Error importing file %s. %s".formatted(fileNameToOpen.getName(), e.getMessage()), e);
     }
 
     if (isCanceled()) {


### PR DESCRIPTION
An issue was found where the tdf lib expects a utf8 string, but java strings are always utf16. If there is a non utf8 character, opening the file fails.