### PR TITLE
Fix mzML import crash when optional scan-level CV params are missing or referenced

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/msdk/data/BuildingMzMLMsScan.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/msdk/data/BuildingMzMLMsScan.java
@@ -296,9 +296,11 @@ public class BuildingMzMLMsScan extends MetadataOnlyScan {
       Optional<String> cvv1 = getCVValue(MzMLCV.cvHighestMz);
       if (cvv.isEmpty() || cvv1.isEmpty()) {
         // mz values is null if data was not loaded yet
+        // note: mzBinaryDataInfo is cleared after loading (see clearUnusedData()), so use the
+        // decoded array's own length instead
         if (mzValues != null) {
-          mzRange = MsSpectrumUtil.getMzRange(DataPointUtils.getDoubleBufferAsArray(mzValues),
-              getMzBinaryDataInfo().getArrayLength());
+          double[] mzArr = DataPointUtils.getDoubleBufferAsArray(mzValues);
+          mzRange = MsSpectrumUtil.getMzRange(mzArr, mzArr.length);
         }
       } else {
         try {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/msdk/data/MzMLParser.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/msdk/data/MzMLParser.java
@@ -246,7 +246,26 @@ public class MzMLParser {
         String refValue = getRequiredAttribute(xmlStreamReader, "ref");
         for (MzMLReferenceableParamGroup ref : vars.referenceableParamGroupList) {
           if (ref.getParamGroupName().equals(refValue)) {
-            vars.spectrum.getCVParams().getCVParamsList().addAll(ref.getCVParamsList());
+            // Route referenced params to the correct context, mirroring inline cvParam logic
+            if (tracker.inside(MzMLTags.TAG_SCAN_LIST)) {
+              if (tracker.inside(MzMLTags.TAG_SCAN_WINDOW)) {
+                vars.scanWindow.getCVParamsList().addAll(ref.getCVParamsList());
+              } else if (tracker.inside(MzMLTags.TAG_SCAN)) {
+                vars.scan.getCVParamsList().addAll(ref.getCVParamsList());
+              } else {
+                vars.spectrum.getScanList().getCVParamsList().addAll(ref.getCVParamsList());
+              }
+            } else if (tracker.inside(MzMLTags.TAG_PRECURSOR_LIST)) {
+              if (tracker.inside(MzMLTags.TAG_ISOLATION_WINDOW)) {
+                vars.isolationWindow.getCVParamsList().addAll(ref.getCVParamsList());
+              } else if (tracker.inside(MzMLTags.TAG_SELECTED_ION_LIST)) {
+                vars.selectedIon.getCVParamsList().addAll(ref.getCVParamsList());
+              } else if (tracker.inside(MzMLTags.TAG_ACTIVATION)) {
+                vars.activation.getCVParamsList().addAll(ref.getCVParamsList());
+              }
+            } else {
+              vars.spectrum.getCVParams().getCVParamsList().addAll(ref.getCVParamsList());
+            }
             break;
           }
         }

--- a/mzmine-community/src/test/java/import_data/MzMLMissingOptionalCvParamsTest.java
+++ b/mzmine-community/src/test/java/import_data/MzMLMissingOptionalCvParamsTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2004-2025 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package import_data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.Scan;
+import io.github.mzmine.project.ProjectService;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import testutils.MZmineTestUtil;
+
+/**
+ * Tests mzML import of files that omit optional scan-level CV params (MS:1000528 lowest observed
+ * m/z and MS:1000527 highest observed m/z). This is valid mzML and occurs with converters like
+ * SCIEX MS Converter. Previously caused a NullPointerException in
+ * BuildingMzMLMsScan.getDataPointMZRange() because it dereferenced mzBinaryDataInfo after it was
+ * cleared.
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+@DisabledOnOs(OS.MAC)
+public class MzMLMissingOptionalCvParamsTest {
+
+  private static final String TEST_FILE = "rawdatafiles/additional/sciex_no_mz_range_cv.mzML";
+  private static final String TEST_FILE_NO_WINDOW_LIMITS = "rawdatafiles/additional/no_scan_window_limits.mzML";
+
+  @BeforeAll
+  void initialize() {
+    MZmineTestUtil.startMzmineCore();
+  }
+
+  @AfterAll
+  void tearDown() {
+    MZmineTestUtil.cleanProject();
+  }
+
+  @Test
+  @DisplayName("Import mzML without lowest/highest observed m/z CV params should not crash")
+  void testImportWithoutMzRangeCvParams() throws InterruptedException {
+    MZmineTestUtil.cleanProject();
+    MZmineTestUtil.importFiles(List.of(TEST_FILE), 60);
+
+    RawDataFile[] dataFiles = ProjectService.getProject().getDataFiles();
+    assertEquals(1, dataFiles.length, "Expected 1 imported data file");
+
+    RawDataFile raw = dataFiles[0];
+    assertNotNull(raw);
+    assertEquals(2, raw.getNumOfScans(), "Expected 2 scans total");
+    assertEquals(1, raw.getNumOfScans(1), "Expected 1 MS1 scan");
+    assertEquals(1, raw.getNumOfScans(2), "Expected 1 MS2 scan");
+
+    // Verify scans have valid data and getDataPointMZRange does not throw
+    for (Scan scan : raw.getScans()) {
+      assertTrue(scan.getNumberOfDataPoints() > 0,
+          "Scan " + scan.getScanNumber() + " should have data points");
+
+      Range<Double> mzRange = scan.getDataPointMZRange();
+      assertNotNull(mzRange, "Scan " + scan.getScanNumber() + " should have a valid mz range");
+      assertTrue(mzRange.lowerEndpoint() > 0, "Lower mz bound should be positive");
+      assertTrue(mzRange.upperEndpoint() > mzRange.lowerEndpoint(),
+          "Upper mz bound should be greater than lower");
+    }
+
+    // Verify MS1 scan has expected values (mz: 100, 200, 300)
+    Scan ms1 = raw.getScan(0);
+    assertEquals(1, ms1.getMSLevel());
+    assertEquals(3, ms1.getNumberOfDataPoints());
+    Range<Double> ms1Range = ms1.getDataPointMZRange();
+    assertEquals(100.0, ms1Range.lowerEndpoint(), 0.01);
+    assertEquals(300.0, ms1Range.upperEndpoint(), 0.01);
+
+    // Verify scanning mz range resolved from referenceableParamGroupRef in scanWindow
+    Range<Double> scanningRange = ms1.getScanningMZRange();
+    assertNotNull(scanningRange);
+    assertEquals(50.0, scanningRange.lowerEndpoint(), 0.01,
+        "Scan window lower limit should be resolved from referenceableParamGroupRef");
+    assertEquals(500.0, scanningRange.upperEndpoint(), 0.01,
+        "Scan window upper limit should be resolved from referenceableParamGroupRef");
+
+    // Verify MS2 scan has expected values (mz: 105, 150)
+    Scan ms2 = raw.getScan(1);
+    assertEquals(2, ms2.getMSLevel());
+    assertEquals(2, ms2.getNumberOfDataPoints());
+    Range<Double> ms2Range = ms2.getDataPointMZRange();
+    assertEquals(105.0, ms2Range.lowerEndpoint(), 0.01);
+    assertEquals(150.0, ms2Range.upperEndpoint(), 0.01);
+  }
+
+  /**
+   * Tests the fallback path in getDataPointMZRange when scan window lower/upper limit CV params are
+   * completely absent (not even via referenceableParamGroupRef). This directly exercises the NPE fix
+   * in BuildingMzMLMsScan.getDataPointMZRange where mzBinaryDataInfo is null after clearUnusedData.
+   */
+  @Test
+  @DisplayName("Import mzML with empty scan window (no limits) should compute mz range from data")
+  void testImportWithEmptyScanWindow() throws InterruptedException {
+    MZmineTestUtil.cleanProject();
+    MZmineTestUtil.importFiles(List.of(TEST_FILE_NO_WINDOW_LIMITS), 60);
+
+    RawDataFile[] dataFiles = ProjectService.getProject().getDataFiles();
+    assertEquals(1, dataFiles.length, "Expected 1 imported data file");
+
+    RawDataFile raw = dataFiles[0];
+    assertNotNull(raw);
+    assertEquals(1, raw.getNumOfScans(), "Expected 1 scan");
+
+    Scan scan = raw.getScan(0);
+    assertEquals(1, scan.getMSLevel());
+    assertEquals(3, scan.getNumberOfDataPoints());
+
+    // This is the critical assertion: getScanningMZRange falls through to getDataPointMZRange
+    // because scan window has no lower/upper limits. Without the NPE fix, this crashes.
+    Range<Double> scanningRange = scan.getScanningMZRange();
+    assertNotNull(scanningRange, "Scanning range should not be null");
+    assertEquals(100.0, scanningRange.lowerEndpoint(), 0.01,
+        "Scanning range should fall back to data point mz range lower bound");
+    assertEquals(300.0, scanningRange.upperEndpoint(), 0.01,
+        "Scanning range should fall back to data point mz range upper bound");
+  }
+}

--- a/mzmine-community/src/test/resources/rawdatafiles/additional/no_scan_window_limits.mzML
+++ b/mzmine-community/src/test/resources/rawdatafiles/additional/no_scan_window_limits.mzML
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<indexedmzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.2_idx.xsd">
+  <mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="no_scan_window_limits" version="1.1.0">
+    <cvList count="2">
+      <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.30" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
+      <cv id="UO" fullName="Unit Ontology" version="09:04:2014" URI="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"/>
+    </cvList>
+    <fileDescription>
+      <fileContent>
+        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+      </fileContent>
+    </fileDescription>
+    <softwareList count="1">
+      <software id="test_converter" version="1.0">
+        <cvParam cvRef="MS" accession="MS:1000799" name="custom unreferenced format" value="test"/>
+      </software>
+    </softwareList>
+    <instrumentConfigurationList count="1">
+      <instrumentConfiguration id="IC1">
+        <cvParam cvRef="MS" accession="MS:1000443" name="mass analyzer type" value=""/>
+      </instrumentConfiguration>
+    </instrumentConfigurationList>
+    <dataProcessingList count="1">
+      <dataProcessing id="dp1">
+        <processingMethod order="0" softwareRef="test_converter">
+          <cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" value=""/>
+        </processingMethod>
+      </dataProcessing>
+    </dataProcessingList>
+    <run id="no_scan_window_limits" defaultInstrumentConfigurationRef="IC1">
+      <spectrumList count="1" defaultDataProcessingRef="dp1">
+        <spectrum index="0" id="scan=1" defaultArrayLength="3">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="200.0"/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="5000.0"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="8000.0"/>
+          <!-- No lowest/highest observed m/z CV params (MS:1000528/MS:1000527) -->
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan instrumentConfigurationRef="IC1">
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.5" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <!-- Scan window element present but NO lower/upper limit CV params -->
+                  <!-- This forces getScanningMZRange to fall through to getDataPointMZRange -->
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="32">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>AAAAAAAAWUAAAAAAAABpQAAAAAAAwHJA</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="32">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>AAAAAABAj0AAAAAAAIizQAAAAAAAQJ9A</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+      </spectrumList>
+    </run>
+  </mzML>
+  <indexList count="1">
+    <index name="spectrum">
+      <offset idRef="scan=1">780</offset>
+    </index>
+  </indexList>
+  <indexListOffset>3200</indexListOffset>
+  <fileChecksum>0000000000000000000000000000000000000000</fileChecksum>
+</indexedmzML>

--- a/mzmine-community/src/test/resources/rawdatafiles/additional/sciex_no_mz_range_cv.mzML
+++ b/mzmine-community/src/test/resources/rawdatafiles/additional/sciex_no_mz_range_cv.mzML
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="utf-8"?>
+<indexedmzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.2_idx.xsd">
+  <mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="sciex_no_mz_range_cv" version="1.1.0">
+    <cvList count="2">
+      <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.30" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
+      <cv id="UO" fullName="Unit Ontology" version="09:04:2014" URI="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"/>
+    </cvList>
+    <referenceableParamGroupList count="1">
+      <referenceableParamGroup id="scanWindowParams">
+        <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+        <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="500.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+      </referenceableParamGroup>
+    </referenceableParamGroupList>
+    <fileDescription>
+      <fileContent>
+        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+      </fileContent>
+    </fileDescription>
+    <softwareList count="1">
+      <software id="SCIEX_MS_Converter" version="2.0.1">
+        <cvParam cvRef="MS" accession="MS:1000799" name="custom unreferenced format" value="SCIEX MS Converter"/>
+      </software>
+    </softwareList>
+    <instrumentConfigurationList count="1">
+      <instrumentConfiguration id="IC1">
+        <cvParam cvRef="MS" accession="MS:1000870" name="SCIEX instrument model" value=""/>
+      </instrumentConfiguration>
+    </instrumentConfigurationList>
+    <dataProcessingList count="1">
+      <dataProcessing id="dp1">
+        <processingMethod order="0" softwareRef="SCIEX_MS_Converter">
+          <cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" value=""/>
+        </processingMethod>
+      </dataProcessing>
+    </dataProcessingList>
+    <run id="sciex_no_mz_range_cv" defaultInstrumentConfigurationRef="IC1">
+      <spectrumList count="2" defaultDataProcessingRef="dp1">
+        <spectrum index="0" id="scan=1" defaultArrayLength="3">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="200.0"/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="5000.0"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="8000.0"/>
+          <!-- NOTE: No MS:1000528 (lowest observed m/z) or MS:1000527 (highest observed m/z) -->
+          <!-- Scan window limits provided via referenceableParamGroupRef - mimics SCIEX output -->
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan instrumentConfigurationRef="IC1">
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.5" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <referenceableParamGroupRef ref="scanWindowParams"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="32">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>AAAAAAAAWUAAAAAAAABpQAAAAAAAwHJA</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="32">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>AAAAAABAj0AAAAAAAIizQAAAAAAAQJ9A</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="1" id="scan=2" defaultArrayLength="2">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="150.0"/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="3000.0"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="3800.0"/>
+          <!-- NOTE: No MS:1000528 (lowest observed m/z) or MS:1000527 (highest observed m/z) -->
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan instrumentConfigurationRef="IC1">
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.55" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <referenceableParamGroupRef ref="scanWindowParams"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor spectrumRef="scan=1">
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="200.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="0.5" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="0.5" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="200.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="1"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="35.0" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="24">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>AAAAAABAWkAAAAAAAMBiQA==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="24">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>AAAAAAAAiUAAAAAAAHCnQA==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+      </spectrumList>
+    </run>
+  </mzML>
+  <indexList count="1">
+    <index name="spectrum">
+      <offset idRef="scan=1">1204</offset>
+      <offset idRef="scan=2">3508</offset>
+    </index>
+  </indexList>
+  <indexListOffset>6165</indexListOffset>
+  <fileChecksum>0000000000000000000000000000000000000000</fileChecksum>
+</indexedmzML>


### PR DESCRIPTION
Two issues fixed:

1. referenceableParamGroupRef elements inside scanWindow, scan, isolationWindow, selectedIon, and activation were always routed to the spectrum's top-level CV params instead of the correct nested element. This caused scan window limits defined via param group references (as in SCIEX MS Converter output) to be invisible to getScanningMZRange().

2. getDataPointMZRange() dereferenced getMzBinaryDataInfo() after it was already cleared by clearUnusedData(), causing a NullPointerException when both lowest/highest observed m/z CV params and scan window limits were absent.

Added regression tests with minimal mzML files covering both paths.