### PR TITLE
FeatureFullDataAccess: also fill mz ranges

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/data_access/FeatureFullDataAccess.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/data_access/FeatureFullDataAccess.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2004-2025 The mzmine Development Team
- *
+ * Copyright (c) 2004-2026 The mzmine Development Team
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
  * files (the "Software"), to deal in the Software without
@@ -200,9 +199,11 @@ public class FeatureFullDataAccess extends FeatureDataAccess {
           detectedIndex++;
         } else {
           intensities[i] = 0d;
+          mzs[i] = 0d;
         }
         if (detectedIndex == detectedScans.size() && i < intensities.length - 1) {
           Arrays.fill(intensities, i + 1, intensities.length, 0d);
+          Arrays.fill(mzs, i + 1, mzs.length, 0d);
           break;
         }
       }


### PR DESCRIPTION
Not filling the mzs could have led to mz ranges still containing mzs from previous chromatograms in the new wavelet resolver if the range was greater than the original peak. 
The other fix would be to also check the intensity in FeatureDataUtils.getMzRange, but i think that would make the processing slower. 0 is excluded in that method.

<img width="1127" height="258" alt="image" src="https://github.com/user-attachments/assets/13b05813-ac3a-40de-bcb9-39db6185ca21" />
