### PR TITLE
Allow ProjectLoadModule in batch

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModule.java
@@ -31,6 +31,7 @@ import io.github.mzmine.main.ConfigService;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
+import io.github.mzmine.modules.io.projectload.ProjectOpeningTask;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
@@ -79,6 +80,12 @@ public class BatchModeModule implements MZmineProcessingModule {
           "Cannot run a second batch while the current batch is not finished.");
       return null;
     }
+    if (MZmineCore.getTaskController().isTaskInstanceRunningOrQueued(ProjectOpeningTask.class)) {
+      MZmineCore.getDesktop().displayErrorMessage(
+          "Currently loading a project, cannot run a batch until project load is finished.");
+      return null;
+    }
+
 
     logger.info("Running batch from file " + batchFile);
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectload/ProjectLoadModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectload/ProjectLoadModule.java
@@ -25,17 +25,16 @@
 
 package io.github.mzmine.modules.io.projectload;
 
-import java.time.Instant;
-import java.util.Collection;
-
-import org.jetbrains.annotations.NotNull;
-
 import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineModuleCategory;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
+import java.time.Instant;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * This class implements BatchStep interface, so project loading can be activated in a batch.
@@ -61,6 +60,12 @@ public class ProjectLoadModule implements MZmineProcessingModule {
   @NotNull
   public ExitCode runModule(@NotNull MZmineProject project, @NotNull ParameterSet parameters,
       @NotNull Collection<Task> tasks, @NotNull Instant moduleCallDate) {
+    if (MZmineCore.getTaskController().isTaskInstanceRunningOrQueued(ProjectOpeningTask.class)) {
+      MZmineCore.getDesktop().displayErrorMessage(
+          "Currently loading a project, cannot start a second project import.");
+      return null;
+    }
+
     ProjectOpeningTask newTask = new ProjectOpeningTask(parameters, moduleCallDate);
     tasks.add(newTask);
     return ExitCode.OK;

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectload/version_3_0/RawDataFileOpenHandler_3_0.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectload/version_3_0/RawDataFileOpenHandler_3_0.java
@@ -27,12 +27,12 @@ package io.github.mzmine.modules.io.projectload.version_3_0;
 
 import io.github.mzmine.datamodel.MZmineProject;
 import io.github.mzmine.main.ConfigService;
-import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.modules.MZmineProcessingStep;
 import io.github.mzmine.modules.batchmode.BatchModeModule;
 import io.github.mzmine.modules.batchmode.BatchModeParameters;
 import io.github.mzmine.modules.batchmode.BatchQueue;
+import io.github.mzmine.modules.batchmode.BatchTask;
 import io.github.mzmine.modules.io.projectload.RawDataFileOpenHandler;
 import io.github.mzmine.modules.io.projectsave.RawDataFileSaveHandler;
 import io.github.mzmine.parameters.Parameter;
@@ -45,8 +45,6 @@ import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilePlacehold
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesSelectionType;
 import io.github.mzmine.taskcontrol.AbstractTask;
-import io.github.mzmine.taskcontrol.AllTasksFinishedListener;
-import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.taskcontrol.TaskPriority;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.StreamCopy;
@@ -60,7 +58,6 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -225,29 +222,17 @@ public class RawDataFileOpenHandler_3_0 extends AbstractTask implements RawDataF
         resolvePathsUnpackFiles(batchQueue, tempDir);
 
         param.setParameter(BatchModeParameters.batchQueue, batchQueue);
-        final BatchModeModule batchModule = MZmineCore.getModuleInstance(BatchModeModule.class);
-        final List<Task> tasks = new ArrayList<>();
-        batchModule.runModule(project, param, tasks, Instant.now());
 
-        List<AbstractTask> abstractTasks = tasks.stream().filter(t -> t instanceof AbstractTask)
-            .map(t -> (AbstractTask) t).toList();
-        currentTask = abstractTasks.get(0);
+        // run task blocking on this thread
+        currentTask = new BatchTask(project, param, Instant.now(), null, this);
+        currentTask.run();
 
-        AtomicBoolean finished = new AtomicBoolean(false);
-        AtomicBoolean success = new AtomicBoolean(true);
-        AllTasksFinishedListener listener = new AllTasksFinishedListener(abstractTasks, true,
-            c -> finished.set(true), c -> success.set(false), c -> success.set(false));
-
-        MZmineCore.getTaskController().addTasks(tasks.toArray(Task[]::new));
-
-        while (!finished.get()) {
-          Thread.sleep(100);
-          if (isCanceled()) {
-            return false;
-          }
+        if (currentTask.getStatus() == TaskStatus.ERROR) {
+          error(currentTask.getErrorMessage());
+          return false;
         }
 
-        if (!success.get()) {
+        if (!currentTask.isFinished()) {
           return false;
         }
 
@@ -337,8 +322,7 @@ public class RawDataFileOpenHandler_3_0 extends AbstractTask implements RawDataF
           }
           final File file = fnp.getValue();
           // check if the file was actually saved in the project
-          final Matcher matcher = RawDataFileSaveHandler.DATA_FILE_PATTERN.matcher(
-              file.getPath());
+          final Matcher matcher = RawDataFileSaveHandler.DATA_FILE_PATTERN.matcher(file.getPath());
           if (matcher.matches()) {
             String fileInZip = matcher.group(2);
             ZipUtils.unzipDirectory(fileInZip.replaceAll("\\\\", "/"), zipFile,


### PR DESCRIPTION
Somehow the BatchQueue in the module parameters is still replaced by the project load... 
Cannot really find why.
In the end the raw data import and processing is in the latest batch