### PR TITLE
gap filling: limit rt width in gap filled peaks

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/Gap.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/Gap.java
@@ -91,9 +91,6 @@ public class Gap {
         .filter(f -> f.getFeatureStatus() == FeatureStatus.DETECTED)
         .max(Comparator.comparingDouble(Feature::getHeight))
         .orElse((ModularFeature) peakListRow.getBestFeature());
-    if (bestFeature.getFeatureStatus() != FeatureStatus.DETECTED) {
-      throw new IllegalArgumentException();
-    }
     final float bestFeatureRt = bestFeature.getRT();
     // assume that previously undetected features are limited by the RT width of the most intense one
     rtLengthLeft = bestFeatureRt - bestFeature.getRawDataPointsRTRange().lowerEndpoint();


### PR DESCRIPTION
Limit the RT range of gap filled peaks by the left and right range of the most intense primary peak
This should lead to more reproducible secondary feature finding and also reduce overall RSD.

Criteria are currently derived from the most intense primary peak. Another option would be to use the primary peak with the least number of data points, or the least intense primary peak, which would make the filter more strict. 

**Still contains logging, will remove before merge**

Example (not a good one, but hard to find a good one):

Before:
some of the orange peaks are narrow and correctly integrated. The gap filled (magenta) also integrate some of the fronting. (yes, primary feature finding performed even worse in some cases, but that is a different issue to tackle)
<img width="393" height="145" alt="image" src="https://github.com/user-attachments/assets/6d573820-1886-4b33-bdbb-d72d27cb5538" />

After:
all secondary peaks are within the range of the "correctly" integrated peaks
<img width="401" height="159" alt="image" src="https://github.com/user-attachments/assets/5c2c334e-f342-45b6-bfe8-63fa9e0e314a" />
