### PR TITLE
quick-search: use event handler over filter

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/gui/MZmineGUI.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/MZmineGUI.java
@@ -592,8 +592,9 @@ public class MZmineGUI extends Application implements MZmineDesktop, JavaFxDeskt
 
     // add global keys that may be added to other dialogs to receive the same key event handling
     // key typed does not work
-    // using EventFilter instead of handler as this is a top level to get all events
-//    rootScene.addEventFilter(KeyEvent.KEY_RELEASED, GlobalKeyHandler.getInstance());
+    // using EventHandler to allow that other handlers before might intercept and consume the event
+    // EventFilter was used ealier to get all events but this was not needed
+    // rootScene.addEventFilter(KeyEvent.KEY_RELEASED, GlobalKeyHandler.getInstance());
     rootScene.addEventHandler(KeyEvent.KEY_RELEASED, GlobalKeyHandler.getInstance());
 
     // check user in gui mode and show message now


### PR DESCRIPTION
Grab Ctrl+F and double shift events with a handler instead of a filter.

Handler is triggered at the end of the event bubbling, but at least for me i couldnt find a case where the ctrl f and shift mappings did not work. this gives us the option to also use these combinations in other ui components.

unsure where the comment in the initial implementation came from. maybe there was a case i did not find.

edit:

tried in feature table, selected ui components, charts (raw overview), stats dashboard