### PR TITLE
fix-rsd-filter: correctly apply missing value tracking

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/statistics/FeatureListRowAbundances.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/statistics/FeatureListRowAbundances.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2025 The mzmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -42,7 +42,7 @@ public interface FeatureListRowAbundances {
    */
   static FeatureListRowAbundances of(FeatureListRow row, double[] abundances,
       boolean trackMissingValues) {
-    if (trackMissingValues) {
+    if (!trackMissingValues) {
       return new SimpleFeatureListRowAbundances(row, abundances);
     } else {
       int nMissingValues = 0;


### PR DESCRIPTION
before when filtering for rsd in qc group:
<img width="1113" height="260" alt="image" src="https://github.com/user-attachments/assets/a51ab49a-46d5-4365-a819-7b77c43d48ad" />

after:
<img width="1682" height="380" alt="image" src="https://github.com/user-attachments/assets/2fdef82a-ee6a-4ea5-bc43-44a29f148c64" />
