### PR TITLE
Start network MVCI, offload network generation from GUI thread

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/network_overview/NetworkOverviewController.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/network_overview/NetworkOverviewController.java
@@ -108,6 +108,26 @@ public class NetworkOverviewController {
     this.focussedRows = FXCollections.observableArrayList();
   }
 
+  public @NotNull ObservableList<FeatureListRow> getFocussedRows() {
+    return focussedRows;
+  }
+
+  /**
+   * Sets up the overview using a pre-built {@link FeatureNetworkController} whose graph data was
+   * created on a task thread. All remaining setup still runs on the GUI thread.
+   */
+  public void setUpWithNetworkController(@NotNull FeatureNetworkController networkController,
+      @NotNull ModularFeatureList featureList, @Nullable FeatureTableFX externalTable,
+      @Nullable List<? extends FeatureListRow> focussedRows) throws IOException {
+    if (setUpCalled) {
+      throw new IllegalStateException(
+          "Cannot setup NetworkOverviewController twice. Create a new one.");
+    }
+    setUpCalled = true;
+    this.networkController = networkController;
+    doSetUp(featureList, externalTable, focussedRows);
+  }
+
   public void setUp(@NotNull ModularFeatureList featureList, @Nullable FeatureTableFX externalTable,
       @Nullable List<? extends FeatureListRow> focussedRows, final NetworkOverviewFlavor flavor)
       throws IOException {
@@ -116,9 +136,14 @@ public class NetworkOverviewController {
           "Cannot setup NetworkOverviewController twice. Create a new one.");
     }
     setUpCalled = true;
-
-    // create network
+    // create network (heavy – blocks GUI thread; prefer setUpWithNetworkController for async use)
     networkController = FeatureNetworkController.create(featureList, this.focussedRows, flavor);
+    doSetUp(featureList, externalTable, focussedRows);
+  }
+
+  private void doSetUp(@NotNull ModularFeatureList featureList,
+      @Nullable FeatureTableFX externalTable, @Nullable List<? extends FeatureListRow> focussedRows)
+      throws IOException {
     pnNetwork.setCenter(networkController.getMainPane());
 
     // create edge table
@@ -147,9 +172,6 @@ public class NetworkOverviewController {
 
     LipidAnnotationMatchTabOld lipidAnnotationMatchTabOld = new LipidAnnotationMatchTabOld(
         internalTable);
-
-    // set content to panes
-    // tabEdges.
 
     tabSimilarity.setContent(mirrorScanController.getMainPane());
     tabAnnotations.setContent(gridAnnotations);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/network_overview/NetworkOverviewModel.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/network_overview/NetworkOverviewModel.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.visualization.network_overview;
+
+import io.github.mzmine.datamodel.features.FeatureListRow;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.modules.visualization.featurelisttable_modular.FeatureTableFX;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Holds the immutable parameters used to initialise a network overview. State is read-only because
+ * setup happens exactly once.
+ */
+public class NetworkOverviewModel {
+
+  private final @NotNull ModularFeatureList featureList;
+  private final @Nullable FeatureTableFX externalTable;
+  private final @Nullable List<? extends FeatureListRow> focussedRows;
+  private final @NotNull NetworkOverviewFlavor flavor;
+
+  public NetworkOverviewModel(@NotNull ModularFeatureList featureList,
+      @Nullable FeatureTableFX externalTable, @Nullable List<? extends FeatureListRow> focussedRows,
+      @NotNull NetworkOverviewFlavor flavor) {
+    this.featureList = featureList;
+    this.externalTable = externalTable;
+    this.focussedRows = focussedRows;
+    this.flavor = flavor;
+  }
+
+  public @NotNull ModularFeatureList getFeatureList() {
+    return featureList;
+  }
+
+  public @Nullable FeatureTableFX getExternalTable() {
+    return externalTable;
+  }
+
+  public @Nullable List<? extends FeatureListRow> getFocussedRows() {
+    return focussedRows;
+  }
+
+  public @NotNull NetworkOverviewFlavor getFlavor() {
+    return flavor;
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/network_overview/NetworkOverviewMvciController.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/network_overview/NetworkOverviewMvciController.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.visualization.network_overview;
+
+import io.github.mzmine.datamodel.features.FeatureListRow;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.javafx.mvci.FxController;
+import io.github.mzmine.javafx.mvci.FxUpdateTask;
+import io.github.mzmine.javafx.mvci.FxViewBuilder;
+import io.github.mzmine.modules.visualization.featurelisttable_modular.FeatureTableFX;
+import io.github.mzmine.modules.visualization.networking.visual.FeatureNetworkController;
+import io.github.mzmine.modules.visualization.networking.visual.NetworkGraphData;
+import java.io.IOException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javafx.fxml.FXMLLoader;
+import javafx.geometry.Pos;
+import javafx.scene.control.Label;
+import javafx.scene.control.ProgressIndicator;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.VBox;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * MVCI controller for the network overview window. It offloads the heavy graph data generation
+ * ({@link FeatureNetworkController#createGraphData}) to a task thread so the window becomes
+ * responsive immediately. The remaining FX-bound setup runs on the GUI thread once the graph is
+ * ready.
+ */
+public class NetworkOverviewMvciController extends FxController<NetworkOverviewModel> {
+
+  private static final Logger logger = Logger.getLogger(
+      NetworkOverviewMvciController.class.getName());
+
+  private final NetworkOverviewController networkOverviewController;
+  private final BorderPane fxmlPane;
+
+  public NetworkOverviewMvciController(@NotNull ModularFeatureList featureList,
+      @Nullable FeatureTableFX externalTable, @Nullable List<? extends FeatureListRow> focussedRows,
+      @NotNull NetworkOverviewFlavor flavor) throws IOException {
+    super(new NetworkOverviewModel(featureList, externalTable, focussedRows, flavor));
+
+    // Load the overview pane FXML – fast (layout + controller injection only, no graph generation)
+    final FXMLLoader loader = new FXMLLoader(
+        NetworkOverviewController.class.getResource("NetworkOverviewPane.fxml"));
+    fxmlPane = loader.load();
+    networkOverviewController = loader.getController();
+
+    // Show a loading indicator in the network area while the graph is built on the task thread
+    final ProgressIndicator spinner = new ProgressIndicator(-1);
+    spinner.setMaxSize(80, 80);
+    final VBox loadingBox = new VBox(10, spinner, new Label("Loading network…"));
+    loadingBox.setAlignment(Pos.CENTER);
+    networkOverviewController.pnNetwork.setCenter(loadingBox);
+  }
+
+  /**
+   * Starts network setup. Graph data generation runs on a task thread; the FX-bound setup completes
+   * on the GUI thread afterwards.
+   */
+  public void initNetwork() {
+    onTaskThread(new NetworkSetupTask());
+  }
+
+  @Override
+  protected @NotNull FxViewBuilder<NetworkOverviewModel> getViewBuilder() {
+    return new NetworkOverviewViewBuilder(model, fxmlPane);
+  }
+
+  @Override
+  public void close() {
+    super.close();
+    networkOverviewController.close();
+  }
+
+  public @NotNull NetworkOverviewController getNetworkOverviewController() {
+    return networkOverviewController;
+  }
+
+
+  /**
+   * Splits the heavy graph-data generation (task thread) from the FX-bound setup (GUI thread).
+   */
+  private final class NetworkSetupTask extends FxUpdateTask<NetworkOverviewModel> {
+
+    // computed on task thread, consumed in updateGuiModel
+    private NetworkGraphData graphData;
+
+    private NetworkSetupTask() {
+      super("Create feature network graph", NetworkOverviewMvciController.this.model);
+    }
+
+    @Override
+    protected void process() {
+      // decision: only createNewGraph runs on the task thread; all FX setup stays on GUI thread
+      graphData = FeatureNetworkController.createGraphData(model.getFeatureList());
+    }
+
+    @Override
+    protected void updateGuiModel() {
+      try {
+        final FeatureNetworkController featureNetworkController = FeatureNetworkController.createWithGraphData(
+            model.getFeatureList(), networkOverviewController.getFocussedRows(), graphData,
+            model.getFlavor());
+        networkOverviewController.setUpWithNetworkController(featureNetworkController,
+            model.getFeatureList(), model.getExternalTable(), model.getFocussedRows());
+      } catch (IOException ex) {
+        logger.log(Level.WARNING, "Could not set up network overview: " + ex.getMessage(), ex);
+      }
+    }
+
+    @Override
+    public String getTaskDescription() {
+      return "Generating network graph";
+    }
+
+    @Override
+    public double getFinishedPercentage() {
+      return 0;
+    }
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/network_overview/NetworkOverviewViewBuilder.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/network_overview/NetworkOverviewViewBuilder.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.visualization.network_overview;
+
+import io.github.mzmine.javafx.mvci.FxViewBuilder;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.Region;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Returns the pre-loaded FXML pane as the view. The network area inside that pane initially shows a
+ * loading indicator (set by {@link NetworkOverviewMvciController}) which is replaced once graph
+ * setup completes on the GUI thread.
+ */
+public class NetworkOverviewViewBuilder extends FxViewBuilder<NetworkOverviewModel> {
+
+  private final @NotNull BorderPane fxmlPane;
+
+  public NetworkOverviewViewBuilder(@NotNull NetworkOverviewModel model,
+      @NotNull BorderPane fxmlPane) {
+    super(model);
+    this.fxmlPane = fxmlPane;
+  }
+
+  @Override
+  public @NotNull Region build() {
+    return fxmlPane;
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/network_overview/NetworkOverviewWindow.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/network_overview/NetworkOverviewWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 The MZmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -32,7 +32,6 @@ import io.github.mzmine.modules.visualization.featurelisttable_modular.FeatureTa
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.scene.layout.BorderPane;
@@ -43,40 +42,35 @@ import org.jetbrains.annotations.Nullable;
 public class NetworkOverviewWindow extends Stage {
 
   private static final Logger logger = Logger.getLogger(NetworkOverviewWindow.class.getName());
-  private NetworkOverviewController controller;
+  private NetworkOverviewMvciController mvciController;
 
   public NetworkOverviewWindow(@NotNull ModularFeatureList featureList,
       @Nullable FeatureTableFX externalTable, @Nullable List<? extends FeatureListRow> selectedRows,
       final NetworkOverviewFlavor flavor) {
     setTitle("Network overview: " + featureList.getName());
-    setOnCloseRequest(event -> {
-      if (controller != null) {
-        controller.close();
-      }
-    });
     try {
-      // Load the window FXML
-      FXMLLoader loader = new FXMLLoader(getClass().getResource("NetworkOverviewPane.fxml"));
-      BorderPane rootPane = loader.load();
-      controller = loader.getController();
-      controller.setUp(featureList, externalTable, selectedRows, flavor);
+      mvciController = new NetworkOverviewMvciController(featureList, externalTable, selectedRows,
+          flavor);
+      setOnCloseRequest(_ -> mvciController.close());
 
-      Scene mainScene = new Scene(rootPane);
+      final Scene mainScene = new Scene(mvciController.buildView());
       mainScene.getStylesheets()
           .addAll(MZmineCore.getDesktop().getMainWindow().getScene().getStylesheets());
-      this.setScene(mainScene);
+      setScene(mainScene);
+
+      // Start graph generation on a task thread after the window is ready to show
+      mvciController.initNetwork();
     } catch (Exception ex) {
-      Scene mainScene = new Scene(
+      final Scene mainScene = new Scene(
           new BorderPane(new Label("Could not load pane, see log for more information")));
       mainScene.getStylesheets()
           .addAll(MZmineCore.getDesktop().getMainWindow().getScene().getStylesheets());
-      this.setScene(mainScene);
+      setScene(mainScene);
       logger.log(Level.WARNING, "Could not load network overview pane " + ex.getMessage(), ex);
     }
   }
 
   public NetworkOverviewController getController() {
-    return controller;
+    return mvciController != null ? mvciController.getNetworkOverviewController() : null;
   }
-
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/networking/visual/FeatureNetworkController.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/networking/visual/FeatureNetworkController.java
@@ -70,6 +70,7 @@ import org.controlsfx.control.CheckComboBox;
 import org.controlsfx.control.SearchableComboBox;
 import org.controlsfx.control.ToggleSwitch;
 import org.graphstream.graph.Node;
+import org.graphstream.graph.implementations.MultiGraph;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -97,6 +98,33 @@ public class FeatureNetworkController {
   public HBox pieGroupingBox;
 
   private FeatureNetworkPane networkPane;
+
+  /**
+   * Creates only the graph data structure – safe to call from a task thread. No JavaFX objects are
+   * created here. Pass the result to {@link #createWithGraphData} on the GUI thread.
+   */
+  public static @NotNull NetworkGraphData createGraphData(@NotNull FeatureList flist) {
+    FeatureNetworkGenerator generator = new FeatureNetworkGenerator();
+    MultiGraph fullGraph = generator.createNewGraph(flist, true, true, false);
+    return new NetworkGraphData(generator, fullGraph);
+  }
+
+  /**
+   * Creates a {@link FeatureNetworkController} using a pre-built graph. Must be called on the GUI
+   * thread.
+   *
+   * @param graphData graph built by {@link #createGraphData} on a task thread
+   */
+  public static @NotNull FeatureNetworkController createWithGraphData(@NotNull FeatureList flist,
+      @NotNull ObservableList<FeatureListRow> focussedRows, @NotNull NetworkGraphData graphData,
+      final NetworkOverviewFlavor flavor) throws IOException {
+    FXMLLoader loader = new FXMLLoader(
+        FeatureNetworkController.class.getResource("FeatureNetworkPane.fxml"));
+    loader.load();
+    FeatureNetworkController controller = loader.getController();
+    controller.initWithGraphData(flist, focussedRows, graphData, flavor);
+    return controller;
+  }
 
   /**
    * Load fxml and create network
@@ -127,15 +155,24 @@ public class FeatureNetworkController {
       final @NotNull ObservableList<FeatureListRow> focussedRows,
       final NetworkOverviewFlavor flavor) {
     // create graph and add to center
-    FeatureNetworkGenerator generator = new FeatureNetworkGenerator();
-    var fullGraph = generator.createNewGraph(flist, true, true, false);
-    networkPane = new FeatureNetworkPane(this, flist, focussedRows, generator, fullGraph);
+    final NetworkGraphData graphData = createGraphData(flist);
+    initWithGraphData(flist, focussedRows, graphData, flavor);
+  }
+
+  /**
+   * Finishes controller setup using a pre-built graph. Must be called on the GUI thread.
+   */
+  private void initWithGraphData(final @NotNull FeatureList flist,
+      final @NotNull ObservableList<FeatureListRow> focussedRows,
+      final @NotNull NetworkGraphData graphData, final NetworkOverviewFlavor flavor) {
+    networkPane = new FeatureNetworkPane(this, flist, focussedRows, graphData.generator(),
+        graphData.fullGraph());
     mainPane.setCenter(networkPane);
 
     // Filter the legend to the node/edge types actually emitted by the generator. The generator
     // tracks them in observable sets while building the graph, so the legend reflects what's in
     // this particular network instead of every possible enum value.
-    legend.bindToTypes(generator.getNodeTypes(), generator.getEdgeTypes());
+    legend.bindToTypes(graphData.generator().getNodeTypes(), graphData.generator().getEdgeTypes());
 
     addMenuOptions(flavor);
     addAnnotationFilterOptions(flist);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/networking/visual/NetworkGraphData.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/networking/visual/NetworkGraphData.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.visualization.networking.visual;
+
+import org.graphstream.graph.implementations.MultiGraph;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Holds the pre-computed graph data produced on a task thread. Pass this to
+ * {@link FeatureNetworkController#createWithGraphData} on the GUI thread to finish setup without
+ * blocking.
+ */
+public record NetworkGraphData(@NotNull FeatureNetworkGenerator generator,
+                               @NotNull MultiGraph fullGraph) {
+
+}


### PR DESCRIPTION
- opening network currently freezes GUI as it computes things on GUI thread. 
- this puts the network generation off the GUI thread, making it faster and less frozen
- Only builds a thin wrapper of MVCI around the existing network visualizer. 

Maybe we should directly convert the dashboard to a full MVCI. 
