### PR TITLE
set initial size of parameter dialogs

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/gui/StageWindowSettingsUtil.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/StageWindowSettingsUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2025 The mzmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -27,6 +27,7 @@ package io.github.mzmine.gui;
 
 import io.github.mzmine.javafx.properties.PropertyUtils;
 import io.github.mzmine.parameters.parametertypes.WindowSettings;
+import java.util.Objects;
 import java.util.logging.Logger;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -63,18 +64,22 @@ public class StageWindowSettingsUtil {
   }
 
   /**
-   * @return first screen index or -1 if none matches bounds
+   * @return first matching screen this window is on or null if none matches bounds
    */
-  public static int getCurrentScreen(@NotNull Stage stage) {
+  public static @Nullable Screen getCurrentScreen(@NotNull Stage stage) {
     final ObservableList<Screen> screens = Screen.getScreens();
     for (int i = 0; i < screens.size(); i++) {
       Screen screen = screens.get(i);
       if (screen.getBounds()
           .intersects(stage.getX(), stage.getY(), stage.getWidth(), stage.getHeight())) {
-        return i;
+        return screen;
       }
     }
-    return -1;
+    return null;
+  }
+
+  public static @NotNull Screen getCurrentScreenOrPrimary(@NotNull Stage stage) {
+    return Objects.requireNonNullElse(getCurrentScreen(stage), Screen.getPrimary());
   }
 
   /**

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/dialogs/EmptyParameterSetupDialogBase.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/dialogs/EmptyParameterSetupDialogBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2025 The mzmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -26,6 +26,7 @@
 package io.github.mzmine.parameters.dialogs;
 
 import io.github.mzmine.gui.DesktopService;
+import io.github.mzmine.gui.StageWindowSettingsUtil;
 import io.github.mzmine.javafx.dialogs.DialogLoggerUtil;
 import io.github.mzmine.javafx.util.FxIconUtil;
 import io.github.mzmine.main.MZmineCore;
@@ -165,16 +166,14 @@ public class EmptyParameterSetupDialogBase extends Stage {
       if(!showing) {
         return;
       }
-      final Screen primary = Screen.getPrimary();
-      if (primary != null) {
-        // primary.getBounds is already scaling aware.
-        final Rectangle2D resolution = primary.getBounds();
-        // no dialogs larger than the screen
-        if (mainPane.getHeight() > resolution.getHeight() * 0.8
-            || scene.getHeight() > resolution.getHeight() * 0.8) {
-          setHeight(resolution.getHeight() * 0.8);
-          centerOnScreen();
-        }
+      final Screen screen = StageWindowSettingsUtil.getCurrentScreenOrPrimary(this);
+      // primary.getBounds is already scaling aware.
+      final Rectangle2D resolution = screen.getBounds();
+      // no dialogs larger than the screen
+      if (mainPane.getHeight() > resolution.getHeight() * 0.8
+          || scene.getHeight() > resolution.getHeight() * 0.8) {
+        setHeight(resolution.getHeight() * 0.8);
+        centerOnScreen();
       }
     });
 

--- a/mzmine-community/src/main/java/io/github/mzmine/parameters/dialogs/EmptyParameterSetupDialogBase.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/parameters/dialogs/EmptyParameterSetupDialogBase.java
@@ -46,6 +46,7 @@ import java.util.stream.Stream;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
+import javafx.geometry.Rectangle2D;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.ButtonBar;
@@ -56,6 +57,7 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -158,6 +160,23 @@ public class EmptyParameterSetupDialogBase extends Stage {
 
     setMinWidth(500.0);
     setMinHeight(400.0);
+
+    showingProperty().subscribe(showing -> {
+      if(!showing) {
+        return;
+      }
+      final Screen primary = Screen.getPrimary();
+      if (primary != null) {
+        // primary.getBounds is already scaling aware.
+        final Rectangle2D resolution = primary.getBounds();
+        // no dialogs larger than the screen
+        if (mainPane.getHeight() > resolution.getHeight() * 0.8
+            || scene.getHeight() > resolution.getHeight() * 0.8) {
+          setHeight(resolution.getHeight() * 0.8);
+          centerOnScreen();
+        }
+      }
+    });
 
     centerOnScreen();
   }


### PR DESCRIPTION
with scaling or lower resolutions, some parameter dialogs were too large in height. 
Setting just the height still allows the dialog to be maximized if the user wants