### PR TITLE
tag potential duplicates in gap-filling

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/gapfilling/GapFillMzMatchDuplicateType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/types/gapfilling/GapFillMzMatchDuplicateType.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.datamodel.features.types.gapfilling;
+
+import io.github.mzmine.datamodel.features.types.abstr.StringType;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Tags a gap-filled feature when, on top of the m/z and RT window check
+ * ({@link GapFillRtMzWindowDuplicateType}), a candidate feature from the same raw data file shares
+ * at least 50 % of its m/z values with the gap-filled feature (compared only within the same scan,
+ * since m/z is unaffected by smoothing). Value is "no" or "yes (IDs: ...)" listing the other rows.
+ */
+public class GapFillMzMatchDuplicateType extends StringType {
+
+  @Override
+  public @NotNull String getUniqueID() {
+    return "gap_fill_mz_duplicate";
+  }
+
+  @Override
+  public @NotNull String getHeaderString() {
+    return "Gap dup (m/z)";
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/Gap.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/Gap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -36,11 +36,17 @@ import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.datamodel.features.types.gapfilling.GapFillMzMatchDuplicateType;
 import io.github.mzmine.util.DataPointUtils;
 import io.github.mzmine.util.RangeUtils;
+import io.github.mzmine.util.collections.BinarySearch;
+import io.github.mzmine.util.collections.BinarySearch.DefaultTo;
+import io.github.mzmine.util.maths.Precision;
 import io.github.mzmine.util.scans.ScanUtils;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
 
 public class Gap {
 
@@ -157,12 +163,90 @@ public class Gap {
         mzIntensities[0], mzIntensities[1],
         bestPeakDataPoints.stream().map(GapDataPoint::getScan).toList());
 
-    final Feature newPeak = new ModularFeature((ModularFeatureList) featureListRow.getFeatureList(),
-        rawDataFile, series, FeatureStatus.ESTIMATED);
+    final ModularFeature newPeak = new ModularFeature(
+        (ModularFeatureList) featureListRow.getFeatureList(), rawDataFile, series,
+        FeatureStatus.ESTIMATED);
+
+    tagPotentialDuplicates(newPeak);
 
     // Fill the gap
     featureListRow.addFeature(rawDataFile, newPeak, false);
     return true;
+  }
+
+  /**
+   * Tags this gap-filled feature when it is a potential duplicate of another row's feature from the
+   * same raw data file (caused by (mis)alignment during gap filling). Sets two feature data types:
+   * and {@link GapFillMzMatchDuplicateType} (another row within this gap's m/z and RT window holds
+   * a feature of the same file, additionally, &ge; 50 % of the gap-filled feature's m/z values
+   * match such a feature, compared per scan).
+   *
+   * @param newFeature the freshly gap-filled feature
+   */
+  protected void tagPotentialDuplicates(@NotNull final ModularFeature newFeature) {
+    final ModularFeatureList flist = (ModularFeatureList) featureListRow.getFeatureList();
+    // make the columns available in the feature table (addFeatureType de-dupes by class)
+    flist.addFeatureType(new GapFillMzMatchDuplicateType());
+
+    final List<FeatureListRow> candidates = flist.getRowsInsideScanAndMZRange(rtRange, mzRange);
+
+    final List<Integer> mzIds = new ArrayList<>();
+    for (final FeatureListRow other : candidates) {
+      if (other == featureListRow) {
+        continue;
+      }
+      final Feature otherFeature = other.getFeature(rawDataFile);
+      if (otherFeature == null) {
+        continue;
+      }
+      // decision: only real peaks in other rows count as duplicates, not other gap-fills. This also
+      // keeps the result deterministic regardless of multithreaded gap-fill order.
+      final FeatureStatus status = otherFeature.getFeatureStatus();
+      if (status != FeatureStatus.DETECTED && status != FeatureStatus.MANUAL) {
+        continue;
+      }
+      if (fractionOfEqualMz(newFeature, otherFeature) >= 0.5) {
+        mzIds.add(other.getID());
+      }
+    }
+
+    newFeature.set(GapFillMzMatchDuplicateType.class, formatTag(mzIds));
+  }
+
+  /**
+   * Fraction of the gap-filled feature's data points whose scan (matched by retention time) is also
+   * present in the other feature with an equal m/z. m/z is unaffected by smoothing, so a true
+   * duplicate matches. Overridden in {@code ImsGap} for ion mobility data.
+   *
+   * @param gapFilled the gap-filled feature
+   * @param other     a real feature from the same raw data file in another row
+   * @return fraction in [0, 1]
+   */
+  protected double fractionOfEqualMz(@NotNull final Feature gapFilled,
+      @NotNull final Feature other) {
+    final IonTimeSeries<?> a = gapFilled.getFeatureData();
+    final IonTimeSeries<?> b = other.getFeatureData();
+    final int n = a.getNumberOfValues();
+    final int m = b.getNumberOfValues();
+    if (n == 0 || m == 0) {
+      return 0d;
+    }
+    int matches = 0;
+    for (int i = 0; i < n; i++) {
+      // same scan = same RT (b is sorted ascending in RT); negative result means no shared scan
+      final int j = BinarySearch.binarySearch(a.getRetentionTime(i),
+          DefaultTo.MINUS_INSERTION_POINT, m, b::getRetentionTime);
+//      if (j >= 0 && MZTolerance.NARROW_5_PPM_OR_1_MDA.checkWithinTolerance(a.getMZ(i), b.getMZ(j))) {
+      if (j >= 0 && Precision.equalFloatSignificance(a.getMZ(i), b.getMZ(j))) {
+        matches++;
+      }
+    }
+    return (double) matches / n;
+  }
+
+  private static @NotNull String formatTag(@NotNull final List<Integer> ids) {
+    return ids.isEmpty() ? "no"
+        : "yes (IDs: " + ids.stream().map(String::valueOf).collect(Collectors.joining(", ")) + ")";
   }
 
   /**

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/multithreaded/ImsGap.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/gapfill_peakfinder/multithreaded/ImsGap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 The MZmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -38,14 +38,17 @@ import io.github.mzmine.datamodel.data_access.MobilityScanDataAccess;
 import io.github.mzmine.datamodel.featuredata.IonMobilitySeries;
 import io.github.mzmine.datamodel.featuredata.IonMobilogramTimeSeries;
 import io.github.mzmine.datamodel.featuredata.impl.IonMobilogramTimeSeriesFactory;
+import io.github.mzmine.datamodel.features.Feature;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularFeature;
 import io.github.mzmine.datamodel.features.ModularFeatureList;
 import io.github.mzmine.modules.dataprocessing.gapfill_peakfinder.Gap;
 import io.github.mzmine.modules.dataprocessing.gapfill_peakfinder.GapDataPoint;
 import io.github.mzmine.util.RangeUtils;
+import io.github.mzmine.util.collections.BinarySearch;
 import io.github.mzmine.util.collections.BinarySearch.DefaultTo;
 import io.github.mzmine.util.exceptions.MissingMassListException;
+import io.github.mzmine.util.maths.Precision;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -207,7 +210,71 @@ public class ImsGap extends Gap {
     ModularFeature f = new ModularFeature((ModularFeatureList) featureListRow.getFeatureList(),
         rawDataFile, trace, FeatureStatus.ESTIMATED);
 
+    tagPotentialDuplicates(f);
+
     featureListRow.addFeature(rawDataFile, f, false);
     return true;
+  }
+
+  /**
+   * Ion mobility variant of the m/z comparison: matches frames by retention time and, within each
+   * shared frame, matches mobility scans by mobility, comparing the m/z stored in the
+   * {@link IonMobilitySeries} of the {@link IonMobilogramTimeSeries}. m/z is unaffected by
+   * smoothing, so a true duplicate matches.
+   *
+   * @param gapFilled the gap-filled feature
+   * @param other     a real feature from the same raw data file in another row
+   * @return fraction of the gap-filled feature's mobility data points that match, in [0, 1]
+   */
+  @Override
+  protected double fractionOfEqualMz(@NotNull final Feature gapFilled,
+      @NotNull final Feature other) {
+    if (!(gapFilled.getFeatureData() instanceof IonMobilogramTimeSeries a)
+        || !(other.getFeatureData() instanceof IonMobilogramTimeSeries b)) {
+      return 0d; // mixed dimensionality; cannot be the same peak
+    }
+    final int bFrames = b.getNumberOfValues();
+    int total = 0;
+    int matches = 0;
+    for (int fi = 0; fi < a.getNumberOfValues(); fi++) {
+      final IonMobilitySeries am = a.getMobilogram(fi);
+      total += am.getNumberOfValues();
+      // match the frame in b by retention time (frames sorted ascending in RT)
+      final int fj = BinarySearch.binarySearch(a.getRetentionTime(fi),
+          DefaultTo.MINUS_INSERTION_POINT, bFrames, b::getRetentionTime);
+      if (fj < 0) {
+        continue; // frame not shared
+      }
+      final IonMobilitySeries bm = b.getMobilogram(fj);
+      for (int i = 0; i < am.getNumberOfValues(); i++) {
+        final int j = matchMobility(bm, am.getMobility(i));
+//        if (j >= 0 && MZTolerance.NARROW_5_PPM_OR_1_MDA.checkWithinTolerance(am.getMZ(i), bm.getMZ(j))) {
+        if (j >= 0 && Precision.equalFloatSignificance(am.getMZ(i), bm.getMZ(j))) {
+          matches++;
+        }
+      }
+    }
+    return total == 0 ? 0d : (double) matches / total;
+  }
+
+  /**
+   * Finds the index of the mobility scan in {@code series} with the exact given mobility, or -1.
+   * Mobility within a mobilogram is monotonic but may be ascending (processed) or descending (raw
+   * TIMS), so the direction is detected and the binary search adapted accordingly (it requires
+   * ascending order).
+   */
+  private static int matchMobility(@NotNull final IonMobilitySeries series, final double mobility) {
+    final int size = series.getNumberOfValues();
+    if (size == 0) {
+      return -1;
+    }
+    if (size == 1) {
+      return Double.compare(series.getMobility(0), mobility) == 0 ? 0 : -1;
+    }
+    final boolean ascending = series.getMobility(size - 1) >= series.getMobility(0);
+    // negate for descending mobilograms so the binary search sees ascending values
+    final double key = ascending ? mobility : -mobility;
+    return BinarySearch.binarySearch(key, DefaultTo.MINUS_INSERTION_POINT, size,
+        i -> ascending ? series.getMobility(i) : -series.getMobility(i));
   }
 }

--- a/mzmine-community/src/main/resources/dependency/dependency-licenses.json
+++ b/mzmine-community/src/main/resources/dependency/dependency-licenses.json
@@ -299,6 +299,19 @@
             ]
         },
         {
+            "moduleName": "com.github.ben-manes.caffeine:caffeine",
+            "moduleVersion": "3.2.2",
+            "moduleUrls": [
+                "https://github.com/ben-manes/caffeine"
+            ],
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
             "moduleName": "com.github.chhh:javolution-core-java-msftbx",
             "moduleVersion": "6.11.8",
             "moduleUrls": [
@@ -447,7 +460,7 @@
         },
         {
             "moduleName": "com.google.errorprone:error_prone_annotations",
-            "moduleVersion": "2.36.0",
+            "moduleVersion": "2.40.0",
             "moduleUrls": [
                 "https://errorprone.info/error_prone_annotations"
             ],


### PR DESCRIPTION
During gap filling it may happen that duplicate features are created for some files due to prior mis-alignment or inconsistencies in feature detection.
This introduces a tag to potentially falsely introduced features. It does not yet provide a cleanup, because i am currently unsure what the best way to do such a cleanup would be, as there may be multiple reasons for it happening in the first place.

<img width="1989" height="522" alt="image" src="https://github.com/user-attachments/assets/3c545547-8fc4-4aca-9548-c89c0fdd62d6" />


Equality is checked by the raw mz values, sicne the intensities may be smoothed. Only 50% have to match since the gap filling may be shorter or longer than the true peak.