### PR TITLE
Merge contrast style for text and label into single class

### DIFF
--- a/javafx-framework/src/main/java/io/github/mzmine/javafx/components/factories/FxLabels.java
+++ b/javafx-framework/src/main/java/io/github/mzmine/javafx/components/factories/FxLabels.java
@@ -41,15 +41,18 @@ public class FxLabels {
 
   public enum Styles {
     REGULAR, BOLD_TITLE, BOLD_SEMI_TITLE, BOLD, ITALIC, // colored
-    WARNING, ERROR,
     /**
-     * Changes color of LABELS
+     * Changes color of LABELS to yellow
      */
-    CONTRAST_LABEL,
+    WARNING,
     /**
-     * Changes color of TEXT
+     * Changes color of LABELS to red/orange
      */
-    CONTRAST_TEXT;
+    ERROR,
+    /**
+     * Changes color of LABELS to magenta
+     */
+    CONTRAST_LABEL;
 
     public void addStyleClass(Node label) {
       var style = getStyleClass();
@@ -69,7 +72,6 @@ public class FxLabels {
         case BOLD -> "bold-label";
         case ITALIC -> "italic-label";
         case CONTRAST_LABEL -> "contrast-label";
-        case CONTRAST_TEXT -> "contrast-text";
       };
     }
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/dialogs/GroupedParameterSetupPane.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/dialogs/GroupedParameterSetupPane.java
@@ -275,11 +275,11 @@ public class GroupedParameterSetupPane extends BorderPane {
           selected.add(up);
           // make text clickable to auto filter
           final Text text = FxTexts.styledText(up.getName(), Styles.BOLD_SEMI_TITLE,
-              Styles.CONTRAST_TEXT);
+              Styles.CONTRAST_LABEL);
           text.getStyleClass().add("text-hover");
           text.setOnMouseClicked(_ -> setSearchFilter(up.getName()));
           if (selected.size() > 1) {
-            texts.add(FxTexts.styledText(", ", Styles.BOLD_SEMI_TITLE, Styles.CONTRAST_TEXT));
+            texts.add(FxTexts.styledText(", ", Styles.BOLD_SEMI_TITLE, Styles.CONTRAST_LABEL));
           }
           texts.add(text);
         }

--- a/mzmine-community/src/main/resources/themes/jabref_additions_common.css
+++ b/mzmine-community/src/main/resources/themes/jabref_additions_common.css
@@ -47,19 +47,19 @@ Text.error-label {
   -fx-icon-color: -warning-text-color;
 }
 
+Text.warning-label {
+  /* Text uses fill instead of text fill */
+  -fx-fill: -warning-text-color;
+}
+
 .contrast-label {
   -fx-text-fill: -contrast-text-color;
   -fx-icon-color: -contrast-text-color;
 }
 
-.contrast-text {
+Text.contrast-label {
   -fx-fill: -contrast-text-color;
   -fx-icon-color: -contrast-text-color;
-}
-
-Text.warning-label {
-  /* Text uses fill instead of text fill */
-  -fx-fill: -warning-text-color;
 }
 
 /* Option to set all Text children in TextFlow to yellow */


### PR DESCRIPTION
#3106 introduced contrast style class

this PR only merges the contrast style into single style class like warning and error


We could also think about adding a line break like left (but this is not in this PR just tested this without commit) 
<img width="2593" height="1199" alt="image" src="https://github.com/user-attachments/assets/79f8ce60-737f-4051-b4b9-526b6f745cb4" />
