### PR TITLE
Fix load of TDF with special chars in file path

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/TDFUtils.java
@@ -26,6 +26,7 @@
 package io.github.mzmine.modules.io.import_rawdata_bruker_tdf;
 
 import com.google.common.collect.Range;
+import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import io.github.mzmine.datamodel.IMSRawDataFile;
@@ -63,10 +64,14 @@ import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -224,7 +229,10 @@ public class TDFUtils implements AutoCloseable {
     logger.finest(() -> "Opening tdf file " + path.getAbsolutePath());
     final String dirToOpen =
         path.isFile() ? path.getParentFile().getAbsolutePath() : path.getAbsolutePath();
-    handle = tdfLib.tims_open_v2(dirToOpen, useRecalibratedState, pressureCompensation);
+
+    // UTF8 required to load files from paths with special chars like ü
+    final byte[] fileBytes = Native.toByteArray(dirToOpen, StandardCharsets.UTF_8);
+    handle = tdfLib.tims_open_v2(fileBytes, useRecalibratedState, pressureCompensation);
 
     if (handle == 0) {
       printLastError(0).throwOnError();

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/datamodel/TDFLibrary.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_bruker_tdf/datamodel/TDFLibrary.java
@@ -74,7 +74,7 @@ public interface TDFLibrary extends Library {
    * API calls, in particular to the required call to tims_close(). On failure, returns 0, and you
    * can use tims_get_last_error_string() to obtain a string describing the problem.
    */
-  long tims_open_v2(String analysis_dir, long use_recalib, int pressureCompensation);
+  long tims_open_v2(byte[] analysis_dir, long use_recalib, int pressureCompensation);
 
   /**
    * Close data set.


### PR DESCRIPTION
- Instead of String, pass UTF-8 bytes to JNA interface
- Fixes special chars like ü in file path