### PR TITLE
Rename module to Annotation ranking

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/filter_sortannotations/PreferredAnnotationRankingModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/filter_sortannotations/PreferredAnnotationRankingModule.java
@@ -38,9 +38,11 @@ import org.jetbrains.annotations.Nullable;
 public class PreferredAnnotationRankingModule extends TaskPerFeatureListModule {
 
   public PreferredAnnotationRankingModule() {
-    super("Preferred annotation ranking", PreferredAnnotationRankingParameters.class,
-        MZmineModuleCategory.FEATURELISTFILTERING, false,
-        "Define how preferred annotations are determined and ranked in a feature list.");
+    super("Annotation ranking", PreferredAnnotationRankingParameters.class,
+        MZmineModuleCategory.FEATURELISTFILTERING, false, """
+            Define how ranks of preferred annotations are determined in a feature list.
+            This will replace the default that is already set to all new feature lists.
+            The ranking configs are usually transferred from an input to an output feature list by modules.""");
   }
 
   @Override


### PR DESCRIPTION
Maybe we should directly call it annotation ranking (more general than preferred annotation ranking). 
And later also use it in ranking the internal lists of other annotation types.
