### PR TITLE
Bugfix for extrapolation with RI calculation, now uses correct offset for large retention times

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_ri/RICalculationTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_ri/RICalculationTask.java
@@ -223,7 +223,7 @@ public class RICalculationTask extends AbstractFeatureListTask {
       ri = (float) riScale.interpolator().value(rt);
     } else if (shouldExtrapolate && rt > knots[knots.length - 1]) {
       ri = (float) riScale.interpolator().getPolynomials()[
-          riScale.interpolator().getPolynomials().length - 1].value(rt - knots[knots.length - 1]);
+          riScale.interpolator().getPolynomials().length - 1].value(rt - knots[knots.length - 2]);
     } else if (shouldExtrapolate && rt < knots[0]) {
       ri = (float) riScale.interpolator().getPolynomials()[0].value(rt - knots[0]);
     }


### PR DESCRIPTION
Before:
<img width="2128" height="1597" alt="image" src="https://github.com/user-attachments/assets/0c0b82ee-ce04-481f-a403-31f051581ded" />
After:
<img width="2593" height="1831" alt="image" src="https://github.com/user-attachments/assets/bbb233c0-4890-46f0-90d3-3640c99a4dd6" />

Note: extrapolation is a nonstandard feature that probably no one uses