### PR TITLE
Mass Dynamics export

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/workspace/AbstractWorkspace.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/mainwindow/workspace/AbstractWorkspace.java
@@ -91,6 +91,7 @@ import io.github.mzmine.modules.io.export_features_csv_legacy.LegacyCSVExportMod
 import io.github.mzmine.modules.io.export_features_featureML.FeatureMLExportModularModule;
 import io.github.mzmine.modules.io.export_features_gnps.fbmn.GnpsFbmnExportAndSubmitModule;
 import io.github.mzmine.modules.io.export_features_gnps.gc.GnpsGcExportAndSubmitModule;
+import io.github.mzmine.modules.io.export_features_massdynamics.MassDynamicsExportModule;
 import io.github.mzmine.modules.io.export_features_metaboanalyst.MetaboAnalystExportModule;
 import io.github.mzmine.modules.io.export_features_mgf.AdapMgfExportModule;
 import io.github.mzmine.modules.io.export_features_msp.AdapMspExportModule;
@@ -288,7 +289,8 @@ public abstract class AbstractWorkspace implements Workspace {
         ImportFeatureNetworksSimpleModule.class, ExportCorrAnnotationModule.class,
         NetworkGraphMlExportModule.class, FeatureMLExportModularModule.class,
         CcsBaseExportModule.class, ExportFeaturesDataModule.class);
-    addModuleMenuItems(menu, "Statistics", VennExportModule.class, MetaboAnalystExportModule.class);
+    addModuleMenuItems(menu, "Statistics", VennExportModule.class, MetaboAnalystExportModule.class,
+        MassDynamicsExportModule.class);
     addModuleMenuItems(menu, "Libraries", LibraryBatchGenerationModule.class,
         GNPSLibraryBatchExportModule.class, ExportScansFeatureModule.class);
 
@@ -355,8 +357,7 @@ public abstract class AbstractWorkspace implements Workspace {
         MassvoltammogramFromFeatureListModule.class);
     addSeparator(featureVis);
     addModuleMenuItems(featureVis, "Lipids", LipidAnnotationQCDashboardModule.class,
-        EquivalentCarbonNumberModule.class,
-        LipidAnnotationSummaryModule.class);
+        EquivalentCarbonNumberModule.class, LipidAnnotationSummaryModule.class);
     addModuleMenuItems(featureVis, "Dashboards", CompoundDashboardModule.class,
         IntegrationDashboardModule.class, LipidAnnotationQCDashboardModule.class,
         StatsDasboardModule.class);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModulesList.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModulesList.java
@@ -139,6 +139,7 @@ import io.github.mzmine.modules.io.export_features_csv_legacy.LegacyCSVExportMod
 import io.github.mzmine.modules.io.export_features_featureML.FeatureMLExportModularModule;
 import io.github.mzmine.modules.io.export_features_gnps.fbmn.GnpsFbmnExportAndSubmitModule;
 import io.github.mzmine.modules.io.export_features_gnps.gc.GnpsGcExportAndSubmitModule;
+import io.github.mzmine.modules.io.export_features_massdynamics.MassDynamicsExportModule;
 import io.github.mzmine.modules.io.export_features_metaboanalyst.MetaboAnalystExportModule;
 import io.github.mzmine.modules.io.export_features_mgf.AdapMgfExportModule;
 import io.github.mzmine.modules.io.export_features_msp.AdapMspExportModule;
@@ -418,6 +419,7 @@ public class BatchModeModulesList {
           ImportFeatureNetworksSimpleModule.class, //
           NetworkGraphMlExportModule.class, //
           MetaboAnalystExportModule.class, //
+          MassDynamicsExportModule.class, //
           AdapMgfExportModule.class, //
           GNPSResultsImportModule.class, //
           AdapMspExportModule.class, //

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportModule.java
@@ -39,9 +39,9 @@ import org.jetbrains.annotations.Nullable;
 public class MassDynamicsExportModule extends TaskPerFeatureListModule {
 
   public MassDynamicsExportModule() {
-    super("Export for MassDynamics", MassDynamicsExportParameters.class,
+    super("Export for Mass Dynamics", MassDynamicsExportParameters.class,
         MZmineModuleCategory.FEATURELISTEXPORT, false,
-        "Export a feature list MassDynamics metabolites format file (long table) and sample metadata files for MassDynamics.");
+        "Export a feature list Mass Dynamics metabolites format file (long table) and sample metadata files for Mass Dynamics.");
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportModule.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.io.export_features_massdynamics;
+
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.features.FeatureList;
+import io.github.mzmine.modules.MZmineModuleCategory;
+import io.github.mzmine.modules.impl.TaskPerFeatureListModule;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.taskcontrol.Task;
+import io.github.mzmine.util.MemoryMapStorage;
+import java.time.Instant;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class MassDynamicsExportModule extends TaskPerFeatureListModule {
+
+  public MassDynamicsExportModule() {
+    super("Export for MassDynamics", MassDynamicsExportParameters.class,
+        MZmineModuleCategory.FEATURELISTEXPORT, false,
+        "Export a feature list MassDynamics metabolites format file (long table) and sample metadata files for MassDynamics.");
+  }
+
+  @Override
+  public @NotNull Task createTask(@NotNull final MZmineProject project,
+      @NotNull final ParameterSet parameters, @NotNull final Instant moduleCallDate,
+      @Nullable final MemoryMapStorage storage, @NotNull final FeatureList featureList) {
+    return new MassDynamicsExportTask(storage, moduleCallDate, parameters, this.getClass(),
+        featureList);
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportParameters.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.io.export_features_massdynamics;
+
+import static io.github.mzmine.util.StringUtils.inQuotes;
+
+import io.github.mzmine.datamodel.AbundanceMeasure;
+import io.github.mzmine.modules.io.export_features_sirius.SiriusExportTask;
+import io.github.mzmine.parameters.impl.IonMobilitySupport;
+import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.AbundanceMeasureParameter;
+import io.github.mzmine.parameters.parametertypes.filenames.FileNameSuffixExportParameter;
+import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
+
+public class MassDynamicsExportParameters extends SimpleParameterSet {
+
+  public static final FeatureListsParameter featureLists = new FeatureListsParameter(1);
+
+  public static final FileNameSuffixExportParameter filename = new FileNameSuffixExportParameter(
+      "Filename",
+      "Base filename for MassDynamics files: metabolite TSV file and experiment metadata file. Use '{}' in the file name to insert the feature list name.");
+
+  public static final AbundanceMeasureParameter abundanceMeasure = new AbundanceMeasureParameter(
+      "Abundance measure", "Feature abundance written to the MetaboliteIntensity column.",
+      AbundanceMeasure.values(), AbundanceMeasure.Area);
+
+  public MassDynamicsExportParameters() {
+    super(featureLists, filename, abundanceMeasure);
+  }
+
+  @Override
+  public boolean checkParameterValues(@NotNull final Collection<String> errorMessages,
+      final boolean skipRawDataAndFeatureListParameters) {
+    final boolean superCheck = super.checkParameterValues(errorMessages,
+        skipRawDataAndFeatureListParameters);
+
+    if (getValue(featureLists).getMatchingFeatureLists().length > 1 && !getValue(filename).getName()
+        .contains(SiriusExportTask.MULTI_NAME_PATTERN)) {
+      errorMessages.add(
+          "Multiple feature lists (%d) were selected, but the file name does not contain the pattern %s.".formatted(
+              getValue(featureLists).getMatchingFeatureLists().length,
+              inQuotes(SiriusExportTask.MULTI_NAME_PATTERN)));
+    }
+
+    return superCheck && errorMessages.isEmpty();
+  }
+
+  @Override
+  public @NotNull IonMobilitySupport getIonMobilitySupport() {
+    return IonMobilitySupport.SUPPORTED;
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportParameters.java
@@ -29,11 +29,16 @@ import static io.github.mzmine.util.StringUtils.inQuotes;
 
 import io.github.mzmine.datamodel.AbundanceMeasure;
 import io.github.mzmine.modules.io.export_features_sirius.SiriusExportTask;
+import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
 import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.AbundanceMeasureParameter;
+import io.github.mzmine.parameters.parametertypes.OptionalParameter;
+import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.filenames.FileNameSuffixExportParameter;
+import io.github.mzmine.parameters.parametertypes.metadata.MetadataGroupingParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
+import io.github.mzmine.parameters.parametertypes.statistics.MissingValueImputationParameter;
 import java.util.Collection;
 import org.jetbrains.annotations.NotNull;
 
@@ -49,8 +54,19 @@ public class MassDynamicsExportParameters extends SimpleParameterSet {
       "Abundance measure", "Feature abundance written to the MetaboliteIntensity column.",
       AbundanceMeasure.values(), AbundanceMeasure.Area);
 
+  public static final MissingValueImputationParameter missingValueImputation = new MissingValueImputationParameter();
+
+  public static final MetadataGroupingParameter conditionColumn = new MetadataGroupingParameter(
+      "Condition metadata column", "Metadata column mapped to the MassDynamics condition column.",
+      MetadataColumn.SAMPLE_TYPE_HEADER);
+
+  public static final OptionalParameter<StringParameter> defaultCondition = new OptionalParameter<>(
+      new StringParameter("Default condition",
+          "Condition value used when the selected metadata column is empty.", ""), false);
+
   public MassDynamicsExportParameters() {
-    super(featureLists, filename, abundanceMeasure);
+    super(featureLists, filename, abundanceMeasure, missingValueImputation, conditionColumn,
+        defaultCondition);
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportParameters.java
@@ -48,7 +48,7 @@ public class MassDynamicsExportParameters extends SimpleParameterSet {
 
   public static final FileNameSuffixExportParameter filename = new FileNameSuffixExportParameter(
       "Filename",
-      "Base filename for MassDynamics files: metabolite TSV file and experiment metadata file. Use '{}' in the file name to insert the feature list name.");
+      "Base filename for Mass Dynamics files: metabolite TSV file and experiment metadata file. Use '{}' in the file name to insert the feature list name.");
 
   public static final AbundanceMeasureParameter abundanceMeasure = new AbundanceMeasureParameter(
       "Abundance measure", "Feature abundance written to the MetaboliteIntensity column.",
@@ -57,7 +57,7 @@ public class MassDynamicsExportParameters extends SimpleParameterSet {
   public static final MissingValueImputationParameter missingValueImputation = new MissingValueImputationParameter();
 
   public static final MetadataGroupingParameter conditionColumn = new MetadataGroupingParameter(
-      "Condition metadata column", "Metadata column mapped to the MassDynamics condition column.",
+      "Condition metadata column", "Metadata column mapped to the Mass Dynamics condition column.",
       MetadataColumn.SAMPLE_TYPE_HEADER);
 
   public static final OptionalParameter<StringParameter> defaultCondition = new OptionalParameter<>(

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportParameters.java
@@ -33,6 +33,7 @@ import io.github.mzmine.modules.visualization.projectmetadata.table.columns.Meta
 import io.github.mzmine.parameters.impl.IonMobilitySupport;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
 import io.github.mzmine.parameters.parametertypes.AbundanceMeasureParameter;
+import io.github.mzmine.parameters.parametertypes.CompoundFeatureRowSelectionParameter;
 import io.github.mzmine.parameters.parametertypes.OptionalParameter;
 import io.github.mzmine.parameters.parametertypes.StringParameter;
 import io.github.mzmine.parameters.parametertypes.filenames.FileNameSuffixExportParameter;
@@ -50,6 +51,7 @@ public class MassDynamicsExportParameters extends SimpleParameterSet {
       "Filename",
       "Base filename for Mass Dynamics files: metabolite TSV file and experiment metadata file. Use '{}' in the file name to insert the feature list name.");
 
+  public static final CompoundFeatureRowSelectionParameter compoundRowSelection = CompoundFeatureRowSelectionParameter.createDefault();
   public static final AbundanceMeasureParameter abundanceMeasure = new AbundanceMeasureParameter(
       "Abundance measure", "Feature abundance written to the MetaboliteIntensity column.",
       AbundanceMeasure.values(), AbundanceMeasure.Area);
@@ -65,7 +67,8 @@ public class MassDynamicsExportParameters extends SimpleParameterSet {
           "Condition value used when the selected metadata column is empty.", ""), false);
 
   public MassDynamicsExportParameters() {
-    super(featureLists, filename, abundanceMeasure, missingValueImputation, conditionColumn,
+    super(featureLists, compoundRowSelection, filename, abundanceMeasure, missingValueImputation,
+        conditionColumn,
         defaultCondition);
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportTask.java
@@ -116,7 +116,7 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
   protected void process() {
     final File flistFilename = getFileForFeatureList(featureList, this.baseFileName);
     if (flistFilename == null) {
-      error("Could not create directories for MassDynamics export file " + this.baseFileName);
+      error("Could not create directories for Mass Dynamics export file " + this.baseFileName);
       return;
     }
 
@@ -132,8 +132,8 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
       exportFeatureList(writer);
     } catch (IOException e) {
       logger.log(Level.WARNING,
-          "Error during MassDynamics metabolite export to " + flistFilename.getAbsolutePath(), e);
-      error("Could not export MassDynamics metabolite TSV to " + flistFilename.getAbsolutePath(),
+          "Error during Mass Dynamics metabolite export to " + flistFilename.getAbsolutePath(), e);
+      error("Could not export Mass Dynamics metabolite TSV to " + flistFilename.getAbsolutePath(),
           e);
       return;
     }
@@ -147,7 +147,7 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
     }
 
     logger.info(
-        () -> "Exported MassDynamics files for feature list " + featureList.getName() + " to "
+        () -> "Exported Mass Dynamics files for feature list " + featureList.getName() + " to "
             + flistFilename.getParent());
   }
 
@@ -162,7 +162,7 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
     metadataTask.run();
 
     if (metadataTask.getStatus() == TaskStatus.ERROR) {
-      error("Could not export MassDynamics metadata CSV to " + file.getAbsolutePath() + ": "
+      error("Could not export Mass Dynamics metadata CSV to " + file.getAbsolutePath() + ": "
           + Objects.toString(metadataTask.getErrorMessage(), ""));
       return false;
     }
@@ -171,7 +171,7 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
       return false;
     }
     if (metadataTask.getStatus() != TaskStatus.FINISHED) {
-      error("Could not export MassDynamics metadata CSV to " + file.getAbsolutePath());
+      error("Could not export Mass Dynamics metadata CSV to " + file.getAbsolutePath());
       return false;
     }
 
@@ -290,6 +290,6 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
 
   @Override
   public @NotNull String getTaskDescription() {
-    return "Exporting feature list " + featureList.getName() + " for MassDynamics";
+    return "Exporting feature list " + featureList.getName() + " for Mass Dynamics";
   }
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportTask.java
@@ -33,14 +33,22 @@ import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularDataModel;
 import io.github.mzmine.datamodel.features.compoundannotations.FeatureAnnotation;
+import io.github.mzmine.datamodel.statistics.FeaturesDataTable;
 import io.github.mzmine.modules.MZmineModule;
+import io.github.mzmine.modules.dataanalysis.utils.StatisticUtils;
+import io.github.mzmine.modules.dataanalysis.utils.imputation.ImputationFunctions;
 import io.github.mzmine.modules.io.export_features_sirius.SiriusExportTask;
+import io.github.mzmine.modules.visualization.projectmetadata.io.ProjectMetadataColumnMapping;
 import io.github.mzmine.modules.visualization.projectmetadata.io.ProjectMetadataExportParameters;
 import io.github.mzmine.modules.visualization.projectmetadata.io.ProjectMetadataExportParameters.MetadataFileFormat;
-import io.github.mzmine.modules.visualization.projectmetadata.io.ProjectMetadataWriter;
+import io.github.mzmine.modules.visualization.projectmetadata.io.ProjectMetadataExportTask;
+import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTable;
+import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
 import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.parametertypes.statistics.AbundanceDataTablePreparationConfig;
 import io.github.mzmine.project.ProjectService;
 import io.github.mzmine.taskcontrol.AbstractFeatureListTask;
+import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.CSVParsingUtils;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.files.FileAndPathUtil;
@@ -49,11 +57,14 @@ import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
 
 public class MassDynamicsExportTask extends AbstractFeatureListTask {
 
@@ -69,6 +80,14 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
   private final FeatureList featureList;
   private final File baseFileName;
   private final AbundanceMeasure abundanceMeasure;
+  private final ImputationFunctions missingValueImputation;
+  private final String conditionColumn;
+  private final String defaultCondition;
+  private final List<RawDataFile> rawDataFiles;
+  private FeaturesDataTable dataTable;
+  private @NotNull MetadataTable metadata;
+  private @NotNull MetadataColumn<String> sampleNameColumn;
+  private @Nullable Map<RawDataFile, Object> sampleNamesMap;
 
   protected MassDynamicsExportTask(@Nullable final MemoryMapStorage storage,
       @NotNull final Instant moduleCallDate, @NotNull final ParameterSet parameters,
@@ -78,7 +97,14 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
     this.featureList = featureList;
     this.baseFileName = parameters.getValue(MassDynamicsExportParameters.filename);
     this.abundanceMeasure = parameters.getValue(MassDynamicsExportParameters.abundanceMeasure);
-    totalItems = (long) featureList.getNumberOfRows() * featureList.getRawDataFiles().size() + 2;
+    this.missingValueImputation = parameters.getValue(
+        MassDynamicsExportParameters.missingValueImputation);
+    this.conditionColumn = parameters.getValue(MassDynamicsExportParameters.conditionColumn);
+    this.defaultCondition = parameters.getEmbeddedParameterValueIfSelectedOrElseGet(
+        MassDynamicsExportParameters.defaultCondition, () -> "");
+
+    rawDataFiles = featureList.getRawDataFiles();
+    totalItems = (long) featureList.getNumberOfRows() * rawDataFiles.size() + 1;
   }
 
   @Override
@@ -94,8 +120,12 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
       return;
     }
 
+    metadata = ProjectService.getMetadata();
+    sampleNameColumn = metadata.getSampleNameColumn();
+    sampleNamesMap = metadata.getColumnData(sampleNameColumn);
+
     final File metaboliteFile = FileAndPathUtil.getRealFilePathWithSuffix(flistFilename,
-        METABOLITE_SUFFIX + ".tsv");
+        METABOLITE_SUFFIX + "." + METABOLITE_EXTENSION);
 
     try (final ICSVWriter writer = CSVParsingUtils.createDefaultWriter(metaboliteFile, '\t',
         WriterOptions.REPLACE)) {
@@ -108,10 +138,11 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
       return;
     }
 
-    final ProjectMetadataWriter metadataWriter = new ProjectMetadataWriter(
-        ProjectService.getProject().getProjectMetadata(), MetadataFileFormat.MASS_DYNAMICS,
-        ProjectMetadataExportParameters.MASS_DYNAMICS_DEFAULT_MAPPINGS);
-    if (!exportMetadata(metadataWriter, getExperimentMetadataFile(flistFilename))) {
+    if (isCanceled()) {
+      return;
+    }
+
+    if (!exportMetadata(getExperimentMetadataFile(flistFilename))) {
       return;
     }
 
@@ -120,54 +151,117 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
             + flistFilename.getParent());
   }
 
-  private boolean exportMetadata(@NotNull final ProjectMetadataWriter metadataWriter,
-      @NotNull final File file) {
-    if (!metadataWriter.exportTo(file, featureList.getRawDataFiles())) {
+  private boolean exportMetadata(@NotNull final File file) {
+    final ParameterSet metadataParameters = ProjectMetadataExportParameters.create(file, false,
+        MetadataFileFormat.MASS_DYNAMICS);
+    metadataParameters.setParameter(ProjectMetadataExportParameters.columnMappings, true,
+        List.of(new ProjectMetadataColumnMapping(conditionColumn, "condition", defaultCondition)));
+
+    final ProjectMetadataExportTask metadataTask = new ProjectMetadataExportTask(moduleCallDate,
+        metadataParameters, featureList.getRawDataFiles());
+    metadataTask.run();
+
+    if (metadataTask.getStatus() == TaskStatus.ERROR) {
+      error("Could not export MassDynamics metadata CSV to " + file.getAbsolutePath() + ": "
+          + Objects.toString(metadataTask.getErrorMessage(), ""));
+      return false;
+    }
+    if (metadataTask.getStatus() == TaskStatus.CANCELED) {
+      cancel();
+      return false;
+    }
+    if (metadataTask.getStatus() != TaskStatus.FINISHED) {
       error("Could not export MassDynamics metadata CSV to " + file.getAbsolutePath());
       return false;
     }
+
     incrementFinishedItems();
     return true;
   }
 
   private void exportFeatureList(@NotNull final ICSVWriter writer) {
     writer.writeNext(HEADER);
-    final List<RawDataFile> rawDataFiles = featureList.getRawDataFiles();
+
+    prepareImputedIntensities();
     for (final FeatureListRow row : featureList.getRows()) {
       for (final RawDataFile rawDataFile : rawDataFiles) {
+        final @NotNull String[] line = createLine(row, rawDataFile);
         if (isCanceled()) {
           return;
         }
 
-        writer.writeNext(createLine(row, rawDataFile));
+        writer.writeNext(line);
         incrementFinishedItems();
       }
     }
   }
 
-  private @NotNull String[] createLine(@NotNull final FeatureListRow row,
+  private @Nullable String[] createLine(@NotNull final FeatureListRow row,
       @NotNull final RawDataFile rawDataFile) {
+
+    final Object sampleName = sampleNamesMap.get(rawDataFile);
+    if (sampleName == null) {
+      final String missingNames = rawDataFiles.stream()
+          .filter(raw -> sampleNamesMap.get(raw) == null).map(RawDataFile::getName).sorted()
+          .collect(Collectors.joining("\n"));
+      error("""
+          %s metadata column has sample name for data files:
+          %s""".formatted(sampleNameColumn.getTitle(), missingNames));
+      return null;
+    }
+
+
     final FeatureAnnotation annotation = row.getPreferredAnnotation();
     final Feature feature = row.getFeature(rawDataFile);
-    final Float abundance = getAbundance(feature);
-    final boolean imputed = abundance == null || !Float.isFinite(abundance) || abundance <= 0f;
+    final Float rawAbundance = getAbundance(feature);
+    final boolean imputed = isMissingAbundance(rawAbundance);
     final String metaboliteId = getMetaboliteId(row);
 
+    // maybe missing value imputed
+    final double actualAbundance = getActualImputedAbundance(row, rawDataFile);
     return new String[]{metaboliteId,
         firstNotBlank(annotation == null ? null : annotation.getCompoundName(), metaboliteId),
         text(annotation == null ? null : annotation.getSmiles()),
         text(annotation == null ? null : annotation.getIsomericSmiles()),
         text(annotation == null ? null : annotation.getInChI()),
         text(annotation == null ? null : annotation.getInChIKey()), "", "",
-        text(row.getAverageMZ()), text(row.getAverageRT()), rawDataFile.getName(),
-        imputed ? "0.0" : abundance.toString(), imputed ? "1" : "0"};
+        text(row.getAverageMZ()), text(row.getAverageRT()), sampleName.toString(),
+        imputed ? Double.toString(actualAbundance) : rawAbundance.toString(), imputed ? "1" : "0"};
+  }
+
+  /**
+   * Always a finite value, never NaN
+   */
+  private double getActualImputedAbundance(@NonNull FeatureListRow row,
+      @NonNull RawDataFile rawDataFile) {
+    final double value = dataTable.getValue(row, rawDataFile);
+    if (Double.compare(value, 0d) <= 0 || !Double.isFinite(value)) {
+      return 0d;
+    }
+    return value;
   }
 
   private @Nullable Float getAbundance(@Nullable final Feature feature) {
     if (feature == null) {
       return null;
     }
-    return abundanceMeasure.get((ModularDataModel) feature);
+    return switch (abundanceMeasure) {
+      case Area -> feature.getArea();
+      case Height -> feature.getHeight();
+      case NORMALIZED_AREA, NORMALIZED_HEIGHT ->
+          feature instanceof ModularDataModel dataModel ? abundanceMeasure.get(dataModel) : null;
+    };
+  }
+
+  private void prepareImputedIntensities() {
+    final var config = new AbundanceDataTablePreparationConfig(abundanceMeasure,
+        missingValueImputation);
+    dataTable = StatisticUtils.extractAbundancesPrepareData(featureList.getRows(),
+        featureList.getRawDataFiles(), config);
+  }
+
+  private static boolean isMissingAbundance(@Nullable final Float abundance) {
+    return abundance == null || !Float.isFinite(abundance) || abundance <= 0f;
   }
 
   private static @NotNull String getMetaboliteId(@NotNull final FeatureListRow row) {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportTask.java
@@ -73,8 +73,9 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
   private static final String METABOLITE_EXTENSION = "tsv";
   private static final String METABOLITE_SUFFIX = "_massdynamics_metabolite";
   private static final String EXPERIMENT_METADATA_SUFFIX = "_massdynamics_experiment_metadata";
-  private static final String[] HEADER = {"MetaboliteId", "MetaboliteName", "Smiles",
-      "IsomericSmiles", "InChI", "InChIKey", "HMDB", "KEGG", "mz", "RetentionTime", "SampleName",
+  public static final String[] HEADER = {"MetaboliteId", "MetaboliteName", "Smiles",
+      "IsomericSmiles", "InChI", "InChIKey", "HMDB", "KEGG", "mz", "RetentionTime", "CCS",
+      "IonMobility", "SampleName",
       "MetaboliteIntensity", "Imputed"};
 
   private final FeatureList featureList;
@@ -225,7 +226,11 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
         text(annotation == null ? null : annotation.getIsomericSmiles()),
         text(annotation == null ? null : annotation.getInChI()),
         text(annotation == null ? null : annotation.getInChIKey()), "", "",
-        text(row.getAverageMZ()), text(row.getAverageRT()), sampleName.toString(),
+        text(row.getAverageMZ()), //
+        text(row.getAverageRT()),  //
+        text(row.getAverageCCS()),  //
+        text(row.getAverageMobility()),  //
+        sampleName.toString(), //
         imputed ? Double.toString(actualAbundance) : rawAbundance.toString(), imputed ? "1" : "0"};
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportTask.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.io.export_features_massdynamics;
+
+import com.opencsv.ICSVWriter;
+import io.github.mzmine.datamodel.AbundanceMeasure;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.features.Feature;
+import io.github.mzmine.datamodel.features.FeatureList;
+import io.github.mzmine.datamodel.features.FeatureListRow;
+import io.github.mzmine.datamodel.features.ModularDataModel;
+import io.github.mzmine.datamodel.features.compoundannotations.FeatureAnnotation;
+import io.github.mzmine.modules.MZmineModule;
+import io.github.mzmine.modules.io.export_features_sirius.SiriusExportTask;
+import io.github.mzmine.modules.visualization.projectmetadata.io.ProjectMetadataExportParameters;
+import io.github.mzmine.modules.visualization.projectmetadata.io.ProjectMetadataExportParameters.MetadataFileFormat;
+import io.github.mzmine.modules.visualization.projectmetadata.io.ProjectMetadataWriter;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.project.ProjectService;
+import io.github.mzmine.taskcontrol.AbstractFeatureListTask;
+import io.github.mzmine.util.CSVParsingUtils;
+import io.github.mzmine.util.MemoryMapStorage;
+import io.github.mzmine.util.files.FileAndPathUtil;
+import io.github.mzmine.util.io.WriterOptions;
+import java.io.File;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class MassDynamicsExportTask extends AbstractFeatureListTask {
+
+  private static final Logger logger = Logger.getLogger(MassDynamicsExportTask.class.getName());
+
+  private static final String METABOLITE_EXTENSION = "tsv";
+  private static final String METABOLITE_SUFFIX = "_massdynamics_metabolite";
+  private static final String EXPERIMENT_METADATA_SUFFIX = "_massdynamics_experiment_metadata";
+  private static final String[] HEADER = {"MetaboliteId", "MetaboliteName", "Smiles",
+      "IsomericSmiles", "InChI", "InChIKey", "HMDB", "KEGG", "mz", "RetentionTime", "SampleName",
+      "MetaboliteIntensity", "Imputed"};
+
+  private final FeatureList featureList;
+  private final File baseFileName;
+  private final AbundanceMeasure abundanceMeasure;
+
+  protected MassDynamicsExportTask(@Nullable final MemoryMapStorage storage,
+      @NotNull final Instant moduleCallDate, @NotNull final ParameterSet parameters,
+      @NotNull final Class<? extends MZmineModule> moduleClass,
+      @NotNull final FeatureList featureList) {
+    super(storage, moduleCallDate, parameters, moduleClass);
+    this.featureList = featureList;
+    this.baseFileName = parameters.getValue(MassDynamicsExportParameters.filename);
+    this.abundanceMeasure = parameters.getValue(MassDynamicsExportParameters.abundanceMeasure);
+    totalItems = (long) featureList.getNumberOfRows() * featureList.getRawDataFiles().size() + 2;
+  }
+
+  @Override
+  protected @NotNull List<FeatureList> getProcessedFeatureLists() {
+    return List.of(featureList);
+  }
+
+  @Override
+  protected void process() {
+    final File flistFilename = getFileForFeatureList(featureList, this.baseFileName);
+    if (flistFilename == null) {
+      error("Could not create directories for MassDynamics export file " + this.baseFileName);
+      return;
+    }
+
+    final File metaboliteFile = FileAndPathUtil.getRealFilePathWithSuffix(flistFilename,
+        METABOLITE_SUFFIX + ".tsv");
+
+    try (final ICSVWriter writer = CSVParsingUtils.createDefaultWriter(metaboliteFile, '\t',
+        WriterOptions.REPLACE)) {
+      exportFeatureList(writer);
+    } catch (IOException e) {
+      logger.log(Level.WARNING,
+          "Error during MassDynamics metabolite export to " + flistFilename.getAbsolutePath(), e);
+      error("Could not export MassDynamics metabolite TSV to " + flistFilename.getAbsolutePath(),
+          e);
+      return;
+    }
+
+    final ProjectMetadataWriter metadataWriter = new ProjectMetadataWriter(
+        ProjectService.getProject().getProjectMetadata(), MetadataFileFormat.MASS_DYNAMICS,
+        ProjectMetadataExportParameters.MASS_DYNAMICS_DEFAULT_MAPPINGS);
+    if (!exportMetadata(metadataWriter, getExperimentMetadataFile(flistFilename))) {
+      return;
+    }
+
+    logger.info(
+        () -> "Exported MassDynamics files for feature list " + featureList.getName() + " to "
+            + flistFilename.getParent());
+  }
+
+  private boolean exportMetadata(@NotNull final ProjectMetadataWriter metadataWriter,
+      @NotNull final File file) {
+    if (!metadataWriter.exportTo(file, featureList.getRawDataFiles())) {
+      error("Could not export MassDynamics metadata CSV to " + file.getAbsolutePath());
+      return false;
+    }
+    incrementFinishedItems();
+    return true;
+  }
+
+  private void exportFeatureList(@NotNull final ICSVWriter writer) {
+    writer.writeNext(HEADER);
+    final List<RawDataFile> rawDataFiles = featureList.getRawDataFiles();
+    for (final FeatureListRow row : featureList.getRows()) {
+      for (final RawDataFile rawDataFile : rawDataFiles) {
+        if (isCanceled()) {
+          return;
+        }
+
+        writer.writeNext(createLine(row, rawDataFile));
+        incrementFinishedItems();
+      }
+    }
+  }
+
+  private @NotNull String[] createLine(@NotNull final FeatureListRow row,
+      @NotNull final RawDataFile rawDataFile) {
+    final FeatureAnnotation annotation = row.getPreferredAnnotation();
+    final Feature feature = row.getFeature(rawDataFile);
+    final Float abundance = getAbundance(feature);
+    final boolean imputed = abundance == null || !Float.isFinite(abundance) || abundance <= 0f;
+    final String metaboliteId = getMetaboliteId(row);
+
+    return new String[]{metaboliteId,
+        firstNotBlank(annotation == null ? null : annotation.getCompoundName(), metaboliteId),
+        text(annotation == null ? null : annotation.getSmiles()),
+        text(annotation == null ? null : annotation.getIsomericSmiles()),
+        text(annotation == null ? null : annotation.getInChI()),
+        text(annotation == null ? null : annotation.getInChIKey()), "", "",
+        text(row.getAverageMZ()), text(row.getAverageRT()), rawDataFile.getName(),
+        imputed ? "0.0" : abundance.toString(), imputed ? "1" : "0"};
+  }
+
+  private @Nullable Float getAbundance(@Nullable final Feature feature) {
+    if (feature == null) {
+      return null;
+    }
+    return abundanceMeasure.get((ModularDataModel) feature);
+  }
+
+  private static @NotNull String getMetaboliteId(@NotNull final FeatureListRow row) {
+    return "row_" + row.getID();
+  }
+
+  private static @NotNull String firstNotBlank(@Nullable final String first,
+      @NotNull final String fallback) {
+    return first == null || first.isBlank() ? fallback : first;
+  }
+
+  private static @NotNull String text(@Nullable final Object value) {
+    return Objects.toString(value, "");
+  }
+
+  static @Nullable File getFileForFeatureList(@NotNull final FeatureList featureList,
+      @NotNull final File file) {
+    return SiriusExportTask.getFileForFeatureList(featureList, file,
+        SiriusExportTask.MULTI_NAME_PATTERN, METABOLITE_EXTENSION);
+  }
+
+  static @NotNull File getExperimentMetadataFile(@NotNull final File metaboliteFile) {
+    return FileAndPathUtil.getRealFilePathWithSuffix(metaboliteFile, EXPERIMENT_METADATA_SUFFIX,
+        "csv");
+  }
+
+  @Override
+  public @NotNull String getTaskDescription() {
+    return "Exporting feature list " + featureList.getName() + " for MassDynamics";
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportTask.java
@@ -33,6 +33,9 @@ import io.github.mzmine.datamodel.features.FeatureList;
 import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.ModularDataModel;
 import io.github.mzmine.datamodel.features.compoundannotations.FeatureAnnotation;
+import io.github.mzmine.datamodel.features.compoundlist.CompoundRow;
+import io.github.mzmine.datamodel.features.compoundlist.CompoundRowSelection;
+import io.github.mzmine.datamodel.features.compoundlist.MissingCompoundListException;
 import io.github.mzmine.datamodel.statistics.FeaturesDataTable;
 import io.github.mzmine.modules.MZmineModule;
 import io.github.mzmine.modules.dataanalysis.utils.StatisticUtils;
@@ -84,7 +87,9 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
   private final ImputationFunctions missingValueImputation;
   private final String conditionColumn;
   private final String defaultCondition;
+  private final CompoundRowSelection rowSelection;
   private final List<RawDataFile> rawDataFiles;
+  private @NotNull List<FeatureListRow> exportedRows = List.of();
   private FeaturesDataTable dataTable;
   private @NotNull MetadataTable metadata;
   private @NotNull MetadataColumn<String> sampleNameColumn;
@@ -103,8 +108,10 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
     this.conditionColumn = parameters.getValue(MassDynamicsExportParameters.conditionColumn);
     this.defaultCondition = parameters.getEmbeddedParameterValueIfSelectedOrElseGet(
         MassDynamicsExportParameters.defaultCondition, () -> "");
+    this.rowSelection = parameters.getValue(MassDynamicsExportParameters.compoundRowSelection);
 
     rawDataFiles = featureList.getRawDataFiles();
+    // rows are resolved in process() where a missing compound list is reported as a task error
     totalItems = (long) featureList.getNumberOfRows() * rawDataFiles.size() + 1;
   }
 
@@ -120,6 +127,15 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
       error("Could not create directories for Mass Dynamics export file " + this.baseFileName);
       return;
     }
+
+    try {
+      // resolve compound / major ion / all rows depending on the selected level
+      exportedRows = List.copyOf(featureList.getRowsCopy(rowSelection));
+    } catch (MissingCompoundListException e) {
+      error(e.getMessage(), e);
+      return;
+    }
+    totalItems = (long) exportedRows.size() * rawDataFiles.size() + 1;
 
     metadata = ProjectService.getMetadata();
     sampleNameColumn = metadata.getSampleNameColumn();
@@ -184,7 +200,7 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
     writer.writeNext(HEADER);
 
     prepareImputedIntensities();
-    for (final FeatureListRow row : featureList.getRows()) {
+    for (final FeatureListRow row : exportedRows) {
       for (final RawDataFile rawDataFile : rawDataFiles) {
         final @NotNull String[] line = createLine(row, rawDataFile);
         if (isCanceled()) {
@@ -261,7 +277,7 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
   private void prepareImputedIntensities() {
     final var config = new AbundanceDataTablePreparationConfig(abundanceMeasure,
         missingValueImputation);
-    dataTable = StatisticUtils.extractAbundancesPrepareData(featureList.getRows(),
+    dataTable = StatisticUtils.extractAbundancesPrepareData(exportedRows,
         featureList.getRawDataFiles(), config);
   }
 
@@ -270,6 +286,9 @@ public class MassDynamicsExportTask extends AbstractFeatureListTask {
   }
 
   private static @NotNull String getMetaboliteId(@NotNull final FeatureListRow row) {
+    if (row instanceof CompoundRow crow) {
+      return "compound_" + crow.getCompoundId();
+    }
     return "row_" + row.getID();
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataColumnMapping.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataColumnMapping.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.visualization.projectmetadata.io;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public record ProjectMetadataColumnMapping(@NotNull String sourceColumn,
+                                           @NotNull String targetColumn,
+                                           @NotNull String defaultValue) {
+
+  public ProjectMetadataColumnMapping {
+    sourceColumn = sanitize(sourceColumn);
+    targetColumn = sanitize(targetColumn);
+    defaultValue = sanitize(defaultValue);
+  }
+
+  public boolean isEmpty() {
+    return sourceColumn.isBlank() && targetColumn.isBlank() && defaultValue.isBlank();
+  }
+
+  public boolean isActive() {
+    return !sourceColumn.isBlank() && !targetColumn.isBlank();
+  }
+
+  private static @NotNull String sanitize(@Nullable final String value) {
+    return value == null ? "" : value.trim();
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataColumnMappingsComponent.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataColumnMappingsComponent.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.visualization.projectmetadata.io;
+
+import io.github.mzmine.javafx.components.factories.FxTextFields;
+import io.github.mzmine.javafx.components.util.FxLayout;
+import io.github.mzmine.javafx.dialogs.DialogLoggerUtil;
+import io.github.mzmine.javafx.util.FxIconUtil;
+import io.github.mzmine.javafx.util.FxIcons;
+import io.github.mzmine.parameters.parametertypes.metadata.MetadataGroupingComponent;
+import java.util.ArrayList;
+import java.util.List;
+import javafx.geometry.Insets;
+import javafx.scene.control.ButtonBase;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class ProjectMetadataColumnMappingsComponent extends VBox {
+
+  private static final String TARGET_TOOLTIP = """
+      Export column name that receives values from the selected metadata column.""";
+  private static final String DEFAULT_VALUE_TOOLTIP = """
+      Value written when the selected source metadata column has no value for a raw data file.""";
+
+  private final List<MappingRow> rows = new ArrayList<>();
+  private final VBox rowsPane = FxLayout.newVBox(Insets.EMPTY);
+
+  public ProjectMetadataColumnMappingsComponent() {
+    super(FxLayout.DEFAULT_SPACE);
+    setPadding(Insets.EMPTY);
+
+    final ButtonBase addButton = FxIconUtil.newIconButton(FxIcons.PLUS_CIRCLE,
+        "Add metadata column mapping", this::addEmptyRow);
+    getChildren().addAll(rowsPane, addButton);
+    addEmptyRow();
+  }
+
+  public @NotNull List<ProjectMetadataColumnMapping> getValue() {
+    return rows.stream().map(MappingRow::getValue).filter(mapping -> !mapping.isEmpty()).toList();
+  }
+
+  public void setValue(@Nullable final List<ProjectMetadataColumnMapping> mappings) {
+    rows.clear();
+    rowsPane.getChildren().clear();
+
+    if (mappings != null) {
+      mappings.forEach(this::addRow);
+    }
+    if (rows.isEmpty()) {
+      addEmptyRow();
+    }
+  }
+
+  public boolean hasActiveMappings() {
+    return getValue().stream().anyMatch(ProjectMetadataColumnMapping::isActive);
+  }
+
+  private void addEmptyRow() {
+    addRow(new ProjectMetadataColumnMapping("", "", ""));
+  }
+
+  private void addRow(@NotNull final ProjectMetadataColumnMapping mapping) {
+    final MappingRow row = new MappingRow(mapping);
+    rows.add(row);
+    rowsPane.getChildren().add(row.pane());
+  }
+
+  private void removeRow(@NotNull final MappingRow row) {
+    final ProjectMetadataColumnMapping mapping = row.getValue();
+    final String title = mapping.targetColumn().isBlank() ? "Remove metadata mapping?"
+        : "Remove mapping to " + mapping.targetColumn() + "?";
+    if (!DialogLoggerUtil.showDialogYesNo(title, "Remove this export metadata mapping row?")) {
+      return;
+    }
+
+    rows.remove(row);
+    rowsPane.getChildren().remove(row.pane());
+    if (rows.isEmpty()) {
+      addEmptyRow();
+    }
+  }
+
+  private final class MappingRow {
+
+    private final MetadataGroupingComponent sourceColumn = new MetadataGroupingComponent();
+    private final TextField targetColumn = FxTextFields.newAutoGrowTextField(null, "column name",
+        TARGET_TOOLTIP, 8, 30);
+    private final TextField defaultValue = FxTextFields.newAutoGrowTextField(null, "default",
+        DEFAULT_VALUE_TOOLTIP, 6, 30);
+    private final HBox pane;
+
+    private MappingRow(@NotNull final ProjectMetadataColumnMapping mapping) {
+      sourceColumn.setValue(mapping.sourceColumn());
+      targetColumn.setText(mapping.targetColumn());
+      defaultValue.setText(mapping.defaultValue());
+
+      final ButtonBase removeButton = FxIconUtil.newIconButton(FxIcons.X_CIRCLE,
+          "Remove metadata column mapping", () -> removeRow(this));
+      pane = FxLayout.newHBox(Insets.EMPTY, sourceColumn, new Label("map to"), targetColumn,
+          defaultValue, removeButton);
+    }
+
+    private @NotNull ProjectMetadataColumnMapping getValue() {
+      return new ProjectMetadataColumnMapping(sourceColumn.getValue(), targetColumn.getText(),
+          defaultValue.getText());
+    }
+
+    private @NotNull HBox pane() {
+      return pane;
+    }
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataColumnMappingsParameter.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataColumnMappingsParameter.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.visualization.projectmetadata.io;
+
+import io.github.mzmine.parameters.UserParameter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+public class ProjectMetadataColumnMappingsParameter implements
+    UserParameter<List<ProjectMetadataColumnMapping>, ProjectMetadataColumnMappingsComponent> {
+
+  private static final String NAME = "Export column mappings";
+  private static final String DESCRIPTION = """
+      Map project metadata columns to additional or existing export columns. Empty source values are replaced by the default value.""";
+  private static final String ELEMENT_MAPPING = "mapping";
+  private static final String ATTRIBUTE_SOURCE = "source";
+  private static final String ATTRIBUTE_TARGET = "target";
+  private static final String ATTRIBUTE_DEFAULT_VALUE = "default";
+
+  private @NotNull List<ProjectMetadataColumnMapping> value;
+
+  public ProjectMetadataColumnMappingsParameter() {
+    this(List.of());
+  }
+
+  private ProjectMetadataColumnMappingsParameter(
+      @Nullable final List<ProjectMetadataColumnMapping> value) {
+    setValue(value);
+  }
+
+  @Override
+  public @NotNull String getName() {
+    return NAME;
+  }
+
+  @Override
+  public @NotNull List<ProjectMetadataColumnMapping> getValue() {
+    return value;
+  }
+
+  @Override
+  public void setValue(@Nullable final List<ProjectMetadataColumnMapping> newValue) {
+    value = newValue == null ? List.of()
+        : newValue.stream().filter(mapping -> mapping != null && !mapping.isEmpty()).toList();
+  }
+
+  @Override
+  public boolean checkValue(@NotNull final Collection<String> errorMessages) {
+    for (final ProjectMetadataColumnMapping mapping : value) {
+      if (!mapping.isActive()) {
+        errorMessages.add("Metadata export mappings require source and target column names.");
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public void loadValueFromXML(@NotNull final Element xmlElement) {
+    final NodeList items = xmlElement.getElementsByTagName(ELEMENT_MAPPING);
+    final List<ProjectMetadataColumnMapping> loaded = new ArrayList<>();
+    for (int i = 0; i < items.getLength(); i++) {
+      final Element mappingElement = (Element) items.item(i);
+      loaded.add(new ProjectMetadataColumnMapping(mappingElement.getAttribute(ATTRIBUTE_SOURCE),
+          mappingElement.getAttribute(ATTRIBUTE_TARGET),
+          mappingElement.getAttribute(ATTRIBUTE_DEFAULT_VALUE)));
+    }
+    setValue(loaded);
+  }
+
+  @Override
+  public void saveValueToXML(@NotNull final Element xmlElement) {
+    final Document parentDocument = xmlElement.getOwnerDocument();
+    for (final ProjectMetadataColumnMapping mapping : value) {
+      final Element mappingElement = parentDocument.createElement(ELEMENT_MAPPING);
+      mappingElement.setAttribute(ATTRIBUTE_SOURCE, mapping.sourceColumn());
+      mappingElement.setAttribute(ATTRIBUTE_TARGET, mapping.targetColumn());
+      mappingElement.setAttribute(ATTRIBUTE_DEFAULT_VALUE, mapping.defaultValue());
+      xmlElement.appendChild(mappingElement);
+    }
+  }
+
+  @Override
+  public @NotNull String getDescription() {
+    return DESCRIPTION;
+  }
+
+  @Override
+  public @NotNull ProjectMetadataColumnMappingsComponent createEditingComponent() {
+    return new ProjectMetadataColumnMappingsComponent();
+  }
+
+  @Override
+  public void setValueFromComponent(
+      @NotNull final ProjectMetadataColumnMappingsComponent component) {
+    setValue(component.getValue());
+  }
+
+  @Override
+  public void setValueToComponent(@NotNull final ProjectMetadataColumnMappingsComponent component,
+      @Nullable final List<ProjectMetadataColumnMapping> newValue) {
+    component.setValue(newValue);
+  }
+
+  @Override
+  public @NotNull ProjectMetadataColumnMappingsParameter cloneParameter() {
+    return new ProjectMetadataColumnMappingsParameter(value);
+  }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataExportParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataExportParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,14 +25,25 @@
 
 package io.github.mzmine.modules.visualization.projectmetadata.io;
 
+import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
 import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.dialogs.ParameterSetupDialog;
 import io.github.mzmine.parameters.impl.SimpleParameterSet;
+import io.github.mzmine.parameters.parametertypes.ComboComponent;
 import io.github.mzmine.parameters.parametertypes.ComboParameter;
+import io.github.mzmine.parameters.parametertypes.OptionalParameter;
+import io.github.mzmine.parameters.parametertypes.OptionalParameterComponent;
 import io.github.mzmine.parameters.parametertypes.filenames.FileNameSuffixExportParameter;
+import io.github.mzmine.util.ExitCode;
 import io.github.mzmine.util.files.ExtensionFilters;
 import java.io.File;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ProjectMetadataExportParameters extends SimpleParameterSet {
+
+  private static final double SETUP_DIALOG_WIDTH = 750;
 
   public enum MetadataFileFormat {
     DEFAULT,
@@ -43,7 +54,11 @@ public class ProjectMetadataExportParameters extends SimpleParameterSet {
     /**
      * GNPS requires Filename and then all other columns with ATTRIBUTE_ prefix
      */
-    GNPS;
+    GNPS,
+    /**
+     * MassDynamics export
+     */
+    MASS_DYNAMICS;
 
     @Override
     public String toString() {
@@ -51,9 +66,13 @@ public class ProjectMetadataExportParameters extends SimpleParameterSet {
         case DEFAULT -> "Default";
         case MZMINE_INTERNAL -> "mzmine internal";
         case GNPS -> "GNPS";
+        case MASS_DYNAMICS -> "MassDynamics";
       };
     }
   }
+
+  public static final List<ProjectMetadataColumnMapping> MASS_DYNAMICS_DEFAULT_MAPPINGS = List.of(
+      new ProjectMetadataColumnMapping(MetadataColumn.SAMPLE_TYPE_HEADER, "condition", ""));
 
   public static final FileNameSuffixExportParameter fileName = new FileNameSuffixExportParameter(
       "Metadata file", """
@@ -62,19 +81,63 @@ public class ProjectMetadataExportParameters extends SimpleParameterSet {
   public static final ComboParameter<MetadataFileFormat> format = new ComboParameter<>("Format",
       "Format to export the metadata in", MetadataFileFormat.values(), MetadataFileFormat.DEFAULT);
 
+  public static final OptionalParameter<ProjectMetadataColumnMappingsParameter> columnMappings = new OptionalParameter<>(
+      new ProjectMetadataColumnMappingsParameter(), false);
+
   public ProjectMetadataExportParameters() {
-    super(fileName, format);
+    super(fileName, format, columnMappings);
   }
 
-  public static ParameterSet create(final File file, final boolean appendSuffix,
-      final MetadataFileFormat mFormat) {
-    ParameterSet params = new ProjectMetadataExportParameters().cloneParameterSet();
+  @Override
+  public @NotNull ExitCode showSetupDialog(final boolean valueCheckRequired) {
+    final ParameterSetupDialog dialog = new ParameterSetupDialog(valueCheckRequired, this);
+    // parameter needs more space
+    dialog.setMinWidth(SETUP_DIALOG_WIDTH);
+    dialog.setWidth(SETUP_DIALOG_WIDTH);
+    final ComboComponent<MetadataFileFormat> formatComponent = dialog.getComponentForParameter(
+        format);
+    final OptionalParameterComponent<?> mappingsOptionalComponent = dialog.getComponentForParameter(
+        columnMappings);
+
+    // when selecting mass dynamics preset then set default mapping to condition column
+    if (formatComponent != null && mappingsOptionalComponent != null) {
+      formatComponent.valueProperty()
+          .subscribe(newFormat -> applyMassDynamicsDefaults(newFormat, mappingsOptionalComponent));
+      applyMassDynamicsDefaults(formatComponent.getValue(), mappingsOptionalComponent);
+    }
+
+    dialog.showAndWait();
+    return dialog.getExitCode();
+  }
+
+  /**
+   * MassDynamics export needs condition column
+   */
+  private void applyMassDynamicsDefaults(@Nullable final MetadataFileFormat selectedFormat,
+      @NotNull final OptionalParameterComponent<?> mappingsOptionalComponent) {
+    if (selectedFormat != MetadataFileFormat.MASS_DYNAMICS) {
+      return;
+    }
+    if (!(mappingsOptionalComponent.getEmbeddedComponent() instanceof ProjectMetadataColumnMappingsComponent mappingsComponent)) {
+      return;
+    }
+
+    mappingsOptionalComponent.setSelected(true);
+    if (!mappingsComponent.hasActiveMappings()) {
+      mappingsComponent.setValue(MASS_DYNAMICS_DEFAULT_MAPPINGS);
+    }
+  }
+
+  public static @NotNull ParameterSet create(final @NotNull File file, final boolean appendSuffix,
+      final @NotNull MetadataFileFormat mFormat) {
+    final ParameterSet params = new ProjectMetadataExportParameters().cloneParameterSet();
     if (appendSuffix) {
       params.getParameter(fileName).setValueAppendSuffix(file, null);
     } else {
       params.setParameter(fileName, file);
     }
     params.setParameter(format, mFormat);
+    params.setParameter(columnMappings, false, List.of());
     return params;
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataExportParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataExportParameters.java
@@ -56,7 +56,7 @@ public class ProjectMetadataExportParameters extends SimpleParameterSet {
      */
     GNPS,
     /**
-     * MassDynamics export
+     * Mass Dynamics export
      */
     MASS_DYNAMICS;
 
@@ -66,7 +66,7 @@ public class ProjectMetadataExportParameters extends SimpleParameterSet {
         case DEFAULT -> "Default";
         case MZMINE_INTERNAL -> "mzmine internal";
         case GNPS -> "GNPS";
-        case MASS_DYNAMICS -> "MassDynamics";
+        case MASS_DYNAMICS -> "Mass Dynamics";
       };
     }
   }
@@ -111,7 +111,7 @@ public class ProjectMetadataExportParameters extends SimpleParameterSet {
   }
 
   /**
-   * MassDynamics export needs condition column
+   * Mass Dynamics export needs condition column
    */
   private void applyMassDynamicsDefaults(@Nullable final MetadataFileFormat selectedFormat,
       @NotNull final OptionalParameterComponent<?> mappingsOptionalComponent) {

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataExportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataExportTask.java
@@ -25,6 +25,7 @@
 
 package io.github.mzmine.modules.visualization.projectmetadata.io;
 
+import io.github.mzmine.datamodel.RawDataFile;
 import io.github.mzmine.modules.visualization.projectmetadata.io.ProjectMetadataExportParameters.MetadataFileFormat;
 import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTable;
 import io.github.mzmine.parameters.ParameterSet;
@@ -34,31 +35,47 @@ import java.io.File;
 import java.time.Instant;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ProjectMetadataExportTask extends AbstractSimpleToolTask {
 
   private final File file;
   private final MetadataFileFormat format;
   private final List<ProjectMetadataColumnMapping> columnMappings;
+  private final @Nullable List<? extends RawDataFile> rawDataFiles;
 
   /**
    * @param moduleCallDate the call date of module to order execution order
    */
   public ProjectMetadataExportTask(final @NotNull Instant moduleCallDate,
       @NotNull final ParameterSet parameters) {
+    this(moduleCallDate, parameters, null);
+  }
+
+  /**
+   * @param moduleCallDate the call date of module to order execution order
+   * @param rawDataFiles   raw data files to include in the export
+   */
+  public ProjectMetadataExportTask(final @NotNull Instant moduleCallDate,
+      @NotNull final ParameterSet parameters,
+      @Nullable final List<? extends RawDataFile> rawDataFiles) {
     super(moduleCallDate, parameters);
     file = parameters.getValue(ProjectMetadataExportParameters.fileName);
     format = parameters.getValue(ProjectMetadataExportParameters.format);
 
     columnMappings = parameters.getEmbeddedParameterValueIfSelectedOrElseGet(
         ProjectMetadataExportParameters.columnMappings, List::of);
+    this.rawDataFiles = rawDataFiles == null ? null : List.copyOf(rawDataFiles);
   }
 
   @Override
   protected void process() {
-    MetadataTable metadata = ProjectService.getProject().getProjectMetadata();
-    ProjectMetadataWriter writer = new ProjectMetadataWriter(metadata, format, columnMappings);
-    if (!writer.exportTo(file)) {
+    final MetadataTable metadata = ProjectService.getProject().getProjectMetadata();
+    final ProjectMetadataWriter writer = new ProjectMetadataWriter(metadata, format,
+        columnMappings);
+    final List<? extends RawDataFile> exportRawDataFiles =
+        rawDataFiles == null ? List.of(ProjectService.getProject().getDataFiles()) : rawDataFiles;
+    if (!writer.exportTo(file, exportRawDataFiles)) {
       error("Error during metadata file export");
       return;
     }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataExportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataExportTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -32,12 +32,14 @@ import io.github.mzmine.project.ProjectService;
 import io.github.mzmine.taskcontrol.AbstractSimpleToolTask;
 import java.io.File;
 import java.time.Instant;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
 public class ProjectMetadataExportTask extends AbstractSimpleToolTask {
 
   private final File file;
   private final MetadataFileFormat format;
+  private final List<ProjectMetadataColumnMapping> columnMappings;
 
   /**
    * @param moduleCallDate the call date of module to order execution order
@@ -47,12 +49,15 @@ public class ProjectMetadataExportTask extends AbstractSimpleToolTask {
     super(moduleCallDate, parameters);
     file = parameters.getValue(ProjectMetadataExportParameters.fileName);
     format = parameters.getValue(ProjectMetadataExportParameters.format);
+
+    columnMappings = parameters.getEmbeddedParameterValueIfSelectedOrElseGet(
+        ProjectMetadataExportParameters.columnMappings, List::of);
   }
 
   @Override
   protected void process() {
     MetadataTable metadata = ProjectService.getProject().getProjectMetadata();
-    ProjectMetadataWriter writer = new ProjectMetadataWriter(metadata, format);
+    ProjectMetadataWriter writer = new ProjectMetadataWriter(metadata, format, columnMappings);
     if (!writer.exportTo(file)) {
       error("Error during metadata file export");
       return;

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataWriter.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/io/ProjectMetadataWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -38,71 +38,85 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ProjectMetadataWriter {
 
   private static final Logger logger = Logger.getLogger(ProjectMetadataWriter.class.getName());
+  private static final String GNPS_PREFIX = "ATTRIBUTE_";
 
   private final MetadataTable metadataTable;
   private final MetadataFileFormat format;
+  private final List<ProjectMetadataColumnMapping> columnMappings;
+  private Map<MetadataColumn<?>, Map<RawDataFile, Object>> data;
+  private StringMetadataColumn dataFileCol;
+  private List<String> exportTitles;
+  private Map<String, ProjectMetadataColumnMapping> mappingsByTarget;
 
   public ProjectMetadataWriter(@NotNull final MetadataTable metadata,
       @NotNull final MetadataFileFormat format) {
+    this(metadata, format, List.of());
+  }
+
+  public ProjectMetadataWriter(@NotNull final MetadataTable metadata,
+      @NotNull final MetadataFileFormat format,
+      @Nullable final List<ProjectMetadataColumnMapping> columnMappings) {
     this.metadataTable = metadata;
     this.format = format;
+    this.columnMappings = columnMappings == null ? List.of()
+        : columnMappings.stream().filter(ProjectMetadataColumnMapping::isActive).toList();
   }
 
 
   /**
    * @return true if success. also if empty
    */
-  public boolean exportTo(File file) {
-    if (metadataTable.getData().isEmpty()) {
+  public boolean exportTo(@NotNull final File file) {
+    return exportTo(file, List.of(ProjectService.getProject().getDataFiles()));
+  }
+
+  /**
+   * @return true if success. also if empty
+   */
+  public boolean exportTo(@NotNull final File file,
+      @NotNull final List<? extends RawDataFile> rawDataFiles) {
+    if (metadataTable.getData().isEmpty() && columnMappings.isEmpty()) {
       logger.info("Project metadata is empty, nothing to export");
       return true;
     }
 
     try (final ICSVWriter csvWriter = CSVParsingUtils.createDefaultWriterAutoDetect(file, "tsv",
         WriterOptions.REPLACE)) {
-      var data = metadataTable.getData();
+      data = metadataTable.getData();
 
       // create the file header
-      StringMetadataColumn dataFileCol = metadataTable.createDataFileColumn();
+      dataFileCol = metadataTable.createDataFileColumn();
+      exportTitles = createExportTitles();
+      mappingsByTarget = createMappingsByTarget();
 
       // write the header down
       if (format == MetadataFileFormat.MZMINE_INTERNAL) {
-        writeTypeDescriptions(csvWriter, dataFileCol, data);
+        writeTypeDescriptions(csvWriter);
       }
 
-      String GNPS_PREFIX = "ATTRIBUTE_";
-
       final List<String> parametersTitles = new ArrayList<>();
-      parametersTitles.add(dataFileCol.getTitle());
-      for (var column : data.keySet()) {
-        var title = column.getTitle();
-        if (format == MetadataFileFormat.GNPS && !title.toLowerCase()
-            .endsWith(GNPS_PREFIX.toLowerCase())) {
-          title = GNPS_PREFIX + title;
-        }
-
-        parametersTitles.add(title);
+      for (final String title : exportTitles) {
+        parametersTitles.add(formatHeaderTitle(title));
       }
       csvWriter.writeNext(parametersTitles.toArray(String[]::new));
       logger.info("Header was successfully written");
 
       // write the parameters value down
-      RawDataFile[] files = ProjectService.getProject().getDataFiles();
-      for (var rawDataFile : files) {
-        List<String> lineFieldsValues = new ArrayList<>(List.of(rawDataFile.getName()));
-        for (var column : data.entrySet()) {
-          // get the parameter value
-          // [IMPORTANT] "" will be returned in case if it's unset
-          Object value = metadataTable.getValue(column.getKey(), rawDataFile);
-          lineFieldsValues.add(value == null ? "" : value.toString());
+      for (final RawDataFile rawDataFile : rawDataFiles) {
+        final List<String> lineFieldsValues = new ArrayList<>(exportTitles.size());
+        for (final String title : exportTitles) {
+          lineFieldsValues.add(resolveExportValue(title, rawDataFile));
         }
 
         csvWriter.writeNext(lineFieldsValues.toArray(String[]::new));
@@ -121,22 +135,94 @@ public class ProjectMetadataWriter {
     return true;
   }
 
-  private void writeTypeDescriptions(final ICSVWriter writer,
-      final StringMetadataColumn dataFileCol,
-      final Map<MetadataColumn<?>, Map<RawDataFile, Object>> data) {
+  private @NotNull List<String> createExportTitles() {
+    final LinkedHashSet<String> titles = new LinkedHashSet<>();
+    titles.add(dataFileCol.getTitle());
+    data.keySet().stream().map(MetadataColumn::getTitle).forEach(titles::add);
+    columnMappings.stream().map(ProjectMetadataColumnMapping::targetColumn)
+        .filter(title -> !title.equals(dataFileCol.getTitle())).forEach(titles::add);
+    return List.copyOf(titles);
+  }
+
+  private @NotNull Map<String, ProjectMetadataColumnMapping> createMappingsByTarget() {
+    final Map<String, ProjectMetadataColumnMapping> mappingsByTarget = new LinkedHashMap<>();
+    for (final ProjectMetadataColumnMapping mapping : columnMappings) {
+      mappingsByTarget.put(mapping.targetColumn(), mapping);
+    }
+    return mappingsByTarget;
+  }
+
+  private @NotNull String formatHeaderTitle(@NotNull final String title) {
+    if (format == MetadataFileFormat.GNPS && !title.equals(dataFileCol.getTitle())
+        && !title.toLowerCase().endsWith(GNPS_PREFIX.toLowerCase())) {
+      return GNPS_PREFIX + title;
+    }
+    return title;
+  }
+
+  /**
+   * @return ma
+   */
+  private @NotNull String resolveExportValue(@NotNull final String title,
+      @NotNull final RawDataFile rawDataFile) {
+    if (title.equals(dataFileCol.getTitle())) {
+      return rawDataFile.getName();
+    }
+
+    final ProjectMetadataColumnMapping mapping = mappingsByTarget.get(title);
+    if (mapping != null) {
+      return resolveMappedValue(mapping, rawDataFile);
+    }
+
+    final MetadataColumn<?> column = findMetadataColumn(title);
+    return column == null ? "" : metadataValueAsString(column, rawDataFile);
+  }
+
+  private @NotNull String resolveMappedValue(@NotNull final ProjectMetadataColumnMapping mapping,
+      @NotNull final RawDataFile rawDataFile) {
+    if (mapping.sourceColumn().equals(dataFileCol.getTitle())) {
+      final String text = rawDataFile.getName();
+      return text == null || text.isBlank() ? mapping.defaultValue() : text;
+    }
+
+    final MetadataColumn<?> sourceColumn = metadataTable.getColumnByName(mapping.sourceColumn());
+    final String text =
+        sourceColumn == null ? "" : metadataValueAsString(sourceColumn, rawDataFile);
+    return text.isBlank() ? mapping.defaultValue() : text;
+  }
+
+  private <T> @Nullable T getMetadataValue(@NotNull final MetadataColumn<T> column,
+      @NotNull final RawDataFile rawDataFile) {
+    return metadataTable.getValue(column, rawDataFile);
+  }
+
+  private @NotNull String metadataValueAsString(@NotNull final MetadataColumn<?> column,
+      @NotNull final RawDataFile rawDataFile) {
+    final Object value = getMetadataValue(column, rawDataFile);
+    return value == null ? "" : value.toString();
+  }
+
+  private void writeTypeDescriptions(final @NotNull ICSVWriter writer) {
 
     final List<String> parametersDescriptions = new ArrayList<>();
     final List<String> parametersTypes = new ArrayList<>();
-    parametersDescriptions.add(dataFileCol.getDescription());
-    parametersTypes.add(dataFileCol.getType().toString());
-
-    for (var column : data.keySet()) {
-      parametersDescriptions.add(column.getDescription());
-      parametersTypes.add(column.getType().toString());
+    for (final String title : exportTitles) {
+      final MetadataColumn<?> column =
+          title.equals(dataFileCol.getTitle()) ? dataFileCol : findMetadataColumn(title);
+      final ProjectMetadataColumnMapping mapping = mappingsByTarget.get(title);
+      parametersDescriptions.add(column != null ? column.getDescription()
+          : "Mapped from metadata column " + (mapping == null ? "" : mapping.sourceColumn()));
+      parametersTypes.add(column != null ? column.getType().toString()
+          : new StringMetadataColumn(title).getType().toString());
     }
 
     writer.writeNext(parametersDescriptions.toArray(String[]::new));
     writer.writeNext(parametersTypes.toArray(String[]::new));
+  }
+
+  private @Nullable MetadataColumn<?> findMetadataColumn(@NotNull final String title) {
+    return data.keySet().stream().filter(column -> column.getTitle().equals(title)).findFirst()
+        .orElse(null);
   }
 
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/MetadataTable.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/MetadataTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2025 The mzmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -27,6 +27,7 @@ package io.github.mzmine.modules.visualization.projectmetadata.table;
 
 import static io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn.DATE_HEADER;
 import static io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn.FILENAME_HEADER;
+import static io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn.SAMPLE_NAME_HEADER;
 import static io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn.SAMPLE_TYPE_HEADER;
 
 import io.github.mzmine.datamodel.RawDataFile;
@@ -38,6 +39,7 @@ import io.github.mzmine.modules.visualization.projectmetadata.table.columns.Meta
 import io.github.mzmine.modules.visualization.projectmetadata.table.columns.StringMetadataColumn;
 import io.github.mzmine.project.ProjectService;
 import io.github.mzmine.util.StringUtils;
+import io.github.mzmine.util.files.FileAndPathUtil;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -130,7 +132,7 @@ public class MetadataTable {
    *
    * @param newFile file to be added
    */
-  public void addFile(RawDataFile newFile) {
+  public void addFile(@NotNull final RawDataFile newFile) {
     // try to set a value of a start time stamp parameter for a sample
     try {
       if (enableAutoDetection) {
@@ -142,18 +144,24 @@ public class MetadataTable {
         setValue(dateCol, newFile, newFile.getStartTimeStamp());
 
         assignSampleType(newFile);
+        assignSampleName(newFile);
       }
     } catch (Exception ignored) {
-      logger.warning("Cannot set date " + newFile.getStartTimeStamp());
+      logger.warning("Cannot auto-detect metadata for " + newFile.getName());
     }
   }
 
-  private void assignSampleType(RawDataFile newFile) {
+  private void assignSampleType(@NotNull final RawDataFile newFile) {
     final MetadataColumn<String> sampleTypeColumn = getSampleTypeColumn();
     setValue(sampleTypeColumn, newFile, SampleType.ofFile(newFile).toString());
   }
 
-  public MetadataColumn<String> getSampleTypeColumn() {
+  private void assignSampleName(@NotNull final RawDataFile newFile) {
+    final MetadataColumn<String> sampleNameColumn = getSampleNameColumn();
+    setValue(sampleNameColumn, newFile, FileAndPathUtil.eraseFormat(newFile.getName()));
+  }
+
+  public @NotNull MetadataColumn<String> getSampleTypeColumn() {
     final MetadataColumn<?> col = getColumnByName(SAMPLE_TYPE_HEADER);
     if (col == null) {
       final StringMetadataColumn sampleType = new StringMetadataColumn(SAMPLE_TYPE_HEADER,
@@ -163,6 +171,19 @@ public class MetadataTable {
       data.values().stream().flatMap(m -> m.keySet().stream()).distinct()
           .forEach(this::assignSampleType);
       return sampleType;
+    }
+    return (MetadataColumn<String>) col;
+  }
+
+  public @NotNull MetadataColumn<String> getSampleNameColumn() {
+    final MetadataColumn<?> col = getColumnByName(SAMPLE_NAME_HEADER);
+    if (col == null) {
+      final StringMetadataColumn sampleName = new StringMetadataColumn(SAMPLE_NAME_HEADER,
+          "Sample name without raw data file extension");
+      addColumn(sampleName);
+      data.values().stream().flatMap(m -> m.keySet().stream()).distinct()
+          .forEach(this::assignSampleName);
+      return sampleName;
     }
     return (MetadataColumn<String>) col;
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/columns/MetadataColumn.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/columns/MetadataColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2025 The mzmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -40,6 +40,9 @@ public abstract sealed class MetadataColumn<T> implements Comparable<MetadataCol
     StringMetadataColumn, DoubleMetadataColumn, DateMetadataColumn {
 
   public static final String FILENAME_HEADER = "filename";
+  /// sample_name is used by MassDynamics export and may be also used by other workflows default is
+  /// the filename without extension
+  public static final String SAMPLE_NAME_HEADER = "sample_name";
   public static final String DATE_HEADER = "run_date";
   // renamed this from sample_type to mz_sample_type because too standard name that may be overwritten by users metadata
   public static final String SAMPLE_TYPE_HEADER = "mzmine_sample_type";
@@ -188,6 +191,14 @@ public abstract sealed class MetadataColumn<T> implements Comparable<MetadataCol
       return -1;
     }
     if (o.getTitle().equals(FILENAME_HEADER)) {
+      return 1;
+    }
+
+    // then sample name
+    if (this.getTitle().equalsIgnoreCase(SAMPLE_NAME_HEADER)) {
+      return -1;
+    }
+    if (o.getTitle().equalsIgnoreCase(SAMPLE_NAME_HEADER)) {
       return 1;
     }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/columns/MetadataColumn.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/projectmetadata/table/columns/MetadataColumn.java
@@ -40,7 +40,7 @@ public abstract sealed class MetadataColumn<T> implements Comparable<MetadataCol
     StringMetadataColumn, DoubleMetadataColumn, DateMetadataColumn {
 
   public static final String FILENAME_HEADER = "filename";
-  /// sample_name is used by MassDynamics export and may be also used by other workflows default is
+  /// sample_name is used by Mass Dynamics export and may be also used by other workflows default is
   /// the filename without extension
   public static final String SAMPLE_NAME_HEADER = "sample_name";
   public static final String DATE_HEADER = "run_date";

--- a/mzmine-community/src/test/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportTaskTest.java
+++ b/mzmine-community/src/test/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportTaskTest.java
@@ -45,8 +45,10 @@ import io.github.mzmine.datamodel.features.types.annotations.PreferredAnnotation
 import io.github.mzmine.datamodel.features.types.annotations.SmilesIsomericStructureType;
 import io.github.mzmine.datamodel.features.types.annotations.SmilesStructureType;
 import io.github.mzmine.datamodel.features.types.numbers.NormalizedAreaType;
+import io.github.mzmine.modules.dataanalysis.utils.imputation.ImputationFunctions;
 import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTable;
 import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
+import io.github.mzmine.modules.visualization.projectmetadata.table.columns.StringMetadataColumn;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsSelection;
 import io.github.mzmine.project.ProjectService;
@@ -54,6 +56,7 @@ import io.github.mzmine.project.impl.RawDataFileImpl;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.CSVParsingUtils;
 import io.github.mzmine.util.FeatureListTestUtils;
+import io.github.mzmine.util.files.FileAndPathUtil;
 import java.io.File;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -68,8 +71,8 @@ import testutils.MZmineTestUtil;
 
 class MassDynamicsExportTaskTest {
 
-  private static final String[] HEADER = {"MetaboliteId", "MetaboliteName", "InChIKey", "HMDB",
-      "KEGG", "mz", "RetentionTime", "smiles", "isomeric_smiles", "inchi", "SampleName",
+  private static final String[] HEADER = {"MetaboliteId", "MetaboliteName", "Smiles",
+      "IsomericSmiles", "InChI", "InChIKey", "HMDB", "KEGG", "mz", "RetentionTime", "SampleName",
       "MetaboliteIntensity", "Imputed"};
 
   @BeforeAll
@@ -92,9 +95,8 @@ class MassDynamicsExportTaskTest {
     project.addFile(fileB);
 
     final MetadataTable metadata = project.getProjectMetadata();
-    final MetadataColumn<String> sampleType = metadata.getSampleTypeColumn();
-    metadata.setValue(sampleType, fileA, "Tumor");
-    metadata.setValue(sampleType, fileB, "Normal");
+    final MetadataColumn<String> treatment = new StringMetadataColumn("treatment");
+    metadata.setValue(treatment, fileA, "Tumor");
 
     final ModularFeatureList featureList = new ModularFeatureList("Feature/List 1", null, fileA,
         fileB);
@@ -103,19 +105,28 @@ class MassDynamicsExportTaskTest {
         List.of(10f, 20f), 101.1234, 5.5f);
     setNormalizedArea(annotatedRow, fileA, 11f);
     setNormalizedArea(annotatedRow, fileB, 22f);
-    annotatedRow.set(PreferredAnnotationType.class, createAnnotation());
+    final CompoundDBAnnotation annotation = createAnnotation();
+    annotatedRow.set(PreferredAnnotationType.class, annotation);
 
     final ModularFeatureListRow missingRow = FeatureListTestUtils.addRow(featureList, 2, files,
         Arrays.asList(5f, null), 202.2, 6.5f);
     setNormalizedArea(missingRow, fileA, 55f);
 
-    final File metaboliteFile = tempDir.resolve("massdynamics_metabolite.tsv").toFile();
+    final File baseFile = tempDir.resolve("massdynamics.tsv").toFile();
+    final File metaboliteFile = FileAndPathUtil.getRealFilePathWithSuffix(baseFile,
+        "_massdynamics_metabolite.tsv");
+    final File metadataFile = MassDynamicsExportTask.getExperimentMetadataFile(baseFile);
+
     final ParameterSet parameters = new MassDynamicsExportParameters().cloneParameterSet();
     parameters.setParameter(MassDynamicsExportParameters.featureLists,
         new FeatureListsSelection(featureList));
-    parameters.setParameter(MassDynamicsExportParameters.filename, metaboliteFile);
+    parameters.setParameter(MassDynamicsExportParameters.filename, baseFile);
     parameters.setParameter(MassDynamicsExportParameters.abundanceMeasure,
         AbundanceMeasure.NORMALIZED_AREA);
+    parameters.setParameter(MassDynamicsExportParameters.missingValueImputation,
+        ImputationFunctions.OneFifthOfMinimum);
+    parameters.setParameter(MassDynamicsExportParameters.conditionColumn, "treatment");
+    parameters.setParameter(MassDynamicsExportParameters.defaultCondition, true, "Unknown");
 
     final MassDynamicsExportTask task = new MassDynamicsExportTask(null, Instant.now(), parameters,
         MassDynamicsExportModule.class, featureList);
@@ -127,18 +138,16 @@ class MassDynamicsExportTaskTest {
     assertArrayEquals(HEADER, metaboliteRows.getFirst());
 
     assertArrayEquals(
-        new String[]{"row_1", "Glucose", "WQZGKKKJIJFFOK-UHFFFAOYSA-N", "", "", "101.1234", "5.5",
-            "C(C1C(C(C(C(O)O1)O)O)O)O", "C(C1C(C(C(C(O)O1)O)O)O)O",
-            "InChI=1S/C6H12O6/c7-1-2-3(8)4(9)5(10)6(11)12-2/h2-11H,1H2", "sample_A.mzML", "11.0",
-            "0"}, metaboliteRows.get(1));
+        new String[]{"row_1", "Glucose", annotation.getSmiles(), annotation.getIsomericSmiles(),
+            annotation.getInChI(), annotation.getInChIKey(), "", "", "101.1234", "5.5", "sample_A",
+            "11.0", "0"}, metaboliteRows.get(1));
     assertEquals("22.0", metaboliteRows.get(2)[11]);
     assertEquals("0", metaboliteRows.get(2)[12]);
-    assertEquals("sample_B.mzML", metaboliteRows.get(4)[10]);
-    assertEquals("0.0", metaboliteRows.get(4)[11]);
+    assertEquals("sample_B", metaboliteRows.get(4)[10]);
+    assertEquals("11.0", metaboliteRows.get(4)[11]);
     assertEquals("1", metaboliteRows.get(4)[12]);
 
-    assertMetadataCsv(tempDir.resolve("experiment_design.csv").toFile());
-    assertMetadataCsv(tempDir.resolve("sample_metadata.csv").toFile());
+    assertMetadataCsv(metadataFile);
   }
 
   private static void setNormalizedArea(@NotNull final ModularFeatureListRow row,
@@ -171,10 +180,10 @@ class MassDynamicsExportTaskTest {
     assertTrue(conditionIndex >= 0, header::toString);
 
     assertEquals("sample_A.mzML", rows.get(1)[filenameIndex]);
-    assertEquals("sample_A.mzML", rows.get(1)[sampleNameIndex]);
+    assertEquals("sample_A", rows.get(1)[sampleNameIndex]);
     assertEquals("Tumor", rows.get(1)[conditionIndex]);
     assertEquals("sample_B.mzML", rows.get(2)[filenameIndex]);
-    assertEquals("sample_B.mzML", rows.get(2)[sampleNameIndex]);
-    assertEquals("Normal", rows.get(2)[conditionIndex]);
+    assertEquals("sample_B", rows.get(2)[sampleNameIndex]);
+    assertEquals("Unknown", rows.get(2)[conditionIndex]);
   }
 }

--- a/mzmine-community/src/test/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportTaskTest.java
+++ b/mzmine-community/src/test/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportTaskTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.modules.io.export_features_massdynamics;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.mzmine.datamodel.AbundanceMeasure;
+import io.github.mzmine.datamodel.MZmineProject;
+import io.github.mzmine.datamodel.RawDataFile;
+import io.github.mzmine.datamodel.features.ModularFeature;
+import io.github.mzmine.datamodel.features.ModularFeatureList;
+import io.github.mzmine.datamodel.features.ModularFeatureListRow;
+import io.github.mzmine.datamodel.features.compoundannotations.CompoundDBAnnotation;
+import io.github.mzmine.datamodel.features.compoundannotations.SimpleCompoundDBAnnotation;
+import io.github.mzmine.datamodel.features.types.annotations.CompoundNameType;
+import io.github.mzmine.datamodel.features.types.annotations.InChIKeyStructureType;
+import io.github.mzmine.datamodel.features.types.annotations.InChIStructureType;
+import io.github.mzmine.datamodel.features.types.annotations.PreferredAnnotationType;
+import io.github.mzmine.datamodel.features.types.annotations.SmilesIsomericStructureType;
+import io.github.mzmine.datamodel.features.types.annotations.SmilesStructureType;
+import io.github.mzmine.datamodel.features.types.numbers.NormalizedAreaType;
+import io.github.mzmine.modules.visualization.projectmetadata.table.MetadataTable;
+import io.github.mzmine.modules.visualization.projectmetadata.table.columns.MetadataColumn;
+import io.github.mzmine.parameters.ParameterSet;
+import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsSelection;
+import io.github.mzmine.project.ProjectService;
+import io.github.mzmine.project.impl.RawDataFileImpl;
+import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.CSVParsingUtils;
+import io.github.mzmine.util.FeatureListTestUtils;
+import java.io.File;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import testutils.MZmineTestUtil;
+
+class MassDynamicsExportTaskTest {
+
+  private static final String[] HEADER = {"MetaboliteId", "MetaboliteName", "InChIKey", "HMDB",
+      "KEGG", "mz", "RetentionTime", "smiles", "isomeric_smiles", "inchi", "SampleName",
+      "MetaboliteIntensity", "Imputed"};
+
+  @BeforeAll
+  static void startMzmine() {
+    MZmineTestUtil.startMzmineCore();
+  }
+
+  @BeforeEach
+  void cleanProject() {
+    MZmineTestUtil.cleanProject();
+  }
+
+  @Test
+  void exportsMassDynamicsFiles(@TempDir final Path tempDir) throws Exception {
+    final RawDataFileImpl fileA = new RawDataFileImpl("sample_A.mzML", null, null);
+    final RawDataFileImpl fileB = new RawDataFileImpl("sample_B.mzML", null, null);
+    final List<RawDataFileImpl> files = List.of(fileA, fileB);
+    final MZmineProject project = ProjectService.getProject();
+    project.addFile(fileA);
+    project.addFile(fileB);
+
+    final MetadataTable metadata = project.getProjectMetadata();
+    final MetadataColumn<String> sampleType = metadata.getSampleTypeColumn();
+    metadata.setValue(sampleType, fileA, "Tumor");
+    metadata.setValue(sampleType, fileB, "Normal");
+
+    final ModularFeatureList featureList = new ModularFeatureList("Feature/List 1", null, fileA,
+        fileB);
+    project.addFeatureList(featureList);
+    final ModularFeatureListRow annotatedRow = FeatureListTestUtils.addRow(featureList, 1, files,
+        List.of(10f, 20f), 101.1234, 5.5f);
+    setNormalizedArea(annotatedRow, fileA, 11f);
+    setNormalizedArea(annotatedRow, fileB, 22f);
+    annotatedRow.set(PreferredAnnotationType.class, createAnnotation());
+
+    final ModularFeatureListRow missingRow = FeatureListTestUtils.addRow(featureList, 2, files,
+        Arrays.asList(5f, null), 202.2, 6.5f);
+    setNormalizedArea(missingRow, fileA, 55f);
+
+    final File metaboliteFile = tempDir.resolve("massdynamics_metabolite.tsv").toFile();
+    final ParameterSet parameters = new MassDynamicsExportParameters().cloneParameterSet();
+    parameters.setParameter(MassDynamicsExportParameters.featureLists,
+        new FeatureListsSelection(featureList));
+    parameters.setParameter(MassDynamicsExportParameters.filename, metaboliteFile);
+    parameters.setParameter(MassDynamicsExportParameters.abundanceMeasure,
+        AbundanceMeasure.NORMALIZED_AREA);
+
+    final MassDynamicsExportTask task = new MassDynamicsExportTask(null, Instant.now(), parameters,
+        MassDynamicsExportModule.class, featureList);
+    task.run();
+
+    assertEquals(TaskStatus.FINISHED, task.getStatus(), task.getErrorMessage());
+    final List<String[]> metaboliteRows = CSVParsingUtils.readData(metaboliteFile, "\t");
+    assertEquals(5, metaboliteRows.size());
+    assertArrayEquals(HEADER, metaboliteRows.getFirst());
+
+    assertArrayEquals(
+        new String[]{"row_1", "Glucose", "WQZGKKKJIJFFOK-UHFFFAOYSA-N", "", "", "101.1234", "5.5",
+            "C(C1C(C(C(C(O)O1)O)O)O)O", "C(C1C(C(C(C(O)O1)O)O)O)O",
+            "InChI=1S/C6H12O6/c7-1-2-3(8)4(9)5(10)6(11)12-2/h2-11H,1H2", "sample_A.mzML", "11.0",
+            "0"}, metaboliteRows.get(1));
+    assertEquals("22.0", metaboliteRows.get(2)[11]);
+    assertEquals("0", metaboliteRows.get(2)[12]);
+    assertEquals("sample_B.mzML", metaboliteRows.get(4)[10]);
+    assertEquals("0.0", metaboliteRows.get(4)[11]);
+    assertEquals("1", metaboliteRows.get(4)[12]);
+
+    assertMetadataCsv(tempDir.resolve("experiment_design.csv").toFile());
+    assertMetadataCsv(tempDir.resolve("sample_metadata.csv").toFile());
+  }
+
+  private static void setNormalizedArea(@NotNull final ModularFeatureListRow row,
+      @NotNull final RawDataFile file, final float value) {
+    final ModularFeature feature = (ModularFeature) row.getFeature(file);
+    assertNotNull(feature);
+    feature.set(NormalizedAreaType.class, value);
+  }
+
+  private static @NotNull CompoundDBAnnotation createAnnotation() {
+    final CompoundDBAnnotation annotation = new SimpleCompoundDBAnnotation();
+    annotation.put(CompoundNameType.class, "Glucose");
+    annotation.put(InChIKeyStructureType.class, "WQZGKKKJIJFFOK-UHFFFAOYSA-N");
+    annotation.put(SmilesStructureType.class, "C(C1C(C(C(C(O1)O)O)O)O)O");
+    annotation.put(SmilesIsomericStructureType.class, "C(C1C(C(C(C(O1)O)O)O)O)O");
+    annotation.put(InChIStructureType.class, "InChI=1S/C6H12O6");
+    return annotation;
+  }
+
+  private static void assertMetadataCsv(@NotNull final File metadataFile) throws Exception {
+    assertTrue(metadataFile.exists(), metadataFile::getAbsolutePath);
+    final List<String[]> rows = CSVParsingUtils.readData(metadataFile, ",");
+    assertEquals(3, rows.size());
+    final List<String> header = Arrays.asList(rows.getFirst());
+    final int filenameIndex = header.indexOf("filename");
+    final int sampleNameIndex = header.indexOf("sample_name");
+    final int conditionIndex = header.indexOf("condition");
+    assertTrue(filenameIndex >= 0, header::toString);
+    assertTrue(sampleNameIndex >= 0, header::toString);
+    assertTrue(conditionIndex >= 0, header::toString);
+
+    assertEquals("sample_A.mzML", rows.get(1)[filenameIndex]);
+    assertEquals("sample_A.mzML", rows.get(1)[sampleNameIndex]);
+    assertEquals("Tumor", rows.get(1)[conditionIndex]);
+    assertEquals("sample_B.mzML", rows.get(2)[filenameIndex]);
+    assertEquals("sample_B.mzML", rows.get(2)[sampleNameIndex]);
+    assertEquals("Normal", rows.get(2)[conditionIndex]);
+  }
+}

--- a/mzmine-community/src/test/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportTaskTest.java
+++ b/mzmine-community/src/test/java/io/github/mzmine/modules/io/export_features_massdynamics/MassDynamicsExportTaskTest.java
@@ -71,10 +71,6 @@ import testutils.MZmineTestUtil;
 
 class MassDynamicsExportTaskTest {
 
-  private static final String[] HEADER = {"MetaboliteId", "MetaboliteName", "Smiles",
-      "IsomericSmiles", "InChI", "InChIKey", "HMDB", "KEGG", "mz", "RetentionTime", "SampleName",
-      "MetaboliteIntensity", "Imputed"};
-
   @BeforeAll
   static void startMzmine() {
     MZmineTestUtil.startMzmineCore();
@@ -135,17 +131,18 @@ class MassDynamicsExportTaskTest {
     assertEquals(TaskStatus.FINISHED, task.getStatus(), task.getErrorMessage());
     final List<String[]> metaboliteRows = CSVParsingUtils.readData(metaboliteFile, "\t");
     assertEquals(5, metaboliteRows.size());
-    assertArrayEquals(HEADER, metaboliteRows.getFirst());
+    assertArrayEquals(MassDynamicsExportTask.HEADER, metaboliteRows.getFirst());
 
     assertArrayEquals(
         new String[]{"row_1", "Glucose", annotation.getSmiles(), annotation.getIsomericSmiles(),
-            annotation.getInChI(), annotation.getInChIKey(), "", "", "101.1234", "5.5", "sample_A",
+            annotation.getInChI(), annotation.getInChIKey(), "", "", "101.1234", "5.5", "", "",
+            "sample_A",
             "11.0", "0"}, metaboliteRows.get(1));
-    assertEquals("22.0", metaboliteRows.get(2)[11]);
-    assertEquals("0", metaboliteRows.get(2)[12]);
-    assertEquals("sample_B", metaboliteRows.get(4)[10]);
-    assertEquals("11.0", metaboliteRows.get(4)[11]);
-    assertEquals("1", metaboliteRows.get(4)[12]);
+    assertEquals("22.0", metaboliteRows.get(2)[13]);
+    assertEquals("0", metaboliteRows.get(2)[14]);
+    assertEquals("sample_B", metaboliteRows.get(4)[12]);
+    assertEquals("11.0", metaboliteRows.get(4)[13]);
+    assertEquals("1", metaboliteRows.get(4)[14]);
 
     assertMetadataCsv(metadataFile);
   }


### PR DESCRIPTION
- adds a sample_name column mapping the filename without extension by default. 
- requires condition column so we add options to metadata export to map columns to other title so that any column can be condition column
- MassDynamics export exports one project metadata.csv and one metabolite long table with ID, annotation, intensity, SampleName