### PR TITLE
Fix MiniTaskView label update

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/tasksview/MiniTaskView.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/tasksview/MiniTaskView.java
@@ -61,9 +61,13 @@ public class MiniTaskView extends FxViewBuilder<TasksViewModel> {
   }
 
   private LabeledProgressBar createTaskPane() {
+    // Important: bind to task list size too, otherwise the label can stay at "0 tasks" until the
+    // first progress update changes allTasksProgressProperty().
+    final var sizeBinding = Bindings.size(model.getTasks());
     return new LabeledProgressBar( //
         model.allTasksProgressProperty(),
-        Bindings.createStringBinding(this::computeTasksText, model.allTasksProgressProperty()));
+        Bindings.createStringBinding(this::computeTasksText, model.allTasksProgressProperty(),
+            sizeBinding));
   }
 
   private LabeledProgressBar createBatchPane() {


### PR DESCRIPTION
The task count label was not updating correctly when tasks were added or removed until the next progress update. Binding it to the task list size ensures immediate updates.