### PR TITLE
charts: default visible for value marker

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/gui/javafx/model/FxValueMarker.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/gui/javafx/model/FxValueMarker.java
@@ -58,7 +58,7 @@ public class FxValueMarker extends ValueMarker implements FxMarker {
   // the actual alpha is used to hide the marker if value is null or invisible
   private final ReadOnlyFloatWrapper alpha = new ReadOnlyFloatWrapper(1f);
 
-  private final BooleanProperty visible = new SimpleBooleanProperty();
+  private final BooleanProperty visible = new SimpleBooleanProperty(true);
   private final ObjectProperty<@NotNull Stroke> stroke = new SimpleObjectProperty<>(
       new BasicStroke(1.0f));
   private final ObjectProperty<@NotNull Paint> paint = new SimpleObjectProperty<>(


### PR DESCRIPTION
earlier the chart theme always made markers visible, now they were missing in the pca/volcano plot. make them visible by default, but this way the chart theme does not always make them visible if they were turned off before.