### PR TITLE
Export logging.properties to user/.mzmine

### DIFF
--- a/mzmine-community/src/main/resources/internal_logging.properties
+++ b/mzmine-community/src/main/resources/internal_logging.properties
@@ -1,0 +1,75 @@
+#
+# Copyright (c) 2004-2026 The mzmine Development Team
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Set the logging level for the root of the namespace.
+# This becomes the default logging level for all Loggers.
+# SEVERE (highest value)
+# WARNING
+# INFO
+# CONFIG
+# FINE
+# FINER
+# FINEST (lowest value)
+
+# Internal log config that overwrites properties defined in the public log
+
+# Mute messages about copying libraries
+io.github.msdk.id.sirius.NativeLibraryLoader.level = INFO
+# Mute messages from BasicJJob
+de.unijena.bioinf.jjobs.BasicJJob.level=INFO
+# Mute messages about failure of loading CPLEX & Gurobi
+de.unijena.bioinf.FragmentationTreeConstruction.computation.tree.TreeBuilderFactory.level = SEVERE
+
+# mute
+org.keycloak.level = FINEST
+org.apache.http.client.protocol.level = FINEST
+io.undertow.level = FINEST
+org.xnio.level = FINEST
+org.jboss.threads.level = FINEST
+
+# List of global handlers
+handlers = java.util.logging.ConsoleHandler,io.github.mzmine.util.logging.StatusBarHandler,java.util.logging.FileHandler
+
+# The name of files where the logs are written
+# "/" the local pathname separator
+# "%t" the system temporary directory
+# "%h" the value of the "user.home" system property
+# "%g" the generation number to distinguish rotated logs
+# "%u" a unique number to resolve conflicts
+# "%%" translates to a single percent sign "%"
+# this directory must exist before
+java.util.logging.FileHandler.pattern = %h/mzmine_%u_%g.log
+
+# The name of formatter used for output formatting
+java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter
+#java.util.logging.FileHandler.formatter = io.github.mzmine.util.logging.ConsoleFormatter
+# If this property is true, the output should be appended to already existing file
+java.util.logging.FileHandler.append=false
+# Default level for ConsoleHandler. This can be used to
+# limit the levels that are displayed on the console even
+# when the global default has been set to a trace level
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+#java.util.logging.ConsoleHandler.formatter = io.github.mzmine.util.logging.ConsoleFormatter
+java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$-6s %2$s %5$s%6$s%n

--- a/mzmine-community/src/main/resources/logging.properties
+++ b/mzmine-community/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2004-2022 The MZmine Development Team
+# Copyright (c) 2004-2026 The mzmine Development Team
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -33,28 +33,20 @@
 # FINER
 # FINEST (lowest value)
 
+# Can be edited by users for fine-grained control over logging
+# Just change the leves here for individual packages
 javax.level = INFO
 java.level = INFO
 sun.level = INFO
-io.github.mzmine.level = FINEST
-io.github.msdk.level = FINEST
+io.github.mzmine.level = FINE
+io.github.msdk.level = FINE
 
-# Mute messages about copying libraries
-io.github.msdk.id.sirius.NativeLibraryLoader.level = INFO
-# Mute messages from BasicJJob
-de.unijena.bioinf.jjobs.BasicJJob.level=INFO
-# Mute messages about failure of loading CPLEX & Gurobi
-de.unijena.bioinf.FragmentationTreeConstruction.computation.tree.TreeBuilderFactory.level = SEVERE
-
-# mute
-org.keycloak.level = SEVERE
-org.apache.http.client.protocol.level = SEVERE
-io.undertow.level = SEVERE
-org.xnio.level = SEVERE
-org.jboss.threads.level = SEVERE
-
-# List of global handlers
-handlers = java.util.logging.ConsoleHandler,io.github.mzmine.util.logging.StatusBarHandler,java.util.logging.FileHandler
+# or change the level logged to file or to console
+java.util.logging.FileHandler.level=FINE
+# Default level for ConsoleHandler. This can be used to
+# limit the levels that are displayed on the console even
+# when the global default has been set to a trace level
+java.util.logging.ConsoleHandler.level=FINE
 
 # Properties for the FileHandler
 # The maximum size of one log file in bytes
@@ -64,26 +56,3 @@ java.util.logging.FileHandler.limit = 1073741824
 # The number of output files to cycle
 java.util.logging.FileHandler.count = 0
 
-# The name of files where the logs are written
-# "/" the local pathname separator
-# "%t" the system temporary directory
-# "%h" the value of the "user.home" system property
-# "%g" the generation number to distinguish rotated logs
-# "%u" a unique number to resolve conflicts
-# "%%" translates to a single percent sign "%"
-# this directory must exist before
-java.util.logging.FileHandler.pattern = %h/mzmine_%u_%g.log
-
-# The name of formatter used for output formatting
-java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter
-#java.util.logging.FileHandler.formatter = io.github.mzmine.util.logging.ConsoleFormatter
-# If this property is true, the output should be appended to already existing file
-java.util.logging.FileHandler.append=false
-java.util.logging.FileHandler.level=FINEST
-# Default level for ConsoleHandler. This can be used to
-# limit the levels that are displayed on the console even
-# when the global default has been set to a trace level
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
-#java.util.logging.ConsoleHandler.formatter = io.github.mzmine.util.logging.ConsoleFormatter
-java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$-6s %2$s %5$s%6$s%n

--- a/utils/src/main/java/io/github/mzmine/util/files/FileAndPathUtil.java
+++ b/utils/src/main/java/io/github/mzmine/util/files/FileAndPathUtil.java
@@ -498,7 +498,7 @@ public class FileAndPathUtil {
     return new File(resolveInMzmineDir("external_resources"), name);
   }
 
-  @Nullable
+  @NotNull
   public static File resolveInMzmineDir(String name) {
     return new File(USER_MZMINE_DIR, name);
   }


### PR DESCRIPTION
- makes logging properties user facing to edit the log level that should be captured. 
- uses an internal logging file for the default configuration that overwrites some of the user facing ones

@SteffenHeu should we use FINE or FINER as the default log level? 
SO far it was FINEST
