### PR TITLE
[on master] Default sorting of columns in CSV export

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/DataTypes.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/DataTypes.java
@@ -77,6 +77,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -229,6 +230,18 @@ public class DataTypes {
       prioMap.put(DataTypes.get(aClass), i++);
     }
     return prioMap;
+  }
+
+  /**
+   * Default sorter is based on {@link DataType} order in {@link #getDataTypeOrderFeatureTable()}
+   * @return default sorter
+   */
+  @NotNull
+  public static Comparator<DataType> getDefaultSorterFeatureTable() {
+    final Map<DataType, Integer> order = DataTypes.getDataTypeOrderFeatureTable();
+
+    return Comparator.<DataType>comparingInt(
+        t -> order.getOrDefault(t, 99999999)).thenComparing(DataType::getUniqueID);
   }
 
   /**

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_csv/CSVExportModularTask.java
@@ -33,6 +33,7 @@ import io.github.mzmine.datamodel.features.ModularFeatureListRow;
 import io.github.mzmine.datamodel.features.SimpleFeatureListAppliedMethod;
 import io.github.mzmine.datamodel.features.compoundannotations.SimpleCompoundDBAnnotation;
 import io.github.mzmine.datamodel.features.types.DataType;
+import io.github.mzmine.datamodel.features.types.DataTypes;
 import io.github.mzmine.datamodel.features.types.LinkedGraphicalType;
 import io.github.mzmine.datamodel.features.types.modifiers.NoTextColumn;
 import io.github.mzmine.datamodel.features.types.modifiers.NullColumnType;
@@ -55,6 +56,7 @@ import java.text.MessageFormat;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.ConcurrentModificationException;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -230,12 +232,14 @@ public class CSVExportModularTask extends AbstractTask implements ProcessedItems
         .sorted(FeatureListRowSorter.DEFAULT_ID).toList();
     List<RawDataFile> rawDataFiles = flist.getRawDataFiles();
 
+    final Comparator<DataType> sorter = DataTypes.getDefaultSorterFeatureTable();
+
     List<DataType> rowTypes = flist.getRowTypes().stream().filter(this::filterType)
-        .filter(type -> !removeEmptyCols || typeContainData(type, rows, false, -1))
+        .filter(type -> !removeEmptyCols || typeContainData(type, rows, false, -1)).sorted(sorter)
         .collect(Collectors.toList());
 
     List<DataType> featureTypes = flist.getFeatureTypes().stream().filter(this::filterType)
-        .filter(type -> !removeEmptyCols || typeContainData(type, rows, true, -1))
+        .filter(type -> !removeEmptyCols || typeContainData(type, rows, true, -1)).sorted(sorter)
         .collect(Collectors.toList());
 
     final Map<DataType, List<DataType>> rowsSubTypesIndex = indexSubTypes(rowTypes, rows);


### PR DESCRIPTION
CSV export columns were unsorted
Now uses order from table

Example file (also with the new preferred annotation that is not in this PR)
[testcsv7.csv](https://github.com/user-attachments/files/24826975/testcsv7.csv)
