### PR TITLE
Faster sorting of structure column

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/annotations/MolecularStructureType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/annotations/MolecularStructureType.java
@@ -42,6 +42,7 @@ import io.github.mzmine.modules.visualization.featurelisttable_modular.FeatureTa
 import io.github.mzmine.modules.visualization.molstructure.MolStructureViewer;
 import io.github.mzmine.modules.visualization.molstructure.StructureTableCell;
 import io.github.mzmine.modules.visualization.spectra.spectralmatchresults.SpectralIdentificationResultsTab;
+import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Logger;
 import javafx.beans.property.Property;
@@ -104,6 +105,8 @@ public class MolecularStructureType extends DataType<MolecularStructure> impleme
       final int subColumnIndex) {
     var column = super.createColumn(raw, parentType, subColumnIndex);
     column.setCellFactory(_ -> new StructureTableCell<>());
+    column.setComparator(Comparator.comparingInt(
+        v -> v instanceof MolecularStructure structure ? structure.totalAtomsCount() : -1));
     return column;
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/structures/MolecularStructure.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/structures/MolecularStructure.java
@@ -84,4 +84,9 @@ public sealed interface MolecularStructure permits PrecomputedMolecularStructure
 
   int totalFormalCharge();
 
+  /**
+   * Number of atoms in structure
+   */
+  int totalAtomsCount();
+
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/structures/PrecomputedMolecularStructure.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/structures/PrecomputedMolecularStructure.java
@@ -51,4 +51,9 @@ public record PrecomputedMolecularStructure(@NotNull IAtomContainer structure,
         + monoIsotopicMass + ", " + "mostAbundantMass=" + mostAbundantMass + ", "
         + "totalFormalCharge=" + totalFormalCharge + ']';
   }
+
+  @Override
+  public int totalAtomsCount() {
+    return structure.getAtomCount();
+  }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/structures/SimpleMolecularStructure.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/structures/SimpleMolecularStructure.java
@@ -30,7 +30,6 @@ import io.github.mzmine.datamodel.structures.StructureUtils.SmilesFlavor;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.openscience.cdk.inchi.InChIGenerator;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IMolecularFormula;
 import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
@@ -78,6 +77,11 @@ public record SimpleMolecularStructure(@NotNull IAtomContainer structure) implem
     return StructureUtils.getTotalFormalCharge(structure());
   }
 
+  @Override
+  public int totalAtomsCount() {
+    return structure.getAtomCount();
+  }
+
   @Nullable
   public String inchiKey() {
     return StructureUtils.getInchiKey(structure());
@@ -100,11 +104,8 @@ public record SimpleMolecularStructure(@NotNull IAtomContainer structure) implem
 
   @Override
   public @NotNull String toString() {
-    final PrecomputedMolecularStructure val = precomputeValues();
-    return "SimpleMolecularStructure[" + "formula=" + MolecularFormulaManipulator.getString(val.formula())
-        + ", " + "canonicalSmiles=" + val.canonicalSmiles() + ", " + "isomericSmiles=" + val.isomericSmiles()
-        + ", " + "inchi=" + val.inchi() + ", " + "inchiKey=" + val.inchiKey() + ", " + "monoIsotopicMass="
-        + val.monoIsotopicMass() + ", " + "mostAbundantMass=" + val.mostAbundantMass() + ", "
-        + "totalFormalCharge=" + val.totalFormalCharge() + ']';
+    // no need to calculate too many things as to string does not make much sense.
+    // toString was also called by the default comparator in javafx table
+    return "SimpleMolecularStructure[" + "formula=" + MolecularFormulaManipulator.getString(formula())+']';
   }
 }


### PR DESCRIPTION
Default column sorter is always calling toString on the object and toString was heavy for MolecularStructure