### PR TITLE
Better speed benchmarks and reporting

### DIFF
--- a/mzmine-community/build.gradle
+++ b/mzmine-community/build.gradle
@@ -316,6 +316,48 @@ application {
     ]
 }
 
+/*
+ * Batch speed benchmark, see import_data.speed.BatchSpeedTestMain. Run this instead of starting the
+ * main from the IDE when comparing branches: the heap is fixed here, so every branch is measured with
+ * the same memory. The mzmine preferences (threads, GC after batch step) are not changed, they are
+ * only documented in the results.
+ *
+ * gradlew batchSpeedTest -Pspeed.description=my-branch -Pspeed.batch=D:\some.mzbatch -Pspeed.out=D:\speed
+ * gradlew batchSpeedReport -Pspeed.in=D:\speed.jsonlines
+ *
+ * The properties are prefixed because plain names like 'description' collide with built in gradle
+ * project properties.
+ */
+def speedTestProperties = ['out', 'description', 'batch', 'iterations', 'warmups', 'inMemory',
+                           'headless', 'importOnce', 'trackMemory']
+
+tasks.register('batchSpeedTest', JavaExec) {
+    group = 'benchmark'
+    description = 'Runs the batch speed test with a fixed 32 GB heap. See BatchSpeedTestMain.'
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass.set('import_data.speed.BatchSpeedTestMain')
+    // fixed min = max heap so that the GC behaves the same on every branch
+    jvmArgs += application.applicationDefaultJvmArgs + ['-Xms32g', '-Xmx32g']
+    speedTestProperties.each { name ->
+        if (project.hasProperty("speed.$name")) {
+            systemProperty("mzmine.speed.$name", project.property("speed.$name"))
+        }
+    }
+}
+
+tasks.register('batchSpeedReport', JavaExec) {
+    group = 'benchmark'
+    description = 'Creates the html speed report from a speed test export. See SpeedReportMain.'
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass.set('import_data.speed.SpeedReportMain')
+    if (project.hasProperty('speed.in')) {
+        args += [project.property('speed.in').toString()]
+        if (project.hasProperty('speed.report')) {
+            args += [project.property('speed.report').toString()]
+        }
+    }
+}
+
 // Bundle external tools directly through jpackage on all operating systems.
 def EXTERNAL_TOOLS_SRC = getLayout().getProjectDirectory().dir("../external_tools").asFile.absolutePath
 

--- a/mzmine-community/build.gradle
+++ b/mzmine-community/build.gradle
@@ -316,57 +316,8 @@ application {
     ]
 }
 
-/*
- * Batch speed benchmark, see import_data.speed.BatchSpeedTestMain. Run this instead of starting the
- * main from the IDE when comparing branches: the heap is fixed here, so every branch is measured with
- * the same memory. The mzmine preferences (threads, GC after batch step) are not changed, they are
- * only documented in the results.
- *
- * gradlew batchSpeedTest -Pspeed.description=my-branch -Pspeed.batch=D:\some.mzbatch -Pspeed.out=D:\speed
- * gradlew batchSpeedReport -Pspeed.in=D:\speed.jsonlines
- *
- * The heap defaults to 32 GB and can be changed with -Pspeed.heapGb=16. Use the same value for all
- * branches that are compared.
- *
- * The properties are prefixed because plain names like 'description' collide with built in gradle
- * project properties.
- */
-def speedTestProperties = ['out', 'description', 'batch', 'iterations', 'warmups', 'inMemory',
-                           'headless', 'importOnce', 'trackMemory']
-
-def SPEED_TEST_DEFAULT_HEAP_GB = 32
-
-tasks.register('batchSpeedTest', JavaExec) {
-    group = 'benchmark'
-    description = 'Runs the batch speed test with a fixed heap, default 32 GB (-Pspeed.heapGb). See BatchSpeedTestMain.'
-    classpath = sourceSets.test.runtimeClasspath
-    mainClass.set('import_data.speed.BatchSpeedTestMain')
-    def heapGb = project.hasProperty('speed.heapGb') ? project.property('speed.heapGb').toString().trim()
-            : SPEED_TEST_DEFAULT_HEAP_GB.toString()
-    if (!heapGb.isInteger() || heapGb.toInteger() < 1) {
-        throw new GradleException("speed.heapGb must be a positive integer number of GB but was '$heapGb'")
-    }
-    // fixed min = max heap so that the GC behaves the same on every branch
-    jvmArgs += application.applicationDefaultJvmArgs + ["-Xms${heapGb}g", "-Xmx${heapGb}g"]
-    speedTestProperties.each { name ->
-        if (project.hasProperty("speed.$name")) {
-            systemProperty("mzmine.speed.$name", project.property("speed.$name"))
-        }
-    }
-}
-
-tasks.register('batchSpeedReport', JavaExec) {
-    group = 'benchmark'
-    description = 'Creates the html speed report from a speed test export. See SpeedReportMain.'
-    classpath = sourceSets.test.runtimeClasspath
-    mainClass.set('import_data.speed.SpeedReportMain')
-    if (project.hasProperty('speed.in')) {
-        args += [project.property('speed.in').toString()]
-        if (project.hasProperty('speed.report')) {
-            args += [project.property('speed.report').toString()]
-        }
-    }
-}
+// batchSpeedTest / batchSpeedReport benchmark tasks
+apply from: "$projectDir/gradle/speed-test.gradle"
 
 // Bundle external tools directly through jpackage on all operating systems.
 def EXTERNAL_TOOLS_SRC = getLayout().getProjectDirectory().dir("../external_tools").asFile.absolutePath

--- a/mzmine-community/build.gradle
+++ b/mzmine-community/build.gradle
@@ -325,19 +325,29 @@ application {
  * gradlew batchSpeedTest -Pspeed.description=my-branch -Pspeed.batch=D:\some.mzbatch -Pspeed.out=D:\speed
  * gradlew batchSpeedReport -Pspeed.in=D:\speed.jsonlines
  *
+ * The heap defaults to 32 GB and can be changed with -Pspeed.heapGb=16. Use the same value for all
+ * branches that are compared.
+ *
  * The properties are prefixed because plain names like 'description' collide with built in gradle
  * project properties.
  */
 def speedTestProperties = ['out', 'description', 'batch', 'iterations', 'warmups', 'inMemory',
                            'headless', 'importOnce', 'trackMemory']
 
+def SPEED_TEST_DEFAULT_HEAP_GB = 32
+
 tasks.register('batchSpeedTest', JavaExec) {
     group = 'benchmark'
-    description = 'Runs the batch speed test with a fixed 32 GB heap. See BatchSpeedTestMain.'
+    description = 'Runs the batch speed test with a fixed heap, default 32 GB (-Pspeed.heapGb). See BatchSpeedTestMain.'
     classpath = sourceSets.test.runtimeClasspath
     mainClass.set('import_data.speed.BatchSpeedTestMain')
+    def heapGb = project.hasProperty('speed.heapGb') ? project.property('speed.heapGb').toString().trim()
+            : SPEED_TEST_DEFAULT_HEAP_GB.toString()
+    if (!heapGb.isInteger() || heapGb.toInteger() < 1) {
+        throw new GradleException("speed.heapGb must be a positive integer number of GB but was '$heapGb'")
+    }
     // fixed min = max heap so that the GC behaves the same on every branch
-    jvmArgs += application.applicationDefaultJvmArgs + ['-Xms32g', '-Xmx32g']
+    jvmArgs += application.applicationDefaultJvmArgs + ["-Xms${heapGb}g", "-Xmx${heapGb}g"]
     speedTestProperties.each { name ->
         if (project.hasProperty("speed.$name")) {
             systemProperty("mzmine.speed.$name", project.property("speed.$name"))

--- a/mzmine-community/gradle/speed-test.gradle
+++ b/mzmine-community/gradle/speed-test.gradle
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * Batch speed benchmark, see import_data.speed.BatchSpeedTestMain. Run this instead of starting the
+ * main from the IDE when comparing branches: the heap is fixed here, so every branch is measured with
+ * the same memory. The mzmine preferences (threads, GC after batch step) are not changed, they are
+ * only documented in the results.
+ *
+ * gradlew batchSpeedTest -Pspeed.description=my-branch -Pspeed.batch=D:\some.mzbatch -Pspeed.out=D:\speed
+ * gradlew batchSpeedReport -Pspeed.in=D:\speed.jsonlines
+ *
+ * The heap defaults to 32 GB and can be changed with -Pspeed.heapGb=16. Use the same value for all
+ * branches that are compared.
+ *
+ * The properties are prefixed because plain names like 'description' collide with built in gradle
+ * project properties.
+ */
+def speedTestProperties = ['out', 'description', 'batch', 'iterations', 'warmups', 'inMemory',
+                           'headless', 'importOnce', 'trackMemory']
+
+def SPEED_TEST_DEFAULT_HEAP_GB = 32
+
+tasks.register('batchSpeedTest', JavaExec) {
+    group = 'benchmark'
+    description = 'Runs the batch speed test with a fixed heap, default 32 GB (-Pspeed.heapGb). See BatchSpeedTestMain.'
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass.set('import_data.speed.BatchSpeedTestMain')
+    def heapGb = project.hasProperty('speed.heapGb') ? project.property('speed.heapGb').toString().trim()
+            : SPEED_TEST_DEFAULT_HEAP_GB.toString()
+    if (!heapGb.isInteger() || heapGb.toInteger() < 1) {
+        throw new GradleException("speed.heapGb must be a positive integer number of GB but was '$heapGb'")
+    }
+    // fixed min = max heap so that the GC behaves the same on every branch
+    jvmArgs += application.applicationDefaultJvmArgs + ["-Xms${heapGb}g", "-Xmx${heapGb}g"]
+    speedTestProperties.each { name ->
+        if (project.hasProperty("speed.$name")) {
+            systemProperty("mzmine.speed.$name", project.property("speed.$name"))
+        }
+    }
+}
+
+tasks.register('batchSpeedReport', JavaExec) {
+    group = 'benchmark'
+    description = 'Creates the html speed report from a speed test export. See SpeedReportMain.'
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass.set('import_data.speed.SpeedReportMain')
+    if (project.hasProperty('speed.in')) {
+        args += [project.property('speed.in').toString()]
+        if (project.hasProperty('speed.report')) {
+            args += [project.property('speed.report').toString()]
+        }
+    }
+}

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/MZmineProject.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/MZmineProject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2025 The mzmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -219,4 +219,6 @@ public interface MZmineProject {
    */
   @Nullable
   File resolveRelativePathToFile(@Nullable String path);
+
+  void clearFeatureLists();
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchModeModule.java
@@ -39,7 +39,6 @@ import io.github.mzmine.modules.io.projectload.ProjectOpeningTask;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.taskcontrol.Task;
 import io.github.mzmine.util.ExitCode;
-import io.github.mzmine.util.XMLUtils;
 import java.io.File;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -51,7 +50,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.w3c.dom.Document;
 
 /**
  * Batch mode module
@@ -93,20 +91,13 @@ public class BatchModeModule implements MZmineProcessingModule {
       return null;
     }
 
-    logger.info("Running batch from file " + batchFile);
-
     try {
-      final Document parsedBatchXML = XMLUtils.load(batchFile);
-
-      List<String> errorMessages = new ArrayList<>();
-      // fail on missing modules - here its usually run from the command line - fail it
-      BatchQueue newQueue = BatchQueue.loadFromXml(parsedBatchXML.getDocumentElement(),
-          errorMessages, false);
+      final LoadedBatchQueue batchQueue = BatchQueue.loadFromFile(batchFile);
 
       // versions might have changed
-      if (!errorMessages.isEmpty()) {
+      if (!batchQueue.errorMessages().isEmpty()) {
         logger.log(Level.WARNING, "Warnings during batch file import:");
-        for (final String errorMessage : errorMessages) {
+        for (final String errorMessage : batchQueue.errorMessages()) {
           logger.log(Level.WARNING, errorMessage);
         }
         if (!ConfigService.isIgnoreParameterWarningsInBatch()) {
@@ -118,7 +109,7 @@ public class BatchModeModule implements MZmineProcessingModule {
         }
       }
 
-      return runBatchQueue(newQueue, project, overrideDataFiles, overrideMetadataFile,
+      return runBatchQueue(batchQueue.newQueue(), project, overrideDataFiles, overrideMetadataFile,
           overrideSpectralLibraryFiles, overrideOutBaseFile, moduleCallDate, overrideProjectImport,
           overrideCsvDatabase);
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchQueue.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchQueue.java
@@ -39,10 +39,13 @@ import io.github.mzmine.modules.io.import_rawdata_all.AllSpectralDataImportParam
 import io.github.mzmine.modules.io.import_spectral_library.SpectralLibraryImportParameters;
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.UserParameter;
+import io.github.mzmine.util.XMLUtils;
 import io.github.mzmine.util.collections.CollectionUtils;
 import io.github.mzmine.util.io.SemverVersionReader;
 import io.github.mzmine.util.javafx.ArrayObservableList;
 import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -52,11 +55,14 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.xml.parsers.ParserConfigurationException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
 /**
  * Batch steps queue
@@ -206,6 +212,25 @@ public class BatchQueue extends ArrayObservableList<MZmineProcessingStep<MZmineP
       errorMessages.add(1, "Check all steps and parameters carefully; then save the batch again.");
     }
     return queue;
+  }
+
+  /**
+   * Load from file
+   *
+   * @return {@link BatchQueue} and error messages from loading
+   * @throws ParserConfigurationException
+   * @throws IOException
+   * @throws SAXException
+   */
+  public static @NonNull LoadedBatchQueue loadFromFile(File batchFile)
+      throws ParserConfigurationException, IOException, SAXException {
+    logger.info("Loading batch from file " + batchFile);
+    final Document parsedBatchXML = XMLUtils.load(batchFile);
+
+    List<String> errorMessages = new ArrayList<>();
+    // fail on missing modules - here its usually run from the command line - fail it
+    BatchQueue newQueue = loadFromXml(parsedBatchXML.getDocumentElement(), errorMessages, false);
+    return new LoadedBatchQueue(errorMessages, newQueue);
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/BatchTask.java
@@ -88,6 +88,10 @@ import org.jetbrains.annotations.Nullable;
 public class BatchTask extends AbstractTask {
 
   private static final Logger logger = Logger.getLogger(BatchTask.class.getName());
+  /**
+   * Name of the measurement that covers the whole batch instead of a single step.
+   */
+  public static final String WHOLE_BATCH_NAME = "WHOLE BATCH";
   private final BatchQueue queue;
   // advanced parameters
   private final int stepsPerDataset;
@@ -225,7 +229,7 @@ public class BatchTask extends AbstractTask {
     if (runGCafterBatchStep) {
       System.gc();
     }
-    stepTimes.add(new StepTimeMeasurement(0, "WHOLE BATCH", duration, runGCafterBatchStep));
+    stepTimes.add(new StepTimeMeasurement(0, WHOLE_BATCH_NAME, duration, runGCafterBatchStep));
     printBatchMeasurements();
   }
 
@@ -331,24 +335,29 @@ public class BatchTask extends AbstractTask {
   }
 
   /**
-   * Logs timing and temp file usage of all collected steps as a single CSV, followed by a TOTAL row
-   * that sums the per-step values (live values are the latest snapshot). Pairs {@link #stepTimes}
-   * and {@link #stepStorageStats} by index; a trailing "WHOLE BATCH" timing entry (if present) is
-   * ignored in favor of the computed TOTAL row.
+   * Timing, heap and temp file usage of all collected steps, followed by a
+   * {@link #WHOLE_BATCH_NAME} summary row. Pairs {@link #stepTimes} and {@link #stepStorageStats} by
+   * index. The summary row uses the measured wall clock of the whole batch (which also covers
+   * overhead outside of the steps) and falls back to the sum of the step times while the batch is
+   * still running. Its storage columns are the sums of the per-step deltas, its live columns are the
+   * latest snapshot and therefore not a sum.
+   *
+   * @return an unmodifiable list, empty while no step has finished yet
    */
-  private void printBatchMeasurements() {
+  public @NotNull List<StepMeasurement> getStepMeasurements() {
     final int steps = stepStorageStats.size();
     if (steps == 0) {
-      return;
+      return List.of();
     }
     final List<StepMeasurement> measurements = new ArrayList<>(steps + 1);
     for (int i = 0; i < steps; i++) {
       measurements.add(new StepMeasurement(stepTimes.get(i), stepStorageStats.get(i)));
     }
 
-    // TOTAL row: sum per-step values, round to 3 decimals to keep the CSV clean; live values are
-    // the latest snapshot, not a sum
-    final double totalSeconds = round3(
+    // the trailing WHOLE BATCH timing entry is only added once the batch has finished
+    final StepTimeMeasurement wholeBatch = stepTimes.size() > steps ? stepTimes.get(steps) : null;
+    // round to 3 decimals to keep the CSV clean
+    final double totalSeconds = wholeBatch != null ? wholeBatch.secondsToFinish() : round3(
         stepTimes.stream().limit(steps).mapToDouble(StepTimeMeasurement::secondsToFinish).sum());
     final long totalFiles = stepStorageStats.stream()
         .mapToLong(StepStorageMeasurement::filesCreatedInStep).sum();
@@ -358,10 +367,23 @@ public class BatchTask extends AbstractTask {
         stepStorageStats.stream().mapToDouble(StepStorageMeasurement::usedGBInStep).sum());
 
     final StepStorageMeasurement last = stepStorageStats.getLast();
-    measurements.add(new StepMeasurement(new StepTimeMeasurement(0, totalSeconds, "TOTAL", null),
-        new StepStorageMeasurement(0, "TOTAL", totalFiles, totalReservedGB, totalUsedGB,
-            last.liveFiles(), last.liveUsedGB())));
+    final String heap = wholeBatch != null ? wholeBatch.usedHeapGB() : null;
+    measurements.add(
+        new StepMeasurement(new StepTimeMeasurement(0, totalSeconds, WHOLE_BATCH_NAME, heap),
+            new StepStorageMeasurement(0, WHOLE_BATCH_NAME, totalFiles, totalReservedGB,
+                totalUsedGB, last.liveFiles(), last.liveUsedGB())));
 
+    return List.copyOf(measurements);
+  }
+
+  /**
+   * Logs {@link #getStepMeasurements()} as a single CSV.
+   */
+  private void printBatchMeasurements() {
+    final List<StepMeasurement> measurements = getStepMeasurements();
+    if (measurements.isEmpty()) {
+      return;
+    }
     final String csv = CsvWriter.writeToString(measurements, StepMeasurement.class, '\t', true);
     logger.info("""
         Batch step measurements (timing + temp file usage)

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/LoadedBatchQueue.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/batchmode/LoadedBatchQueue.java
@@ -23,18 +23,10 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package import_data.speed;
+package io.github.mzmine.modules.batchmode;
 
-import java.io.File;
 import java.util.List;
-import org.jetbrains.annotations.NotNull;
 
-public record BatchSpeedJob(String description, int iterations, String batchFile,
-                            List<String> files) {
+public record LoadedBatchQueue(List<String> errorMessages, BatchQueue newQueue) {
 
-  @NotNull
-  public String getBatchFileName() {
-    return new File(batchFile).getName();
-  }
 }
-

--- a/mzmine-community/src/main/java/io/github/mzmine/project/impl/MZmineProjectImpl.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/project/impl/MZmineProjectImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2025 The mzmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -12,6 +12,7 @@
  *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -497,6 +498,18 @@ public class MZmineProjectImpl implements MZmineProject {
     } catch (InvalidPathException e) {
       logger.log(Level.SEVERE, "Cannot resolve file path relative to project.", e);
       return null;
+    }
+  }
+
+  @Override
+  public void clearFeatureLists() {
+    try {
+      featureLock.writeLock().lock();
+      final List<FeatureList> current = getCurrentFeatureLists();
+      featureLists.clear();
+      fireFeatureListsChangeEvent(current, Type.REMOVED);
+    } finally {
+      featureLock.writeLock().unlock();
     }
   }
 }

--- a/mzmine-community/src/test/java/import_data/speed/BatchSpeedJob.java
+++ b/mzmine-community/src/test/java/import_data/speed/BatchSpeedJob.java
@@ -28,13 +28,60 @@ package import_data.speed;
 import java.io.File;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-public record BatchSpeedJob(String description, int iterations, String batchFile,
-                            List<String> files) {
+/**
+ * One batch that is applied {@code warmupIterations + iterations} times.
+ *
+ * @param description      string that qualifies what is tested, e.g. the branch name or the
+ *                         optimization under test. The report groups the measurements by this.
+ * @param warmupIterations iterations that run before the measured ones, so that JIT compilation and
+ *                         file system caches do not end up in the compared numbers. They are still
+ *                         exported, marked as {@link SpeedTestPhase#WARMUP}.
+ * @param iterations       measured iterations, marked as {@link SpeedTestPhase#PRODUCTION}
+ * @param batchFile        resource path or absolute path of the batch file
+ * @param files            raw data files to import, or null to use the files defined in the batch
+ * @param trackMemory      samples the peak heap and reads the garbage collector counters, see
+ *                         {@link MemorySampler}. Off by default because it costs performance - run
+ *                         it once to learn the peak heap and the GC behaviour, keep it off when
+ *                         comparing speed.
+ */
+public record BatchSpeedJob(@NotNull String description, int warmupIterations, int iterations,
+                            @NotNull String batchFile, @Nullable List<String> files,
+                            boolean trackMemory) {
+
+  public BatchSpeedJob(@NotNull final String description, final int warmupIterations,
+      final int iterations, @NotNull final String batchFile, @Nullable final List<String> files) {
+    this(description, warmupIterations, iterations, batchFile, files, false);
+  }
+
+  public BatchSpeedJob(@NotNull final String description, final int iterations,
+      @NotNull final String batchFile, @Nullable final List<String> files) {
+    this(description, 1, iterations, batchFile, files, false);
+  }
 
   @NotNull
   public String getBatchFileName() {
     return new File(batchFile).getName();
   }
-}
 
+  /**
+   * @param index overall iteration index, warmups come first
+   */
+  @NotNull
+  public SpeedTestPhase phaseOf(final int index) {
+    return index < warmupIterations ? SpeedTestPhase.WARMUP : SpeedTestPhase.PRODUCTION;
+  }
+
+  /**
+   * @param index overall iteration index
+   * @return the 1-based index within its phase
+   */
+  public int iterationInPhase(final int index) {
+    return index < warmupIterations ? index + 1 : index - warmupIterations + 1;
+  }
+
+  public int totalIterations() {
+    return warmupIterations + iterations;
+  }
+}

--- a/mzmine-community/src/test/java/import_data/speed/BatchSpeedTestMain.java
+++ b/mzmine-community/src/test/java/import_data/speed/BatchSpeedTestMain.java
@@ -95,7 +95,7 @@ public class BatchSpeedTestMain {
   public static void main(String[] args) {
     String speedTestFile = property("out", "D:\\speed");
     // qualifies what is tested, e.g. the branch name or the optimization under test
-    String description = property("description", "mzmine4.10.25_fastercopy3");
+    String description = property("description", "master4.10.26");
     // keep running and all in memory
 //    String inMemory = "all";
     String inMemory = property("inMemory", "none");
@@ -104,13 +104,13 @@ public class BatchSpeedTestMain {
     // opt in, the sampler costs performance
     boolean trackMemory = booleanProperty("trackMemory", false);
     int warmups = intProperty("warmups", 1);
-    int iterations = intProperty("iterations", 2);
+    int iterations = intProperty("iterations", 4);
 
 //    String batchFile = "rawdatafiles/test_batch_small.xml";
 //    String batchFile = "D:\\tmp\\workshop_small.mzbatch";
-    String batchFile = property("batch", "D:\\Data\\batch\\test_small_microbes.mzbatch");
-//    String batchFile = property("batch",
-//        "D:\\OneDrive - mzio GmbH\\mzio\\Example data\\speedtest_benchmark\\Orbitrap_QE_environmental_DOM_sea_water\\0_dom_250_mzmine4-10-25-factor_speed.mzbatch");
+//    String batchFile = property("batch", "D:\\Data\\batch\\test_small_microbes.mzbatch");
+    String batchFile = property("batch",
+        "D:\\OneDrive - mzio GmbH\\mzio\\Example data\\speedtest_benchmark\\Orbitrap_QE_environmental_DOM_sea_water\\0_dom_250_mzmine4-10-25-factor_speed.mzbatch");
 //    List<String> samples = List.of("rawdatafiles/DOM_a.mzML",
 //        "rawdatafiles/DOM_a_invalid_chars.mzML", "rawdatafiles/DOM_a_invalid_header.mzML",
 //        "rawdatafiles/DOM_b.mzXML", "rawdatafiles/DOM_b_invalid_header.mzXML");

--- a/mzmine-community/src/test/java/import_data/speed/BatchSpeedTestMain.java
+++ b/mzmine-community/src/test/java/import_data/speed/BatchSpeedTestMain.java
@@ -25,10 +25,6 @@
 
 package import_data.speed;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.dataformat.csv.CsvMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.modules.MZmineProcessingStep;
@@ -36,23 +32,18 @@ import io.github.mzmine.modules.batchmode.BatchModeModule;
 import io.github.mzmine.modules.batchmode.BatchQueue;
 import io.github.mzmine.modules.batchmode.BatchTask;
 import io.github.mzmine.modules.batchmode.LoadedBatchQueue;
-import io.github.mzmine.modules.batchmode.timing.StepTimeMeasurement;
+import io.github.mzmine.modules.batchmode.timing.StepMeasurement;
 import io.github.mzmine.modules.io.import_rawdata_all.AllSpectralDataImportModule;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesSelectionType;
 import io.github.mzmine.project.ProjectService;
 import io.github.mzmine.taskcontrol.TaskStatus;
-import io.github.mzmine.util.files.FileAndPathUtil;
-import io.github.mzmine.util.io.JsonUtils;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.StandardOpenOption;
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -60,43 +51,97 @@ import java.util.logging.Logger;
 import javax.xml.parsers.ParserConfigurationException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jspecify.annotations.NonNull;
-import org.junit.jupiter.api.Assertions;
 import org.xml.sax.SAXException;
 
 /**
- * Speed test to log the time required to import files. Just define List of String that point to
- * resources files or absolute paths and add a test to the main method. The results will be appended
- * to speedTestFile define a full path here as it will otherwise be relative to build/target path.
- * When working with local files - put those into the import_data/local folder and create a new run
- * script similar to the main method here
+ * Speed test to log the time required to apply a batch. Just define the batch (and optionally a list
+ * of Strings that point to resource files or absolute paths) and add a test to the main method. The
+ * results are appended to speedTestFile as csv and jsonlines - define a full path here as it will
+ * otherwise be relative to build/target path. When working with local files - put those into the
+ * import_data/local folder and create a new run script similar to the main method here.
+ * {@link SpeedReportMain} turns the export into a html report that compares the runs.
  * <p>
- * Be sure to specify VM options -Xms16g -Xmx16g or similar to start with fixed memory
+ * Every job runs {@link BatchSpeedJob#warmupIterations()} warmup iterations before the measured
+ * ones. Warmups are exported as well but marked as {@link SpeedTestPhase#WARMUP} so that the report
+ * can drop them - they carry the JIT compilation and the cold file system caches.
+ * <p>
+ * All measurements that {@link BatchTask} collects are exported: time, used heap and the memory
+ * mapped temp file statistics per step, plus a {@link BatchTask#WHOLE_BATCH_NAME} row. Per iteration
+ * it also exports the {@link SpeedIterationStats}: the feature list result fingerprint, the temp
+ * directory disk usage and, when {@link BatchSpeedJob#trackMemory()} is on, the peak heap and the
+ * garbage collection.
+ * <p>
+ * Started either from the IDE (edit the values in the main) or through the gradle task
+ * {@code gradlew batchSpeedTest -Pspeed.description=... -Pspeed.batch=...}, which fixes the heap to
+ * 32 GB so that runs on different branches stay comparable. The task passes its configuration as
+ * {@code -Dmzmine.speed.*} system properties.
+ * <p>
+ * The harness never changes a preference. The performance relevant configuration
+ * ({@link io.github.mzmine.gui.preferences.MZminePreferences#runGCafterBatchStep},
+ * {@link io.github.mzmine.gui.preferences.MZminePreferences#numOfThreads}, the memory option, the VM
+ * arguments, ...) is only documented in every exported row, see {@link SpeedTestEnvironment}. Two
+ * runs are only comparable when those columns match, so keep the configuration and the VM options
+ * identical when comparing branches.
+ * <p>
+ * Be sure to specify VM options -Xms16g -Xmx16g or similar to start with fixed memory. Note that the
+ * used heap is only measured when runGCafterBatchStep is enabled in the preferences, which also
+ * changes the timings - so enable or disable it for all compared runs.
  */
 public class BatchSpeedTestMain {
 
   private static final Logger logger = Logger.getLogger(BatchSpeedTestMain.class.getName());
-  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+  private static final String PROPERTY_PREFIX = "mzmine.speed.";
 
   public static void main(String[] args) {
-    String speedTestFile = "D:\\speed.jsonlines";
-    String description = "mzmine4.10.25_fastercopy";
+    String speedTestFile = property("out", "D:\\speed");
+    // qualifies what is tested, e.g. the branch name or the optimization under test
+    String description = property("description", "mzmine4.10.25_fastercopy3");
     // keep running and all in memory
 //    String inMemory = "all";
-    String inMemory = "none";
-    boolean headLess = false;
-    boolean dataImportOnce = true;
+    String inMemory = property("inMemory", "none");
+    boolean headLess = booleanProperty("headless", false);
+    boolean dataImportOnce = booleanProperty("importOnce", true);
+    // opt in, the sampler costs performance
+    boolean trackMemory = booleanProperty("trackMemory", false);
+    int warmups = intProperty("warmups", 1);
+    int iterations = intProperty("iterations", 2);
 
 //    String batchFile = "rawdatafiles/test_batch_small.xml";
 //    String batchFile = "D:\\tmp\\workshop_small.mzbatch";
-    String batchFile = "D:\\OneDrive - mzio GmbH\\mzio\\Example data\\speedtest_benchmark\\Orbitrap_QE_environmental_DOM_sea_water\\0_dom_250_mzmine4-10-25-factor_speed.mzbatch";
+    String batchFile = property("batch", "D:\\Data\\batch\\test_small_microbes.mzbatch");
+//    String batchFile = property("batch",
+//        "D:\\OneDrive - mzio GmbH\\mzio\\Example data\\speedtest_benchmark\\Orbitrap_QE_environmental_DOM_sea_water\\0_dom_250_mzmine4-10-25-factor_speed.mzbatch");
 //    List<String> samples = List.of("rawdatafiles/DOM_a.mzML",
 //        "rawdatafiles/DOM_a_invalid_chars.mzML", "rawdatafiles/DOM_a_invalid_header.mzML",
 //        "rawdatafiles/DOM_b.mzXML", "rawdatafiles/DOM_b_invalid_header.mzXML");
 
-    List<BatchSpeedJob> jobs = List.of(new BatchSpeedJob(description, 5, batchFile, null));
+    List<BatchSpeedJob> jobs = List.of(
+        new BatchSpeedJob(description, warmups, iterations, batchFile, null, trackMemory));
 
     startAndRunTests(speedTestFile, headLess, inMemory, jobs, dataImportOnce);
+  }
+
+  /**
+   * The gradle task passes the configuration as {@code -Dmzmine.speed.*} system properties, the
+   * hardcoded values above are the fallback when the main is started from the IDE.
+   */
+  @NotNull
+  private static String property(@NotNull final String name, @NotNull final String defaultValue) {
+    final String value = System.getProperty(PROPERTY_PREFIX + name);
+    return value == null || value.isBlank() ? defaultValue : value.trim();
+  }
+
+  private static boolean booleanProperty(@NotNull final String name, final boolean defaultValue) {
+    return Boolean.parseBoolean(property(name, String.valueOf(defaultValue)));
+  }
+
+  private static int intProperty(@NotNull final String name, final int defaultValue) {
+    try {
+      return Integer.parseInt(property(name, String.valueOf(defaultValue)));
+    } catch (NumberFormatException e) {
+      logger.warning("Not a number for " + PROPERTY_PREFIX + name + ", using " + defaultValue);
+      return defaultValue;
+    }
   }
 
   public static void startAndRunTests(final String outFile, final boolean headLess,
@@ -111,28 +156,31 @@ public class BatchSpeedTestMain {
             MZmineCore.main(new String[]{"-m", inMemory});
           }
         } catch (Exception ex) {
+          logger.log(Level.SEVERE, "Failed to start mzmine: " + ex.getMessage(), ex);
         }
       }, 0, TimeUnit.SECONDS);
       long delay = headLess ? 1 : 6;
-      executor.schedule(
-          () -> BatchSpeedTestMain.testSpeed(outFile, headLess, inMemory, jobs, dataImportOnce),
+      executor.schedule(() -> BatchSpeedTestMain.testSpeed(outFile, inMemory, jobs, dataImportOnce),
           delay, TimeUnit.SECONDS);
     }
   }
 
-  private static void testSpeed(final String outFile, final boolean headLess, final String inMemory,
-      List<BatchSpeedJob> jobs, boolean dataImportOnce) {
-    try {
-      for (int i = 0; i < jobs.size(); i++) {
-        var job = jobs.get(i);
-        // may import data once and then do all iterations with the data
-        final LoadedBatchQueue fullBatch = prepareBatch(job, dataImportOnce);
+  private static void testSpeed(final String outFile, final String inMemory,
+      final List<BatchSpeedJob> jobs, final boolean dataImportOnce) {
+    // one id for all iterations of this JVM, so that drift within a single run stays visible
+    final String runId = UUID.randomUUID().toString().substring(0, 8);
+    final SpeedTestEnvironment env = SpeedTestEnvironment.detect(inMemory);
+    logger.info("Speed test run %s: %s".formatted(runId, env.describe()));
 
-        for (int iteration = 0; iteration < job.iterations(); iteration++) {
-          String description =
-              "inMemory=" + inMemory + ", " + job.description() + " " + (headLess ? "headless"
-                  : "GUI" + (dataImportOnce ? "import once" : ""));
-          runBatch(job, description, fullBatch.newQueue(), outFile, dataImportOnce);
+    try (var writer = new SpeedMeasurementWriter(new File(outFile))) {
+      for (final BatchSpeedJob job : jobs) {
+        // may import data once and then do all iterations with the data
+        final LoadedBatchQueue fullBatch = prepareBatch(job, dataImportOnce, runId, env, writer);
+
+        for (int iteration = 0; iteration < job.totalIterations(); iteration++) {
+          // clone so that a batch changing its own parameters cannot affect the next iteration
+          runBatch(job, runId, env, job.phaseOf(iteration), job.iterationInPhase(iteration),
+              fullBatch.newQueue().clone(), writer, dataImportOnce);
         }
 
         // clear whole project also libraries after each job
@@ -140,15 +188,19 @@ public class BatchSpeedTestMain {
         ProjectService.getProject().clearSpectralLibrary();
       }
 
+      logger.info("Speed test run %s finished, results in %s".formatted(runId,
+          writer.getCsvFile().getAbsolutePath()));
       System.exit(0);
 
-    } catch (InterruptedException | IOException | ParserConfigurationException | SAXException e) {
+    } catch (IOException | ParserConfigurationException | SAXException e) {
       logger.log(Level.SEVERE, e.getMessage(), e);
     }
     System.exit(1);
   }
 
-  private static @NonNull LoadedBatchQueue prepareBatch(BatchSpeedJob job, boolean dataImportOnce)
+  private static @NotNull LoadedBatchQueue prepareBatch(final BatchSpeedJob job,
+      final boolean dataImportOnce, final String runId, final SpeedTestEnvironment env,
+      final SpeedMeasurementWriter writer)
       throws ParserConfigurationException, IOException, SAXException {
     final LoadedBatchQueue fullBatch = BatchQueue.loadFromFile(getFileOrResource(job.batchFile()));
 
@@ -165,94 +217,96 @@ public class BatchSpeedTestMain {
       System.exit(1);
     }
 
-    if (dataImportOnce) {
-      // remove data import step and just apply it once
-      if (fullBatch.newQueue().getFirst().getModule() instanceof AllSpectralDataImportModule) {
-        File[] files = job.files() == null ? null
-            : job.files().stream().map(BatchSpeedTestMain::getFileOrResource).toArray(File[]::new);
-        //
-        final BatchQueue importData = new BatchQueue();
-        // remove first step from full batch and run it once
-        importData.add(fullBatch.newQueue().removeFirst());
-        final BatchTask batchTask = BatchModeModule.runBatchQueue(importData,
-            ProjectService.getProject(), files, null, null, null, Instant.now(), null, null);
-        if (batchTask == null) {
-          logger.severe("Data import once batch queue returned null");
-          System.exit(1);
-        } else if (batchTask.getStatus() != TaskStatus.FINISHED) {
-          logger.severe(
-              "Data import once batch queue finished with bad state " + batchTask.getStatus());
-          System.exit(1);
-        }
-        final StepTimeMeasurement first = batchTask.getStepTimes().getFirst();
-        // maybe add to csv?
+    if (!dataImportOnce) {
+      return fullBatch;
+    }
 
-        // use specific files for rest steps
-        for (MZmineProcessingStep<MZmineProcessingModule> step : fullBatch.newQueue()) {
-          step.getParameterSet().streamForClass(RawDataFilesParameter.class).forEach(
-              rawParam -> rawParam.setValue(RawDataFilesSelectionType.SPECIFIC_FILES,
-                  ProjectService.getProject().getDataFiles()));
-        }
-      } else {
-        logger.severe(
-            "First step needs to be AllSpectralDataImportModule for import data once option. or disable this option");
-        System.exit(1);
-      }
+    // remove data import step and just apply it once
+    if (!(fullBatch.newQueue().getFirst().getModule() instanceof AllSpectralDataImportModule)) {
+      logger.severe(
+          "First step needs to be AllSpectralDataImportModule for import data once option. or disable this option");
+      System.exit(1);
+    }
+
+    final File[] files = filesOf(job.files());
+    //
+    final BatchQueue importData = new BatchQueue();
+    // remove first step from full batch and run it once
+    importData.add(fullBatch.newQueue().removeFirst());
+    final double tempDirFreeGB = SpeedIterationStats.tempDirFreeGB();
+    final BatchTask batchTask = BatchModeModule.runBatchQueue(importData,
+        ProjectService.getProject(), files, null, null, null, Instant.now(), null, null);
+    if (batchTask == null) {
+      logger.severe("Data import once batch queue returned null");
+      System.exit(1);
+      return fullBatch; // unreachable, keeps the compiler happy about the null check
+    }
+    if (batchTask.getStatus() != TaskStatus.FINISHED) {
+      logger.severe(
+          "Data import once batch queue finished with bad state " + batchTask.getStatus());
+      System.exit(1);
+    }
+
+    // the import is not part of the compared iterations but still exported as warmup so that import
+    // regressions stay visible. Its WHOLE BATCH row is dropped, it would only duplicate the step.
+    final List<StepMeasurement> importMeasurements = batchTask.getStepMeasurements().stream()
+        .filter(m -> !BatchTask.WHOLE_BATCH_NAME.equals(m.name())).toList();
+    // no feature lists yet after the import, the fingerprint columns are 0 for these rows
+    writer.append(toRows(job, runId, env, SpeedTestPhase.WARMUP, 1, TaskStatus.FINISHED.toString(),
+        numberOfFiles(job, true), importMeasurements,
+        SpeedIterationStats.after(tempDirFreeGB, null)));
+
+    // use specific files for rest steps
+    for (MZmineProcessingStep<MZmineProcessingModule> step : fullBatch.newQueue()) {
+      step.getParameterSet().streamForClass(RawDataFilesParameter.class).forEach(
+          rawParam -> rawParam.setValue(RawDataFilesSelectionType.SPECIFIC_FILES,
+              ProjectService.getProject().getDataFiles()));
     }
 
     return fullBatch;
   }
 
-  private static void runBatch(BatchSpeedJob job, String description, final BatchQueue batchQueue,
-      final String outFile, boolean dataImportOnce) throws InterruptedException, IOException {
+  private static void runBatch(final BatchSpeedJob job, final String runId,
+      final SpeedTestEnvironment env, final SpeedTestPhase phase, final int iteration,
+      final BatchQueue batchQueue, final SpeedMeasurementWriter writer,
+      final boolean dataImportOnce) {
 
+    logger.info("Speed test %s: %s iteration %d of job %s".formatted(runId, phase, iteration,
+        job.description()));
     System.gc();
     try {
-      File jsonFile = FileAndPathUtil.getRealFilePath(new File(outFile), ".jsonlines");
-      File tsvFile = FileAndPathUtil.getRealFilePath(new File(outFile), ".csv");
+      // disk space of the temp dir volume before the batch, the difference shows what it consumed
+      final double tempDirFreeGB = SpeedIterationStats.tempDirFreeGB();
+      final MemorySampler sampler = job.trackMemory() ? MemorySampler.start() : null;
 
-      FileAndPathUtil.createDirectory(tsvFile.getParentFile());
+      // with dataImportOnce the import step was already applied and removed - do not override the
+      // files again as there is no import step left to change
+      final BatchTask task = BatchModeModule.runBatchQueue(batchQueue, ProjectService.getProject(),
+          dataImportOnce ? null : filesOf(job.files()), null, null, null, Instant.now(), null,
+          null);
 
-      List<StepTimeMeasurement> finished = runBatch(job.files(), batchQueue);
+      final MemoryMeasurement memory = sampler == null ? null : sampler.stop();
+      // reads the newest feature list, so measure before the project is cleared below
+      final SpeedIterationStats iterationStats = SpeedIterationStats.after(tempDirFreeGB, memory);
 
-      boolean exists = tsvFile.exists();
-      try (var jsonWriter = Files.newBufferedWriter(jsonFile.toPath(), StandardCharsets.UTF_8,
-          StandardOpenOption.APPEND, StandardOpenOption.CREATE)) {
-        try (var tsvWriter = Files.newBufferedWriter(tsvFile.toPath(), StandardCharsets.UTF_8,
-            StandardOpenOption.APPEND, StandardOpenOption.CREATE)) {
-
-          logger.info("Exporting files to " + tsvFile.getAbsolutePath());
-
-          var tsvMapper = CsvMapper.builder().addModule(new JavaTimeModule()).build();
-          var schema = tsvMapper.schemaFor(SpeedMeasurement.class).withUseHeader(!exists);
-          ObjectWriter tsvObjectWriter = tsvMapper.writer(schema);
-
-          ObjectMapper jsonMapper = JsonUtils.MAPPER;
-
-          final String now = LocalDate.now().format(DATE_FORMATTER);
-
-          for (final StepTimeMeasurement step : finished) {
-            double seconds = step.secondsToFinish();
-            var nFiles = job.files() == null ? ProjectService.getProject().getNumberOfDataFiles()
-                : job.files().size();
-            var sm = new SpeedMeasurement(now, step.name(), job.getBatchFileName(), description,
-                nFiles, seconds, step.usedHeapGB());
-
-            String tsv = tsvObjectWriter.writeValueAsString(sm);
-            tsvWriter.append(tsv);
-            // disable header
-            tsvObjectWriter = tsvMapper.writer(schema.withUseHeader(false));
-
-            String str = jsonMapper.writeValueAsString(sm);
-            jsonWriter.append(str).append('\n');
-          }
+      if (task == null) {
+        logger.severe("Batch queue returned null, no measurements for this iteration");
+      } else {
+        if (task.getStatus() != TaskStatus.FINISHED) {
+          // still exported, the status column marks the iteration as unusable
+          logger.severe(
+              "Batch finished with bad state " + task.getStatus() + ": " + task.getErrorMessage());
         }
+        logger.info(
+            "Iteration result: %d feature lists, newest has %d rows and %d features".formatted(
+                iterationStats.featureLists(), iterationStats.rows(), iterationStats.features()));
+        writer.append(toRows(job, runId, env, phase, iteration, task.getStatus().toString(),
+            numberOfFiles(job, dataImportOnce), task.getStepMeasurements(), iterationStats));
       }
     } catch (Exception ex) {
       logger.log(Level.SEVERE,
-          "Failed batch " + description + " for " + batchQueue + " with " + (job.files() == null
-              ? "x" : job.files().size()) + " files. Will continue with next task. "
-              + ex.getMessage(), ex);
+          "Failed batch %s %s iteration %d. Will continue with the next iteration. %s".formatted(
+              job.description(), phase, iteration, ex.getMessage()), ex);
     }
 
     if (!dataImportOnce) {
@@ -263,17 +317,33 @@ public class BatchSpeedTestMain {
     }
   }
 
-  public static List<StepTimeMeasurement> runBatch(@Nullable final List<String> fileNames,
-      BatchQueue batchQueue) {
-    File[] files = fileNames == null ? null
+  @NotNull
+  private static List<SpeedMeasurement> toRows(final BatchSpeedJob job, final String runId,
+      final SpeedTestEnvironment env, final SpeedTestPhase phase, final int iteration,
+      final String status, final int files, final List<StepMeasurement> measurements,
+      final SpeedIterationStats iterationStats) {
+    final String now = Instant.now().toString();
+    final List<SpeedMeasurement> rows = new ArrayList<>(measurements.size());
+    for (final StepMeasurement measurement : measurements) {
+      rows.add(new SpeedMeasurement(now, runId, job.description(), job.getBatchFileName(), phase,
+          iteration, status, files, measurement, iterationStats, env));
+    }
+    return rows;
+  }
+
+  /**
+   * With dataImportOnce the files were already imported, so the project knows the real number.
+   */
+  private static int numberOfFiles(final BatchSpeedJob job, final boolean dataImportOnce) {
+    if (dataImportOnce || job.files() == null) {
+      return ProjectService.getProject().getNumberOfDataFiles();
+    }
+    return job.files().size();
+  }
+
+  private static @Nullable File @Nullable [] filesOf(@Nullable final List<String> fileNames) {
+    return fileNames == null ? null
         : fileNames.stream().map(BatchSpeedTestMain::getFileOrResource).toArray(File[]::new);
-
-    BatchTask task = BatchModeModule.runBatchQueue(batchQueue, ProjectService.getProject(), files,
-        null, null, null, Instant.now(), null, null);
-
-    Assertions.assertEquals(TaskStatus.FINISHED, task.getStatus());
-
-    return task.getStepTimes();
   }
 
   @NotNull

--- a/mzmine-community/src/test/java/import_data/speed/BatchSpeedTestMain.java
+++ b/mzmine-community/src/test/java/import_data/speed/BatchSpeedTestMain.java
@@ -73,8 +73,8 @@ import org.xml.sax.SAXException;
  * <p>
  * Started either from the IDE (edit the values in the main) or through the gradle task
  * {@code gradlew batchSpeedTest -Pspeed.description=... -Pspeed.batch=...}, which fixes the heap to
- * 32 GB so that runs on different branches stay comparable. The task passes its configuration as
- * {@code -Dmzmine.speed.*} system properties.
+ * 32 GB, or to {@code -Pspeed.heapGb=...} when given, so that runs on different branches stay
+ * comparable. The task passes its configuration as {@code -Dmzmine.speed.*} system properties.
  * <p>
  * The harness never changes a preference. The performance relevant configuration
  * ({@link io.github.mzmine.gui.preferences.MZminePreferences#runGCafterBatchStep},

--- a/mzmine-community/src/test/java/import_data/speed/BatchSpeedTestMain.java
+++ b/mzmine-community/src/test/java/import_data/speed/BatchSpeedTestMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2025 The mzmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -28,26 +28,41 @@ package import_data.speed;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.MZmineProcessingModule;
+import io.github.mzmine.modules.MZmineProcessingStep;
 import io.github.mzmine.modules.batchmode.BatchModeModule;
+import io.github.mzmine.modules.batchmode.BatchQueue;
 import io.github.mzmine.modules.batchmode.BatchTask;
+import io.github.mzmine.modules.batchmode.LoadedBatchQueue;
 import io.github.mzmine.modules.batchmode.timing.StepTimeMeasurement;
+import io.github.mzmine.modules.io.import_rawdata_all.AllSpectralDataImportModule;
+import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
+import io.github.mzmine.parameters.parametertypes.selectors.RawDataFilesSelectionType;
 import io.github.mzmine.project.ProjectService;
 import io.github.mzmine.taskcontrol.TaskStatus;
 import io.github.mzmine.util.files.FileAndPathUtil;
+import io.github.mzmine.util.io.JsonUtils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.xml.parsers.ParserConfigurationException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Assertions;
+import org.xml.sax.SAXException;
 
 /**
  * Speed test to log the time required to import files. Just define List of String that point to
@@ -61,29 +76,31 @@ import org.junit.jupiter.api.Assertions;
 public class BatchSpeedTestMain {
 
   private static final Logger logger = Logger.getLogger(BatchSpeedTestMain.class.getName());
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
 
   public static void main(String[] args) {
     String speedTestFile = "D:\\speed.jsonlines";
-    String description = "mzmine4.5";
+    String description = "mzmine4.10.25_fastercopy";
     // keep running and all in memory
 //    String inMemory = "all";
     String inMemory = "none";
     boolean headLess = false;
-   
+    boolean dataImportOnce = true;
+
 //    String batchFile = "rawdatafiles/test_batch_small.xml";
 //    String batchFile = "D:\\tmp\\workshop_small.mzbatch";
-    String batchFile = "D:\\OneDrive - mzio GmbH\\mzio\\Example data\\speedtest_benchmark\\Orbitrap_QE_environmental_DOM_sea_water\\0_dom_500_mzmine4-4-52.mzbatch";
+    String batchFile = "D:\\OneDrive - mzio GmbH\\mzio\\Example data\\speedtest_benchmark\\Orbitrap_QE_environmental_DOM_sea_water\\0_dom_250_mzmine4-10-25-factor_speed.mzbatch";
 //    List<String> samples = List.of("rawdatafiles/DOM_a.mzML",
 //        "rawdatafiles/DOM_a_invalid_chars.mzML", "rawdatafiles/DOM_a_invalid_header.mzML",
 //        "rawdatafiles/DOM_b.mzXML", "rawdatafiles/DOM_b_invalid_header.mzXML");
 
-    List<BatchSpeedJob> jobs = List.of(new BatchSpeedJob(description, 1, batchFile, null));
+    List<BatchSpeedJob> jobs = List.of(new BatchSpeedJob(description, 5, batchFile, null));
 
-    startAndRunTests(speedTestFile, headLess, inMemory, jobs);
+    startAndRunTests(speedTestFile, headLess, inMemory, jobs, dataImportOnce);
   }
 
   public static void startAndRunTests(final String outFile, final boolean headLess,
-      final String inMemory, List<BatchSpeedJob> jobs) {
+      final String inMemory, List<BatchSpeedJob> jobs, boolean dataImportOnce) {
     try (var executor = Executors.newScheduledThreadPool(2)) {
 
       executor.schedule(() -> {
@@ -97,44 +114,97 @@ public class BatchSpeedTestMain {
         }
       }, 0, TimeUnit.SECONDS);
       long delay = headLess ? 1 : 6;
-      executor.schedule(() -> BatchSpeedTestMain.testSpeed(outFile, headLess, inMemory, jobs),
+      executor.schedule(
+          () -> BatchSpeedTestMain.testSpeed(outFile, headLess, inMemory, jobs, dataImportOnce),
           delay, TimeUnit.SECONDS);
     }
   }
 
   private static void testSpeed(final String outFile, final boolean headLess, final String inMemory,
-      List<BatchSpeedJob> jobs) {
+      List<BatchSpeedJob> jobs, boolean dataImportOnce) {
     try {
-      int[] iterations = new int[jobs.size()];
-      while (true) {
-        boolean allDone = true;
-        for (int i = 0; i < jobs.size(); i++) {
-          var job = jobs.get(i);
-          if (iterations[i] < job.iterations()) {
-            iterations[i]++;
-            allDone = false;
+      for (int i = 0; i < jobs.size(); i++) {
+        var job = jobs.get(i);
+        // may import data once and then do all iterations with the data
+        final LoadedBatchQueue fullBatch = prepareBatch(job, dataImportOnce);
 
-            String description =
-                "inMemory=" + inMemory + ", " + job.description() + " " + (headLess ? "headless"
-                    : "GUI");
-            runBatch(description, job.files(), job.batchFile(), outFile);
-          }
+        for (int iteration = 0; iteration < job.iterations(); iteration++) {
+          String description =
+              "inMemory=" + inMemory + ", " + job.description() + " " + (headLess ? "headless"
+                  : "GUI" + (dataImportOnce ? "import once" : ""));
+          runBatch(job, description, fullBatch.newQueue(), outFile, dataImportOnce);
         }
-        if (allDone) {
-          break;
-        }
+
+        // clear whole project also libraries after each job
+        ProjectService.getProjectManager().clearProject();
+        ProjectService.getProject().clearSpectralLibrary();
       }
 
       System.exit(0);
 
-    } catch (InterruptedException | IOException e) {
-      throw new RuntimeException(e);
+    } catch (InterruptedException | IOException | ParserConfigurationException | SAXException e) {
+      logger.log(Level.SEVERE, e.getMessage(), e);
     }
     System.exit(1);
   }
 
-  private static void runBatch(String description, @Nullable final List<String> files,
-      final String batchFile, final String outFile) throws InterruptedException, IOException {
+  private static @NonNull LoadedBatchQueue prepareBatch(BatchSpeedJob job, boolean dataImportOnce)
+      throws ParserConfigurationException, IOException, SAXException {
+    final LoadedBatchQueue fullBatch = BatchQueue.loadFromFile(getFileOrResource(job.batchFile()));
+
+    // versions might have changed
+    if (!fullBatch.errorMessages().isEmpty()) {
+      logger.log(Level.WARNING, "Warnings during batch file import:");
+      for (final String errorMessage : fullBatch.errorMessages()) {
+        logger.log(Level.WARNING, errorMessage);
+      }
+      // parameters have updated, we need to exit
+      logger.log(Level.SEVERE,
+          "Exiting because some parameter sets have been updated since the batch was "
+              + "created. Please update the batch file by opening it in the GUI and try again.");
+      System.exit(1);
+    }
+
+    if (dataImportOnce) {
+      // remove data import step and just apply it once
+      if (fullBatch.newQueue().getFirst().getModule() instanceof AllSpectralDataImportModule) {
+        File[] files = job.files() == null ? null
+            : job.files().stream().map(BatchSpeedTestMain::getFileOrResource).toArray(File[]::new);
+        //
+        final BatchQueue importData = new BatchQueue();
+        // remove first step from full batch and run it once
+        importData.add(fullBatch.newQueue().removeFirst());
+        final BatchTask batchTask = BatchModeModule.runBatchQueue(importData,
+            ProjectService.getProject(), files, null, null, null, Instant.now(), null, null);
+        if (batchTask == null) {
+          logger.severe("Data import once batch queue returned null");
+          System.exit(1);
+        } else if (batchTask.getStatus() != TaskStatus.FINISHED) {
+          logger.severe(
+              "Data import once batch queue finished with bad state " + batchTask.getStatus());
+          System.exit(1);
+        }
+        final StepTimeMeasurement first = batchTask.getStepTimes().getFirst();
+        // maybe add to csv?
+
+        // use specific files for rest steps
+        for (MZmineProcessingStep<MZmineProcessingModule> step : fullBatch.newQueue()) {
+          step.getParameterSet().streamForClass(RawDataFilesParameter.class).forEach(
+              rawParam -> rawParam.setValue(RawDataFilesSelectionType.SPECIFIC_FILES,
+                  ProjectService.getProject().getDataFiles()));
+        }
+      } else {
+        logger.severe(
+            "First step needs to be AllSpectralDataImportModule for import data once option. or disable this option");
+        System.exit(1);
+      }
+    }
+
+    return fullBatch;
+  }
+
+  private static void runBatch(BatchSpeedJob job, String description, final BatchQueue batchQueue,
+      final String outFile, boolean dataImportOnce) throws InterruptedException, IOException {
 
     System.gc();
     try {
@@ -143,7 +213,7 @@ public class BatchSpeedTestMain {
 
       FileAndPathUtil.createDirectory(tsvFile.getParentFile());
 
-      List<StepTimeMeasurement> finished = runBatch(files, batchFile);
+      List<StepTimeMeasurement> finished = runBatch(job.files(), batchQueue);
 
       boolean exists = tsvFile.exists();
       try (var jsonWriter = Files.newBufferedWriter(jsonFile.toPath(), StandardCharsets.UTF_8,
@@ -153,17 +223,19 @@ public class BatchSpeedTestMain {
 
           logger.info("Exporting files to " + tsvFile.getAbsolutePath());
 
-          var tsvMapper = new CsvMapper();
+          var tsvMapper = CsvMapper.builder().addModule(new JavaTimeModule()).build();
           var schema = tsvMapper.schemaFor(SpeedMeasurement.class).withUseHeader(!exists);
           ObjectWriter tsvObjectWriter = tsvMapper.writer(schema);
 
-          ObjectMapper jsonMapper = new ObjectMapper();
+          ObjectMapper jsonMapper = JsonUtils.MAPPER;
+
+          final String now = LocalDate.now().format(DATE_FORMATTER);
 
           for (final StepTimeMeasurement step : finished) {
             double seconds = step.secondsToFinish();
-            var nFiles =
-                files == null ? ProjectService.getProject().getNumberOfDataFiles() : files.size();
-            var sm = new SpeedMeasurement(step.name(), new File(batchFile).getName(), description,
+            var nFiles = job.files() == null ? ProjectService.getProject().getNumberOfDataFiles()
+                : job.files().size();
+            var sm = new SpeedMeasurement(now, step.name(), job.getBatchFileName(), description,
                 nFiles, seconds, step.usedHeapGB());
 
             String tsv = tsvObjectWriter.writeValueAsString(sm);
@@ -177,23 +249,27 @@ public class BatchSpeedTestMain {
         }
       }
     } catch (Exception ex) {
-      logger.info(
-          "Failed batch " + description + " for " + batchFile + " with " + (files == null ? "x"
-              : files.size()) + " files. Will continue with next task.");
+      logger.log(Level.SEVERE,
+          "Failed batch " + description + " for " + batchQueue + " with " + (job.files() == null
+              ? "x" : job.files().size()) + " files. Will continue with next task. "
+              + ex.getMessage(), ex);
     }
 
-    ProjectService.getProjectManager().clearProject();
+    if (!dataImportOnce) {
+      // skip if data import once
+      ProjectService.getProjectManager().clearProject();
+    } else {
+      ProjectService.getProject().clearFeatureLists();
+    }
   }
 
   public static List<StepTimeMeasurement> runBatch(@Nullable final List<String> fileNames,
-      String batchFile) {
+      BatchQueue batchQueue) {
     File[] files = fileNames == null ? null
         : fileNames.stream().map(BatchSpeedTestMain::getFileOrResource).toArray(File[]::new);
 
-    File batch = getFileOrResource(batchFile);
-
-    BatchTask task = BatchModeModule.runBatchFile(ProjectService.getProject(), batch, files, null, null,
-        null, Instant.now(), null, null);
+    BatchTask task = BatchModeModule.runBatchQueue(batchQueue, ProjectService.getProject(), files,
+        null, null, null, Instant.now(), null, null);
 
     Assertions.assertEquals(TaskStatus.FINISHED, task.getStatus());
 

--- a/mzmine-community/src/test/java/import_data/speed/BatchSpeedTestMain.java
+++ b/mzmine-community/src/test/java/import_data/speed/BatchSpeedTestMain.java
@@ -25,6 +25,7 @@
 
 package import_data.speed;
 
+import io.github.mzmine.gui.preferences.MZminePreferences;
 import io.github.mzmine.main.MZmineCore;
 import io.github.mzmine.modules.MZmineProcessingModule;
 import io.github.mzmine.modules.MZmineProcessingStep;
@@ -77,8 +78,8 @@ import org.xml.sax.SAXException;
  * comparable. The task passes its configuration as {@code -Dmzmine.speed.*} system properties.
  * <p>
  * The harness never changes a preference. The performance relevant configuration
- * ({@link io.github.mzmine.gui.preferences.MZminePreferences#runGCafterBatchStep},
- * {@link io.github.mzmine.gui.preferences.MZminePreferences#numOfThreads}, the memory option, the VM
+ * ({@link MZminePreferences#runGCafterBatchStep},
+ * {@link MZminePreferences#numOfThreads}, the memory option, the VM
  * arguments, ...) is only documented in every exported row, see {@link SpeedTestEnvironment}. Two
  * runs are only comparable when those columns match, so keep the configuration and the VM options
  * identical when comparing branches.

--- a/mzmine-community/src/test/java/import_data/speed/ImportSpeedTestMain.java
+++ b/mzmine-community/src/test/java/import_data/speed/ImportSpeedTestMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2025 The mzmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -12,6 +12,7 @@
  *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -24,7 +25,8 @@
 
 package import_data.speed;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.collect.Range;
 import io.github.mzmine.gui.preferences.MassLynxImportOptions;
 import io.github.mzmine.gui.preferences.VendorImportParameters;
@@ -43,6 +45,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.Nullable;
@@ -69,6 +73,7 @@ public class ImportSpeedTestMain {
       """.split("\n"));
   private static final Logger logger = Logger.getLogger(ImportSpeedTestMain.class.getName());
   public static String speedTestFile = "D:\\git\\mzmine3\\mzmine-community\\src\\test\\java\\import_data\\speed\\speed.jsonlines";
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
 
   public static void main(String[] args) {
 
@@ -106,7 +111,8 @@ public class ImportSpeedTestMain {
 
     if (finished instanceof FINISHED f) {
       System.gc(); // better memory tracking
-      var sm = new SpeedMeasurement(name, null, description, files.size(), f.getSeconds(),
+      final String now = LocalDate.now().format(DATE_FORMATTER);
+      var sm = new SpeedMeasurement(now, name, null, description, files.size(), f.getSeconds(),
           "%.2f".formatted(ConfigService.getConfiguration().getUsedMemoryGB()));
       appendToFile(speedTestFile, sm);
     }
@@ -120,7 +126,7 @@ public class ImportSpeedTestMain {
 
     try (var fileWriter = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8,
         WriterOptions.APPEND.toOpenOption())) {
-      var jsonWriter = new ObjectMapper();
+      var jsonWriter = JsonMapper.builder().addModule(new JavaTimeModule()).build();
       String str = jsonWriter.writeValueAsString(sm);
       fileWriter.append(str).append('\n');
     }

--- a/mzmine-community/src/test/java/import_data/speed/ImportSpeedTestMain.java
+++ b/mzmine-community/src/test/java/import_data/speed/ImportSpeedTestMain.java
@@ -33,6 +33,9 @@ import io.github.mzmine.gui.preferences.VendorImportParameters;
 import io.github.mzmine.gui.preferences.WatersLockmassParameters;
 import io.github.mzmine.main.ConfigService;
 import io.github.mzmine.main.MZmineCore;
+import io.github.mzmine.modules.batchmode.timing.StepMeasurement;
+import io.github.mzmine.modules.batchmode.timing.StepStorageMeasurement;
+import io.github.mzmine.modules.batchmode.timing.StepTimeMeasurement;
 import io.github.mzmine.modules.io.import_rawdata_all.AdvancedSpectraImportParameters;
 import io.github.mzmine.modules.io.import_rawdata_all.AllSpectralDataImportModule;
 import io.github.mzmine.modules.io.import_rawdata_all.AllSpectralDataImportParameters;
@@ -40,14 +43,17 @@ import io.github.mzmine.modules.tools.batchwizard.subparameters.MassDetectorWiza
 import io.github.mzmine.parameters.ParameterSet;
 import io.github.mzmine.parameters.parametertypes.selectors.ScanSelection;
 import io.github.mzmine.project.ProjectService;
+import io.github.mzmine.taskcontrol.TaskStatus;
+import io.github.mzmine.util.MemoryMapSnapshot;
+import io.github.mzmine.util.MemoryMapStorageStats;
 import io.github.mzmine.util.io.WriterOptions;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
+import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
@@ -73,7 +79,11 @@ public class ImportSpeedTestMain {
       """.split("\n"));
   private static final Logger logger = Logger.getLogger(ImportSpeedTestMain.class.getName());
   public static String speedTestFile = "D:\\git\\mzmine3\\mzmine-community\\src\\test\\java\\import_data\\speed\\speed.jsonlines";
-  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+  /**
+   * Groups all measurements of this JVM, same as in {@link BatchSpeedTestMain}.
+   */
+  private static final String RUN_ID = UUID.randomUUID().toString().substring(0, 8);
+  private static int iteration = 0;
 
   public static void main(String[] args) {
 
@@ -107,13 +117,23 @@ public class ImportSpeedTestMain {
     var advanced = AdvancedSpectraImportParameters.create(
         MassDetectorWizardOptions.FACTOR_OF_LOWEST_SIGNAL, 1E5, 1E3, Range.closed(100d, 1000d),
         selection, true);
+
+    // same measurements as the batch speed test, see BatchTask
+    final MemoryMapSnapshot storageBefore = MemoryMapStorageStats.snapshot();
+    final double tempDirFreeGB = SpeedIterationStats.tempDirFreeGB();
     TaskResult finished = importFiles(files, 5 * 60, advanced);
 
     if (finished instanceof FINISHED f) {
       System.gc(); // better memory tracking
-      final String now = LocalDate.now().format(DATE_FORMATTER);
-      var sm = new SpeedMeasurement(now, name, null, description, files.size(), f.getSeconds(),
+      final MemoryMapSnapshot storageAfter = MemoryMapStorageStats.snapshot();
+      final var time = new StepTimeMeasurement(1, f.getSeconds(), name,
           "%.2f".formatted(ConfigService.getConfiguration().getUsedMemoryGB()));
+      final var storage = new StepStorageMeasurement(1, name, storageBefore, storageAfter);
+
+      var sm = new SpeedMeasurement(Instant.now().toString(), RUN_ID, description, "",
+          SpeedTestPhase.PRODUCTION, ++iteration, TaskStatus.FINISHED.toString(), files.size(),
+          new StepMeasurement(time, storage), SpeedIterationStats.after(tempDirFreeGB, null),
+          SpeedTestEnvironment.detect("all"));
       appendToFile(speedTestFile, sm);
     }
 

--- a/mzmine-community/src/test/java/import_data/speed/MemoryMeasurement.java
+++ b/mzmine-community/src/test/java/import_data/speed/MemoryMeasurement.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package import_data.speed;
+
+/**
+ * Result of one {@link MemorySampler} run, see {@link SpeedIterationStats}.
+ *
+ * @param peakHeapGB    highest used heap that the sampler observed
+ * @param gcCount       garbage collections of all collectors during the iteration
+ * @param gcTimeSeconds time all collectors reported during the iteration
+ */
+public record MemoryMeasurement(double peakHeapGB, long gcCount, double gcTimeSeconds) {
+
+}

--- a/mzmine-community/src/test/java/import_data/speed/MemorySampler.java
+++ b/mzmine-community/src/test/java/import_data/speed/MemorySampler.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package import_data.speed;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Samples the used heap in a background thread and reads the garbage collector counters, so that a
+ * run can answer "how much heap does this batch really need" and "does this branch allocate more".
+ * <p>
+ * This is opt-in ({@link BatchSpeedJob#trackMemory()}) because it costs performance: the sampling
+ * thread takes a core slice from the batch and, more importantly, the numbers invite a slower GC
+ * configuration. Use one tracked run to learn the peak heap and the GC behaviour, then keep it off
+ * for the runs that compare speed.
+ */
+public class MemorySampler {
+
+  private static final long INTERVAL_MS = 250;
+
+  private final AtomicBoolean running = new AtomicBoolean(true);
+  private final Thread thread;
+  private final long startGcCount;
+  private final long startGcMillis;
+  private volatile long peakUsedBytes;
+
+  private MemorySampler() {
+    startGcCount = gcCount();
+    startGcMillis = gcMillis();
+
+    thread = new Thread(this::sample, "speed-test-memory-sampler");
+    // must never keep the JVM alive
+    thread.setDaemon(true);
+    thread.start();
+  }
+
+  /**
+   * Starts sampling immediately, call {@link #stop()} after the measured work.
+   */
+  @NotNull
+  public static MemorySampler start() {
+    return new MemorySampler();
+  }
+
+  private void sample() {
+    final Runtime runtime = Runtime.getRuntime();
+    while (running.get()) {
+      final long used = runtime.totalMemory() - runtime.freeMemory();
+      if (used > peakUsedBytes) {
+        peakUsedBytes = used;
+      }
+      try {
+        Thread.sleep(INTERVAL_MS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+    }
+  }
+
+  /**
+   * Stops the sampling thread and returns the peak heap and the garbage collection that happened
+   * since {@link #start()}.
+   */
+  @NotNull
+  public MemoryMeasurement stop() {
+    running.set(false);
+    thread.interrupt();
+    return new MemoryMeasurement(Math.round(peakUsedBytes / 1e7) / 100d, gcCount() - startGcCount,
+        (gcMillis() - startGcMillis) / 1000.0);
+  }
+
+  private static long gcCount() {
+    long count = 0;
+    for (final GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
+      // -1 means the collector does not provide the counter
+      count += Math.max(bean.getCollectionCount(), 0);
+    }
+    return count;
+  }
+
+  private static long gcMillis() {
+    long millis = 0;
+    for (final GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
+      millis += Math.max(bean.getCollectionTime(), 0);
+    }
+    return millis;
+  }
+}

--- a/mzmine-community/src/test/java/import_data/speed/SmallDomBatchSpeedTestMain.java
+++ b/mzmine-community/src/test/java/import_data/speed/SmallDomBatchSpeedTestMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The MZmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -58,7 +58,7 @@ public class SmallDomBatchSpeedTestMain {
 
     List<BatchSpeedJob> jobs = List.of(new BatchSpeedJob(description, 3, batchFile, samples));
 
-    BatchSpeedTestMain.startAndRunTests(speedTestFile, headLess, inMemory, jobs);
+    BatchSpeedTestMain.startAndRunTests(speedTestFile, headLess, inMemory, jobs, false);
   }
 
 }

--- a/mzmine-community/src/test/java/import_data/speed/SmallDomBatchSpeedTestMain.java
+++ b/mzmine-community/src/test/java/import_data/speed/SmallDomBatchSpeedTestMain.java
@@ -56,7 +56,7 @@ public class SmallDomBatchSpeedTestMain {
 
     String batchFile = "rawdatafiles/test_batch_small.xml";
 
-    List<BatchSpeedJob> jobs = List.of(new BatchSpeedJob(description, 3, batchFile, samples));
+    List<BatchSpeedJob> jobs = List.of(new BatchSpeedJob(description, 1, 3, batchFile, samples));
 
     BatchSpeedTestMain.startAndRunTests(speedTestFile, headLess, inMemory, jobs, false);
   }

--- a/mzmine-community/src/test/java/import_data/speed/SpeedIterationStats.java
+++ b/mzmine-community/src/test/java/import_data/speed/SpeedIterationStats.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package import_data.speed;
+
+import io.github.mzmine.datamodel.features.FeatureList;
+import io.github.mzmine.datamodel.features.FeatureListRow;
+import io.github.mzmine.project.ProjectService;
+import io.github.mzmine.util.files.FileAndPathUtil;
+import java.io.File;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Everything that is measured once per iteration instead of once per batch step. Repeated on every
+ * exported row of the iteration, like the number of raw data files.
+ * <p>
+ * The feature list numbers are the result fingerprint: a branch that is faster because it produced
+ * fewer rows or fewer features is a regression, not a win, and without these columns that would not
+ * be visible in the report.
+ *
+ * @param featureLists        number of feature lists in the project after the batch
+ * @param rows                rows of the newest feature list
+ * @param features            features summed over the rows of the newest feature list
+ * @param tempDirFreeGBBefore usable space of the temp directory volume before the batch
+ * @param tempDirFreeGBAfter  usable space of the temp directory volume after the batch
+ * @param tempDirUsedGB       before - after, so how much space the batch consumed. This is the
+ *                            whole volume, so other processes writing to the same disk distort it,
+ *                            and temp files that mzmine released again make it smaller than the
+ *                            peak.
+ * @param peakHeapGB          highest used heap seen by {@link MemorySampler}, null when memory
+ *                            tracking was off
+ * @param gcCount             garbage collections during the iteration, null when tracking was off
+ * @param gcTimeSeconds       time the collectors reported during the iteration, null when tracking
+ *                            was off
+ */
+public record SpeedIterationStats(int featureLists, int rows, int features,
+                                  double tempDirFreeGBBefore, double tempDirFreeGBAfter,
+                                  double tempDirUsedGB, @Nullable Double peakHeapGB,
+                                  @Nullable Long gcCount, @Nullable Double gcTimeSeconds) {
+
+  /**
+   * @param freeGBBefore the usable temp dir space measured before the batch started
+   * @param memory       null when memory tracking is off
+   */
+  @NotNull
+  public static SpeedIterationStats after(final double freeGBBefore,
+      @Nullable final MemoryMeasurement memory) {
+    final List<FeatureList> featureLists = ProjectService.getProject().getCurrentFeatureLists();
+    // the newest feature list is the result of the last processing step
+    final FeatureList newest = featureLists.isEmpty() ? null : featureLists.getLast();
+    final int rows = newest == null ? 0 : newest.getNumberOfRows();
+    final int features = newest == null ? 0
+        : newest.getRows().stream().mapToInt(FeatureListRow::getNumberOfFeatures).sum();
+
+    final double freeGBAfter = tempDirFreeGB();
+    return new SpeedIterationStats(featureLists.size(), rows, features, freeGBBefore, freeGBAfter,
+        round3(freeGBBefore - freeGBAfter), memory == null ? null : memory.peakHeapGB(),
+        memory == null ? null : memory.gcCount(), memory == null ? null : memory.gcTimeSeconds());
+  }
+
+  /**
+   * Usable space of the volume that holds the mzmine temp directory.
+   */
+  public static double tempDirFreeGB() {
+    final File tempDir = FileAndPathUtil.getTempDir();
+    return round3(tempDir.getUsableSpace() / 1e9);
+  }
+
+  private static double round3(final double value) {
+    return Math.round(value * 1e3) / 1e3;
+  }
+}

--- a/mzmine-community/src/test/java/import_data/speed/SpeedMeasurement.java
+++ b/mzmine-community/src/test/java/import_data/speed/SpeedMeasurement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2025 The mzmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -27,7 +27,8 @@ package import_data.speed;
 
 import org.jetbrains.annotations.Nullable;
 
-public record SpeedMeasurement(String name, String batchFile, String description, int files,
+public record SpeedMeasurement(String runDate, String name, String batchFile, String description,
+                               int files,
                                double timeSeconds, @Nullable String gbRamUsed) {
 
 }

--- a/mzmine-community/src/test/java/import_data/speed/SpeedMeasurement.java
+++ b/mzmine-community/src/test/java/import_data/speed/SpeedMeasurement.java
@@ -25,10 +25,75 @@
 
 package import_data.speed;
 
+import io.github.mzmine.modules.batchmode.timing.StepMeasurement;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public record SpeedMeasurement(String runDate, String name, String batchFile, String description,
-                               int files,
-                               double timeSeconds, @Nullable String gbRamUsed) {
+/**
+ * One exported row: a single batch step (or the whole batch) of a single iteration. Flattened on
+ * purpose - the record components define the csv column order and the json field names. Combines
+ * everything {@link StepMeasurement} collects with the identity of the run ({@link #description()},
+ * {@link #runId()}, {@link #phase()}, {@link #iteration()}) and the documented
+ * {@link SpeedTestEnvironment}.
+ *
+ * @param runDate            ISO timestamp of the moment the iteration was exported
+ * @param runId              same for all iterations of one JVM start, so that iterations of one run
+ *                           can be grouped and drift within a run can be inspected
+ * @param description        user provided string that qualifies what is tested, e.g. the branch or
+ *                           the optimization under test. This is the grouping of the report.
+ * @param batchFile          file name of the batch that was applied
+ * @param phase              {@link SpeedTestPhase#WARMUP} iterations are exported but excluded from
+ *                           the report by default
+ * @param iteration          1-based index within the phase
+ * @param status             final status of the batch, only {@code FINISHED} rows are trustworthy
+ * @param files              number of raw data files the batch was applied to
+ * @param step               1-based step number, 0 for the whole batch row
+ * @param name               module name of the step, or
+ *                           {@link io.github.mzmine.modules.batchmode.BatchTask#WHOLE_BATCH_NAME}
+ * @param timeSeconds        wall clock seconds of the step
+ * @param gbRamUsed          used heap (GB) after the step, only set when
+ *                           {@link SpeedTestEnvironment#runGCafterBatchStep()} is enabled
+ * @param tempFilesCreated   memory mapped temp files created during the step
+ * @param reservedTempFileGB nominal reserved space of the temp files created during the step
+ * @param usedTempFileGB     logical bytes written to temp files during the step
+ * @param liveTempFiles      mapped files still alive at the end of the step (best effort, depends
+ *                           on garbage collection)
+ * @param liveTempFileUsedGB logical bytes of still alive segments at the end of the step (best
+ *                           effort)
+ * @see SpeedIterationStats for the columns that are measured per iteration and therefore repeated
+ * on every row of that iteration: the feature list fingerprint, the temp directory disk space and
+ * the optional memory tracking
+ */
+public record SpeedMeasurement(@NotNull String runDate, @NotNull String runId,
+                               @NotNull String description, @NotNull String batchFile,
+                               @NotNull SpeedTestPhase phase, int iteration, @NotNull String status,
+                               int files, int step, @NotNull String name, double timeSeconds,
+                               @Nullable String gbRamUsed, long tempFilesCreated,
+                               double reservedTempFileGB, double usedTempFileGB, long liveTempFiles,
+                               double liveTempFileUsedGB, int featureLists, int rows, int features,
+                               double tempDirFreeGBBefore, double tempDirFreeGBAfter,
+                               double tempDirUsedGB, @Nullable Double peakHeapGB,
+                               @Nullable Long gcCount, @Nullable Double gcTimeSeconds,
+                               @NotNull String mzmineVersion, @NotNull String inMemory,
+                               boolean runGCafterBatchStep, int numOfThreads,
+                               int availableProcessors, double maxHeapGB,
+                               @NotNull String javaVersion, @NotNull String memoryVmArgs,
+                               @NotNull String osName) {
 
+  public SpeedMeasurement(@NotNull final String runDate, @NotNull final String runId,
+      @NotNull final String description, @NotNull final String batchFile,
+      @NotNull final SpeedTestPhase phase, final int iteration, @NotNull final String status,
+      final int files, @NotNull final StepMeasurement measurement,
+      @NotNull final SpeedIterationStats iterationStats, @NotNull final SpeedTestEnvironment env) {
+    this(runDate, runId, description, batchFile, phase, iteration, status, files,
+        measurement.step(), measurement.name(), measurement.secondsToFinish(),
+        measurement.usedHeapGB(), measurement.tempFilesCreated(), measurement.reservedTempFileGB(),
+        measurement.usedTempFileGB(), measurement.liveTempFiles(), measurement.liveTempFileUsedGB(),
+        iterationStats.featureLists(), iterationStats.rows(), iterationStats.features(),
+        iterationStats.tempDirFreeGBBefore(), iterationStats.tempDirFreeGBAfter(),
+        iterationStats.tempDirUsedGB(), iterationStats.peakHeapGB(), iterationStats.gcCount(),
+        iterationStats.gcTimeSeconds(), env.mzmineVersion(), env.inMemory(),
+        env.runGCafterBatchStep(), env.numOfThreads(), env.availableProcessors(), env.maxHeapGB(),
+        env.javaVersion(), env.memoryVmArgs(), env.osName());
+  }
 }

--- a/mzmine-community/src/test/java/import_data/speed/SpeedMeasurementWriter.java
+++ b/mzmine-community/src/test/java/import_data/speed/SpeedMeasurementWriter.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package import_data.speed;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.github.mzmine.util.files.FileAndPathUtil;
+import io.github.mzmine.util.io.JsonUtils;
+import java.io.BufferedWriter;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.RecordComponent;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Appends {@link SpeedMeasurement}s to a csv and a jsonlines file next to each other. Both files
+ * are kept open for the whole run so that all iterations end up in one file even if a single
+ * iteration fails.
+ * <p>
+ * The csv header is only written for a new file. When an existing file was written with a different
+ * set of columns this logs a warning instead of silently appending rows that do not match the
+ * header - use a new output file in that case.
+ */
+public class SpeedMeasurementWriter implements Closeable {
+
+  private static final Logger logger = Logger.getLogger(SpeedMeasurementWriter.class.getName());
+
+  private final ObjectMapper jsonMapper = JsonUtils.MAPPER;
+  private final CsvMapper csvMapper = CsvMapper.builder().addModule(new JavaTimeModule()).build();
+  private final CsvSchema schema = schemaInRecordOrder();
+  private final ObjectWriter csvObjectWriter = csvMapper.writer(schema.withUseHeader(false));
+
+  private final File csvFile;
+  private final File jsonFile;
+  private final BufferedWriter csvWriter;
+  private final BufferedWriter jsonWriter;
+  /**
+   * The header is written together with the first row of a new file.
+   */
+  private boolean headerPending;
+
+  public SpeedMeasurementWriter(@NotNull final File outFile) throws IOException {
+    csvFile = FileAndPathUtil.getRealFilePath(outFile, ".csv");
+    jsonFile = FileAndPathUtil.getRealFilePath(outFile, ".jsonlines");
+    FileAndPathUtil.createDirectory(csvFile.getParentFile());
+
+    headerPending = !csvFile.exists() || csvFile.length() == 0;
+    if (!headerPending) {
+      checkHeaderMatches();
+    }
+
+    csvWriter = Files.newBufferedWriter(csvFile.toPath(), StandardCharsets.UTF_8,
+        StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+    jsonWriter = Files.newBufferedWriter(jsonFile.toPath(), StandardCharsets.UTF_8,
+        StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+
+    logger.info("Appending speed measurements to " + csvFile.getAbsolutePath() + " and "
+        + jsonFile.getAbsolutePath());
+  }
+
+  /**
+   * {@link CsvMapper#schemaFor(Class)} sorts the columns alphabetically, the record components are
+   * the more useful order because they group the identity, the measurements and the environment.
+   */
+  @NotNull
+  private static CsvSchema schemaInRecordOrder() {
+    final CsvSchema.Builder builder = CsvSchema.builder();
+    for (final RecordComponent component : SpeedMeasurement.class.getRecordComponents()) {
+      builder.addColumn(component.getName());
+    }
+    return builder.build();
+  }
+
+  public void append(@NotNull final List<SpeedMeasurement> measurements) throws IOException {
+    for (final SpeedMeasurement sm : measurements) {
+      final ObjectWriter writer =
+          headerPending ? csvMapper.writer(schema.withUseHeader(true)) : csvObjectWriter;
+      headerPending = false;
+      csvWriter.append(writer.writeValueAsString(sm));
+      jsonWriter.append(jsonMapper.writeValueAsString(sm)).append('\n');
+    }
+    csvWriter.flush();
+    jsonWriter.flush();
+  }
+
+  /**
+   * Warns when the existing csv was written with a different schema, the rows would not match its
+   * header.
+   */
+  private void checkHeaderMatches() throws IOException {
+    final List<String> names = new ArrayList<>();
+    for (final CsvSchema.Column column : schema) {
+      names.add(column.getName());
+    }
+    final String expected = String.join(",", names);
+    try (var lines = Files.lines(csvFile.toPath(), StandardCharsets.UTF_8)) {
+      final String header = lines.findFirst().orElse("");
+      if (!header.isBlank() && !header.strip().equals(expected)) {
+        logger.warning("""
+            The existing csv %s was written with different columns, the appended rows will not \
+            match its header. Please export to a new file.
+            existing: %s
+            current : %s""".formatted(csvFile.getAbsolutePath(), header.strip(), expected));
+      }
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    try (csvWriter; jsonWriter) {
+      csvWriter.flush();
+      jsonWriter.flush();
+    }
+  }
+
+  @NotNull
+  public File getCsvFile() {
+    return csvFile;
+  }
+}

--- a/mzmine-community/src/test/java/import_data/speed/SpeedReportMain.java
+++ b/mzmine-community/src/test/java/import_data/speed/SpeedReportMain.java
@@ -25,6 +25,7 @@
 
 package import_data.speed;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -33,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,35 +44,39 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Reads the csv written by {@link BatchSpeedTestMain} (see speed.csv next to this class) and
- * creates a standalone html page with box plots. Each batch step ({@code name} column) becomes one
- * panel and each panel contains one box per version. The version is taken from the last comma
- * separated part of the description, e.g. {@code "inMemory=none, mzmine4.10.25_master GUI"} becomes
- * {@code "mzmine4.10.25_master GUI"}. Repeated runs of the same batch provide the replicates of a
- * box.
+ * Reads the csv or jsonlines written by {@link BatchSpeedTestMain} and creates a standalone html page
+ * that compares the runs. Each batch step ({@code name} column) becomes one panel and each panel
+ * contains one box per series, where the series is the {@code description} the user provided to
+ * qualify what was tested. Repeated iterations provide the replicates of a box.
  * <p>
- * Usage: {@code SpeedReportMain [speed.csv] [report.html]}, both arguments are optional and default
- * to the csv next to this class and speed_report.html in the same folder.
+ * On top of the box plots the page shows a comparison table with the median of every step relative to
+ * a selectable baseline series - usually the fastest way to see where a branch got faster or slower.
+ * {@link SpeedTestPhase#WARMUP} iterations are read but excluded unless the checkbox is enabled, and
+ * rows that did not finish are always dropped.
+ * <p>
+ * Usage: {@code SpeedReportMain [speed.jsonlines|speed.csv] [report.html]}, both arguments are
+ * optional. The jsonlines file is preferred because it is self describing.
  */
 public class SpeedReportMain {
 
   private static final Logger logger = Logger.getLogger(SpeedReportMain.class.getName());
 
-  private static final Path DEFAULT_CSV = Path.of(
-      "D:\\git\\mzmine3\\mzmine-community\\src\\test\\java\\import_data\\speed\\speed.csv");
+  private static final List<String> DEFAULT_DIRECTORIES = List.of(
+      "mzmine-community/src/test/java/import_data/speed", "src/test/java/import_data/speed",
+      "D:\\git\\mzmine3\\mzmine-community\\src\\test\\java\\import_data\\speed", "D:\\");
 
   public static void main(String[] args) {
-    final Path csv = args.length > 0 ? Path.of(args[0]) : resolveDefaultCsv();
+    final Path input = args.length > 0 ? Path.of(args[0]) : resolveDefaultInput();
     final Path html = args.length > 1 ? Path.of(args[1])
-        : csv.resolveSibling(stripExtension(csv.getFileName().toString()) + "_report.html");
+        : input.resolveSibling(stripExtension(input.getFileName().toString()) + "_report.html");
 
     try {
-      final List<SpeedReportRow> rows = readCsv(csv);
+      final List<SpeedReportRow> rows = read(input);
       if (rows.isEmpty()) {
-        logger.warning("No measurements found in " + csv.toAbsolutePath());
+        logger.warning("No measurements found in " + input.toAbsolutePath());
         return;
       }
-      writeHtml(rows, csv, html);
+      writeHtml(rows, input, html);
       logger.info("Wrote speed report of %d measurements to %s".formatted(rows.size(),
           html.toAbsolutePath()));
     } catch (IOException e) {
@@ -79,70 +85,126 @@ public class SpeedReportMain {
   }
 
   /**
-   * The main is usually started from the repository root but may also run with the module as
-   * working directory.
+   * The main is usually started from the repository root but may also run with the module as working
+   * directory. The jsonlines export is preferred over the csv.
    */
   @NotNull
-  private static Path resolveDefaultCsv() {
-    if (Files.exists(DEFAULT_CSV)) {
-      return DEFAULT_CSV;
-    }
-    // working directory is the module itself
-    final Path fromModule = Path.of("src", "test", "java", "import_data", "speed", "speed.csv");
-    return Files.exists(fromModule) ? fromModule : DEFAULT_CSV;
-  }
-
-  @NotNull
-  public static List<SpeedReportRow> readCsv(@NotNull final Path csv) throws IOException {
-    final List<String> lines = Files.readAllLines(csv, StandardCharsets.UTF_8);
-    final List<SpeedReportRow> rows = new ArrayList<>();
-
-    Map<String, Integer> columns = null;
-    for (final String line : lines) {
-      if (line.isBlank()) {
-        continue;
-      }
-      final List<String> values = splitCsvLine(line);
-      if (columns == null) {
-        columns = new LinkedHashMap<>();
-        for (int i = 0; i < values.size(); i++) {
-          columns.put(values.get(i).trim(), i);
+  private static Path resolveDefaultInput() {
+    for (final String directory : DEFAULT_DIRECTORIES) {
+      for (final String name : List.of("speed.jsonlines", "speed.csv")) {
+        final Path candidate = Path.of(directory, name);
+        if (Files.exists(candidate)) {
+          return candidate;
         }
-        continue;
       }
-      // headers are appended again on every new file - skip repeated header lines
-      if ("name".equals(values.get(columns.get("name")).trim())) {
-        continue;
-      }
-      final String step = value(values, columns, "name");
-      final String description = value(values, columns, "description");
-      if (step.isBlank()) {
-        continue;
-      }
-      rows.add(new SpeedReportRow(step, extractVersion(description),
-          (int) parseDouble(value(values, columns, "files"), 0),
-          parseDouble(value(values, columns, "timeSeconds"), Double.NaN),
-          parseNullableDouble(value(values, columns, "gbRamUsed"))));
     }
-    rows.removeIf(row -> Double.isNaN(row.timeSeconds()));
-    return rows;
-  }
-
-  @NotNull
-  private static String value(final List<String> values, final Map<String, Integer> columns,
-      final String column) {
-    final Integer index = columns.get(column);
-    return index == null || index >= values.size() ? "" : values.get(index).trim();
+    return Path.of(DEFAULT_DIRECTORIES.getFirst(), "speed.jsonlines");
   }
 
   /**
-   * Usually the last comma separated part of the description holds the mzmine version.
+   * Reads either the jsonlines or the csv export written by the current
+   * {@link SpeedMeasurementWriter}.
    */
   @NotNull
-  public static String extractVersion(@NotNull final String description) {
-    final int comma = description.lastIndexOf(',');
-    final String version = comma < 0 ? description : description.substring(comma + 1);
-    return version.isBlank() ? description.trim() : version.trim();
+  public static List<SpeedReportRow> read(@NotNull final Path file) throws IOException {
+    final List<Map<String, String>> records =
+        file.getFileName().toString().endsWith(".jsonlines") ? readJsonLines(file) : readCsv(file);
+
+    final List<SpeedReportRow> rows = new ArrayList<>(records.size());
+    for (final Map<String, String> record : records) {
+      final SpeedReportRow row = toRow(record);
+      if (row != null) {
+        rows.add(row);
+      }
+    }
+    return rows;
+  }
+
+  @Nullable
+  private static SpeedReportRow toRow(@NotNull final Map<String, String> values) {
+    final String name = values.getOrDefault("name", "").trim();
+    final double seconds = parseDouble(values.get("timeSeconds"), Double.NaN);
+    if (name.isBlank() || Double.isNaN(seconds)) {
+      return null;
+    }
+
+    return new SpeedReportRow((int) parseDouble(values.get("step"), 0), name,
+        values.getOrDefault("description", "").trim(), values.getOrDefault("phase", "").trim(),
+        (int) parseDouble(values.get("iteration"), 0), values.getOrDefault("runId", "").trim(),
+        values.getOrDefault("status", "").trim(), (int) parseDouble(values.get("files"), 0),
+        seconds, parseNullableDouble(values.get("gbRamUsed")),
+        parseNullableDouble(values.get("tempFilesCreated")),
+        parseNullableDouble(values.get("reservedTempFileGB")),
+        parseNullableDouble(values.get("usedTempFileGB")),
+        parseNullableDouble(values.get("liveTempFiles")),
+        parseNullableDouble(values.get("liveTempFileUsedGB")),
+        (int) parseDouble(values.get("featureLists"), 0), parseNullableDouble(values.get("rows")),
+        parseNullableDouble(values.get("features")),
+        parseNullableDouble(values.get("tempDirUsedGB")),
+        parseNullableDouble(values.get("peakHeapGB")), parseNullableDouble(values.get("gcCount")),
+        parseNullableDouble(values.get("gcTimeSeconds")), describeEnvironment(values));
+  }
+
+  /**
+   * Compact summary of the documented configuration - the report warns when two compared series
+   * were not measured with the same one.
+   */
+  @NotNull
+  private static String describeEnvironment(@NotNull final Map<String, String> values) {
+    return String.join(" | ", "mzmine " + values.getOrDefault("mzmineVersion", "?").trim(),
+        "inMemory=" + values.getOrDefault("inMemory", "?").trim(),
+        "gc=" + values.getOrDefault("runGCafterBatchStep", "?").trim(),
+        "threads=" + values.getOrDefault("numOfThreads", "?").trim() + "/" + values.getOrDefault(
+            "availableProcessors", "?").trim(),
+        "maxHeap=" + values.getOrDefault("maxHeapGB", "?").trim() + " GB",
+        values.getOrDefault("memoryVmArgs", "").trim(), values.getOrDefault("osName", "").trim());
+  }
+
+  @NotNull
+  private static List<Map<String, String>> readJsonLines(@NotNull final Path file)
+      throws IOException {
+    final ObjectMapper mapper = JsonMapper.builder().addModule(new JavaTimeModule()).build();
+    final List<Map<String, String>> records = new ArrayList<>();
+    for (final String line : Files.readAllLines(file, StandardCharsets.UTF_8)) {
+      if (line.isBlank()) {
+        continue;
+      }
+      final JsonNode node = mapper.readTree(line);
+      final Map<String, String> values = new LinkedHashMap<>();
+      for (final Iterator<String> it = node.fieldNames(); it.hasNext(); ) {
+        final String field = it.next();
+        final JsonNode value = node.get(field);
+        values.put(field, value == null || value.isNull() ? "" : value.asText());
+      }
+      records.add(values);
+    }
+    return records;
+  }
+
+  @NotNull
+  private static List<Map<String, String>> readCsv(@NotNull final Path csv) throws IOException {
+    final List<Map<String, String>> records = new ArrayList<>();
+    List<String> columns = null;
+    for (final String line : Files.readAllLines(csv, StandardCharsets.UTF_8)) {
+      if (line.isBlank()) {
+        continue;
+      }
+      final List<String> values = splitCsvLine(line).stream().map(String::trim).toList();
+      if (columns == null) {
+        columns = values;
+        continue;
+      }
+      // headers are appended again when a new file is started - skip repeated header lines
+      if (values.equals(columns)) {
+        continue;
+      }
+      final Map<String, String> record = new LinkedHashMap<>();
+      for (int i = 0; i < columns.size() && i < values.size(); i++) {
+        record.put(columns.get(i), values.get(i));
+      }
+      records.add(record);
+    }
+    return records;
   }
 
   @NotNull
@@ -171,26 +233,26 @@ public class SpeedReportMain {
     return values;
   }
 
-  private static double parseDouble(final String value, final double defaultValue) {
+  private static double parseDouble(@Nullable final String value, final double defaultValue) {
     try {
-      return value.isBlank() ? defaultValue : Double.parseDouble(value);
+      return value == null || value.isBlank() ? defaultValue : Double.parseDouble(value.trim());
     } catch (NumberFormatException e) {
       return defaultValue;
     }
   }
 
   @Nullable
-  private static Double parseNullableDouble(final String value) {
+  private static Double parseNullableDouble(@Nullable final String value) {
     final double parsed = parseDouble(value, Double.NaN);
     return Double.isNaN(parsed) ? null : parsed;
   }
 
-  private static void writeHtml(@NotNull final List<SpeedReportRow> rows, @NotNull final Path csv,
-      @NotNull final Path html) throws IOException {
+  private static void writeHtml(@NotNull final List<SpeedReportRow> rows,
+      @NotNull final Path source, @NotNull final Path html) throws IOException {
     final ObjectMapper mapper = JsonMapper.builder().addModule(new JavaTimeModule()).build();
     final String data = mapper.writeValueAsString(rows);
     final String meta = mapper.writeValueAsString(
-        Map.of("source", csv.toAbsolutePath().toString(), "measurements", rows.size()));
+        Map.of("source", source.toAbsolutePath().toString(), "measurements", rows.size()));
 
     final String page = template().replace("/*__DATA__*/null", data)
         .replace("/*__META__*/null", meta);
@@ -214,15 +276,18 @@ public class SpeedReportMain {
         <title>mzmine batch speed report</title>
         <style>
           :root { color-scheme: light dark; --fg: #1c1c1e; --muted: #6b7280; --bg: #ffffff;
-                  --panel: #f6f7f9; --grid: #d9dce1; }
+                  --panel: #f6f7f9; --grid: #d9dce1; --good: #2f9e44; --bad: #e03131;
+                  --warn: #e8590c; }
           @media (prefers-color-scheme: dark) {
             :root { --fg: #e8e8ea; --muted: #9aa0a6; --bg: #16181c; --panel: #1e2126;
-                    --grid: #33383f; }
+                    --grid: #33383f; --good: #51cf66; --bad: #ff6b6b; --warn: #ffa94d; }
           }
           body { margin: 0; padding: 20px 24px 40px; background: var(--bg); color: var(--fg);
                  font: 14px/1.45 system-ui, -apple-system, Segoe UI, sans-serif; }
           h1 { font-size: 19px; margin: 0 0 4px; }
-          .sub { color: var(--muted); font-size: 12px; margin-bottom: 14px; }
+          .sub { color: var(--muted); font-size: 12px; margin-bottom: 6px; }
+          .warning { color: var(--warn); font-size: 12px; margin-bottom: 10px;
+                     white-space: pre-wrap; }
           .controls { display: flex; flex-wrap: wrap; gap: 16px; align-items: center;
                       margin-bottom: 12px; font-size: 13px; }
           .legend { display: flex; flex-wrap: wrap; gap: 6px 18px; margin-bottom: 18px;
@@ -232,7 +297,7 @@ public class SpeedReportMain {
           .panels { display: grid; gap: 14px;
                     grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); }
           .panel { background: var(--panel); border-radius: 10px; padding: 10px 10px 4px; }
-          #overview .panel { margin-bottom: 14px; }
+          #table .panel, #overview .panel { margin-bottom: 14px; }
           #overview svg { min-width: 100%; }
           .scroll { overflow-x: auto; }
           .panel h2 { font-size: 13px; margin: 0 0 2px; }
@@ -242,24 +307,37 @@ public class SpeedReportMain {
           .axis { stroke: var(--grid); stroke-width: 1; }
           .tick { fill: var(--muted); font-size: 9px; }
           .xlabel { fill: var(--muted); font-size: 10px; }
+          table { border-collapse: collapse; font-size: 12px; margin-bottom: 6px; }
+          th, td { padding: 3px 12px 3px 0; text-align: right; white-space: nowrap; }
+          th { color: var(--muted); font-weight: 600; }
+          td.step, th.step { text-align: left; }
+          .delta { font-size: 11px; }
+          .faster { color: var(--good); }
+          .slower { color: var(--bad); }
+          .same { color: var(--muted); }
         </style>
         </head>
         <body>
         <h1>mzmine batch speed report</h1>
         <div class="sub" id="sub"></div>
+        <div class="warning" id="warnings"></div>
         <div class="controls">
-          <label>Metric
-            <select id="metric">
-              <option value="timeSeconds">time (seconds)</option>
-              <option value="gbRamUsed">RAM (GB)</option>
-            </select>
-          </label>
+          <label>Metric <select id="metric"></select></label>
+          <label>Baseline <select id="baseline"></select></label>
+          <label><input type="checkbox" id="warmup"> include warmup iterations</label>
           <label><input type="checkbox" id="log"> log scale</label>
           <label><input type="checkbox" id="zero" checked> start axis at 0</label>
           <label><input type="checkbox" id="total" checked> include WHOLE BATCH in overview</label>
+          <label><input type="checkbox" id="share"> per-step share of total</label>
+          <label><input type="checkbox" id="drift"> drift per iteration</label>
+          <button id="markdown" type="button">copy table as markdown</button>
         </div>
         <div class="legend" id="legend"></div>
+        <div id="fingerprint"></div>
+        <div id="table"></div>
+        <div id="shareBox"></div>
         <div id="overview"></div>
+        <div id="driftBox"></div>
         <div class="panels" id="panels"></div>
         <script>
         const DATA = /*__DATA__*/null;
@@ -267,26 +345,54 @@ public class SpeedReportMain {
         const COLORS = ['#4c78a8', '#f58518', '#54a24b', '#e45756', '#9d755d', '#b279a2',
                         '#72b7b2', '#eeca3b'];
         const SVGNS = 'http://www.w3.org/2000/svg';
+        // every measurement that BatchTask collects, see StepMeasurement, plus the per iteration
+        // values of SpeedIterationStats. The perIteration ones are the same on every row of an
+        // iteration, so they are only meaningful on the WHOLE BATCH panel.
+        const METRICS = [
+          { key: 'timeSeconds', label: 'time (seconds)' },
+          { key: 'gbRamUsed', label: 'used heap (GB)' },
+          { key: 'tempFilesCreated', label: 'temp files created' },
+          { key: 'reservedTempFileGB', label: 'temp files reserved (GB)' },
+          { key: 'usedTempFileGB', label: 'temp files used (GB)' },
+          { key: 'liveTempFiles', label: 'live temp files' },
+          { key: 'liveTempFileUsedGB', label: 'live temp files used (GB)' },
+          { key: 'tempDirUsedGB', label: 'temp dir disk used (GB)', perIteration: true },
+          { key: 'peakHeapGB', label: 'peak heap (GB, tracked runs)', perIteration: true },
+          { key: 'gcCount', label: 'GC count (tracked runs)', perIteration: true },
+          { key: 'gcTimeSeconds', label: 'GC time (seconds, tracked runs)', perIteration: true },
+          { key: 'rows', label: 'rows of newest feature list', perIteration: true },
+          { key: 'features', label: 'features of newest feature list', perIteration: true }
+        ];
         
-        // grouping: panel per step, box per version, replicates from repeated runs
+        // series and step order are global so that colors and panels stay stable while filtering
         const seriesOrder = [];
-        const steps = new Map();
+        // key by step number and name, a batch may apply the same module in several steps
+        const stepsByKey = new Map();
         for (const row of DATA) {
           if (!seriesOrder.includes(row.series)) seriesOrder.push(row.series);
-          if (!steps.has(row.step)) steps.set(row.step, new Map());
-          const bySeries = steps.get(row.step);
-          if (!bySeries.has(row.series)) bySeries.set(row.series, []);
-          bySeries.get(row.series).push(row);
+          const key = row.step + '|' + row.name;
+          if (!stepsByKey.has(key)) {
+            stepsByKey.set(key, { key, step: row.step, name: row.name,
+                label: (row.step > 0 ? row.step + '. ' : '') + row.name });
+          }
         }
-        // the total is most interesting last
-        const stepOrder = [...steps.keys()].sort((a, b) => rank(a) - rank(b));
-        function rank(step) {
-          return step.toUpperCase().includes('WHOLE BATCH') ? 1 : 0;
+        // the whole batch (step 0) is most interesting last in the plots and first in the table
+        const stepOrder = [...stepsByKey.values()]
+            .sort((a, b) => (rank(a) - rank(b)) || (a.step - b.step));
+        function rank(meta) {
+          return meta.step === 0 ? 1 : 0;
         }
+        const colorOf = series => COLORS[seriesOrder.indexOf(series) % COLORS.length];
         
         const el = (tag, attrs, text) => {
           const node = document.createElementNS(SVGNS, tag);
           for (const key in attrs) node.setAttribute(key, attrs[key]);
+          if (text !== undefined) node.textContent = text;
+          return node;
+        };
+        const tag = (name, cls, text) => {
+          const node = document.createElement(name);
+          if (cls) node.className = cls;
           if (text !== undefined) node.textContent = text;
           return node;
         };
@@ -308,10 +414,10 @@ public class SpeedReportMain {
             outliers: v.filter(x => x < loFence || x > hiFence), values: v
           };
         }
-        
+
         const fmt = x => Math.abs(x) >= 100 ? x.toFixed(0)
                        : Math.abs(x) >= 10 ? x.toFixed(1) : x.toFixed(2);
-        
+
         function ticks(min, max, log) {
           if (log) {
             const out = [];
@@ -330,20 +436,31 @@ public class SpeedReportMain {
           for (let t = Math.ceil(min / step) * step; t <= max + step * 1e-6; t += step) out.push(t);
           return out;
         }
-        
+
         /**
-         * All boxes of one step, in the global version order. Steps without values for the current
-         * metric return an empty array.
+         * Rows that pass the current filter, grouped as step -> series -> box. Only finished
+         * iterations are used, warmups only when requested.
          */
-        function boxesOfStep(step, metric) {
-          const bySeries = steps.get(step);
-          return seriesOrder.map(series => {
-            const values = (bySeries.get(series) ?? [])
-                .map(r => r[metric]).filter(v => typeof v === 'number' && isFinite(v));
-            return { series, stats: values.length ? stats(values) : null };
-          }).filter(b => b.stats);
+        function groupRows(metric, withWarmup) {
+          const steps = new Map();
+          for (const row of DATA) {
+            if (row.status !== 'FINISHED') continue;
+            if (!withWarmup && row.phase !== 'PRODUCTION') continue;
+            const value = row[metric];
+            if (typeof value !== 'number' || !isFinite(value)) continue;
+            const key = row.step + '|' + row.name;
+            if (!steps.has(key)) steps.set(key, new Map());
+            const bySeries = steps.get(key);
+            if (!bySeries.has(row.series)) bySeries.set(row.series, []);
+            bySeries.get(row.series).push(value);
+          }
+          return stepOrder.filter(meta => steps.has(meta.key)).map(meta => ({
+            meta,
+            boxes: seriesOrder.filter(s => steps.get(meta.key).has(s))
+                .map(series => ({ series, stats: stats(steps.get(meta.key).get(series)) }))
+          }));
         }
-        
+
         function axisRange(allStats, log, fromZero) {
           let max = Math.max(...allStats.map(s => s.max));
           let min = Math.min(...allStats.map(s => s.min));
@@ -358,7 +475,7 @@ public class SpeedReportMain {
           if (max <= min) max = min + 1;
           return { min, max };
         }
-        
+
         function makeScale(min, max, log, mT, plotH) {
           return v => {
             const t = log
@@ -368,7 +485,7 @@ public class SpeedReportMain {
             return mT + plotH - t * plotH;
           };
         }
-        
+
         function drawGrid(svg, min, max, log, scale, mL, mR, mT, plotH, W) {
           for (const t of ticks(min, max, log)) {
             const y = scale(t);
@@ -378,7 +495,7 @@ public class SpeedReportMain {
           }
           svg.appendChild(el('line', { class: 'axis', x1: mL, x2: mL, y1: mT, y2: mT + plotH }));
         }
-        
+
         function drawBox(svg, s, cx, bw, color, scale, tooltip) {
           const g = el('g', {});
           g.appendChild(el('title', {}, tooltip + '\\n' + 'n=' + s.n + ', median ' + fmt(s.med)
@@ -409,35 +526,65 @@ public class SpeedReportMain {
           svg.appendChild(g);
         }
         
-        const colorOf = series => COLORS[seriesOrder.indexOf(series) % COLORS.length];
-        
-        function render() {
-          const metric = document.getElementById('metric').value;
-          const log = document.getElementById('log').checked;
-          const fromZero = document.getElementById('zero').checked && !log;
-          const withTotal = document.getElementById('total').checked;
-          const overview = document.getElementById('overview');
-          const panels = document.getElementById('panels');
-          overview.textContent = '';
-          panels.textContent = '';
-        
-          const groups = stepOrder.map(step => ({ step, boxes: boxesOfStep(step, metric) }))
-              .filter(g => g.boxes.length);
-          if (!groups.length) return;
-        
-          const forOverview = groups.filter(g => withTotal || rank(g.step) === 0);
-          if (forOverview.length) {
-            overview.appendChild(overviewPanel(forOverview, metric, log, fromZero));
-          }
-          for (const group of groups) {
-            panels.appendChild(panel(group.step, group.boxes, log, fromZero));
-          }
-        }
-        
         /**
-         * Combined plot: grouped by step on the x axis, one box per version within each step.
+         * Median per step and series relative to the baseline series. Steps are sorted by the
+         * baseline median so that the most expensive steps come first, the whole batch stays on top.
          */
-        function overviewPanel(groups, metric, log, fromZero) {
+        function comparisonTable(groups, baseline, metricLabel) {
+          const wrap = tag('div', 'panel');
+          wrap.appendChild(tag('h2', null, 'Median per step vs baseline "' + baseline + '"'));
+          wrap.appendChild(tag('p', 'note', metricLabel
+              + ' - negative means lower than the baseline, steps sorted by baseline cost'));
+        
+          const statsOf = (group, series) => group.boxes.find(b => b.series === series)?.stats ?? null;
+          const sorted = [...groups].sort((a, b) => {
+            const byRank = rank(b.meta) - rank(a.meta);
+            if (byRank !== 0) return byRank;
+            return (statsOf(b, baseline)?.med ?? 0) - (statsOf(a, baseline)?.med ?? 0);
+          });
+        
+          const table = tag('table');
+          const head = tag('tr');
+          head.appendChild(tag('th', 'step', 'step'));
+          for (const series of seriesOrder) {
+            head.appendChild(tag('th', null,
+                series === baseline ? series + ' (baseline)' : series));
+          }
+          table.appendChild(head);
+        
+          for (const group of sorted) {
+            const tr = tag('tr');
+            tr.appendChild(tag('td', 'step', group.meta.label));
+            const base = statsOf(group, baseline);
+            for (const series of seriesOrder) {
+              const s = statsOf(group, series);
+              const td = tag('td');
+              if (!s) {
+                td.appendChild(tag('span', 'same', '-'));
+              } else {
+                td.appendChild(tag('span', null, fmt(s.med)));
+                td.title = 'n=' + s.n + ', min ' + fmt(s.min) + ', max ' + fmt(s.max);
+                if (base && series !== baseline && base.med > 0) {
+                  const change = (s.med - base.med) / base.med * 100;
+                  const cls = change < -2 ? 'faster' : change > 2 ? 'slower' : 'same';
+                  td.appendChild(tag('span', 'delta ' + cls,
+                      ' ' + (change >= 0 ? '+' : '') + change.toFixed(1) + '%'));
+                }
+              }
+              tr.appendChild(td);
+            }
+            table.appendChild(tr);
+          }
+          const scroller = tag('div', 'scroll');
+          scroller.appendChild(table);
+          wrap.appendChild(scroller);
+          return wrap;
+        }
+
+        /**
+         * Combined plot: grouped by step on the x axis, one box per series within each step.
+         */
+        function overviewPanel(groups, metricLabel, log, fromZero) {
           const mL = 54, mR = 12, mT = 10, mB = 104, H = 400;
           const boxSlot = 22;
           const groupPad = 14;
@@ -445,31 +592,25 @@ public class SpeedReportMain {
           const W = Math.max(760, mL + mR + groupW.reduce((a, b) => a + b, 0));
           const plotH = H - mT - mB;
         
-          const wrap = document.createElement('div');
-          wrap.className = 'panel';
-          const title = document.createElement('h2');
-          title.textContent = 'All steps'
-              + (metric === 'timeSeconds' ? ' - time (seconds)' : ' - RAM (GB)');
-          const note = document.createElement('p');
-          note.className = 'note';
-          note.textContent = 'grouped by step, one box per version - hover a box for details';
-          wrap.appendChild(title);
-          wrap.appendChild(note);
+          const wrap = tag('div', 'panel');
+          wrap.appendChild(tag('h2', null, 'All steps - ' + metricLabel));
+          wrap.appendChild(tag('p', 'note',
+              'grouped by step, one box per series - hover a box for details'));
         
           const allStats = groups.flatMap(g => g.boxes.map(b => b.stats));
           const { min, max } = axisRange(allStats, log, fromZero);
           const scale = makeScale(min, max, log, mT, plotH);
-        
+
           const svg = el('svg', { viewBox: '0 0 ' + W + ' ' + H, width: W, height: H });
           drawGrid(svg, min, max, log, scale, mL, mR, mT, plotH, W);
-        
+
           let x = mL;
           groups.forEach((group, gi) => {
             const width = groupW[gi];
             group.boxes.forEach((box, i) => {
               const cx = x + groupPad / 2 + boxSlot * (i + 0.5);
               drawBox(svg, box.stats, cx, boxSlot * 0.62, colorOf(box.series), scale,
-                  group.step + ' - ' + box.series);
+                  group.meta.label + ' - ' + box.series);
             });
             // separator between step groups
             if (gi > 0) {
@@ -479,15 +620,15 @@ public class SpeedReportMain {
             const cx = x + width / 2;
             const y = mT + plotH + 8;
             // long step names are shortened, the full name stays in the tooltip
+            const text = group.meta.label;
             const label = el('text', { class: 'xlabel', x: cx, y: y, 'text-anchor': 'end',
                 transform: 'rotate(-35 ' + cx + ' ' + y + ')' },
-                group.step.length > 26 ? group.step.slice(0, 25) + '...' : group.step);
-            label.appendChild(el('title', {}, group.step));
+                text.length > 26 ? text.slice(0, 25) + '...' : text);
+            label.appendChild(el('title', {}, text));
             svg.appendChild(label);
             x += width;
           });
-          const scroller = document.createElement('div');
-          scroller.className = 'scroll';
+          const scroller = tag('div', 'scroll');
           scroller.appendChild(svg);
           wrap.appendChild(scroller);
           return wrap;
@@ -495,16 +636,10 @@ public class SpeedReportMain {
         
         function panel(step, boxes, log, fromZero) {
           const W = 420, H = 250, mL = 48, mR = 10, mT = 8, mB = 34;
-          const wrap = document.createElement('div');
-          wrap.className = 'panel';
-          const title = document.createElement('h2');
-          title.textContent = step;
-          const note = document.createElement('p');
-          note.className = 'note';
-          note.textContent = boxes.map(b => b.series + ': n=' + b.stats.n + ', median '
-              + fmt(b.stats.med)).join('  |  ');
-          wrap.appendChild(title);
-          wrap.appendChild(note);
+          const wrap = tag('div', 'panel');
+          wrap.appendChild(tag('h2', null, step));
+          wrap.appendChild(tag('p', 'note', boxes.map(b => b.series + ': n=' + b.stats.n
+              + ', median ' + fmt(b.stats.med)).join('  |  ')));
         
           const { min, max } = axisRange(boxes.map(b => b.stats), log, fromZero);
           const plotH = H - mT - mB;
@@ -528,12 +663,235 @@ public class SpeedReportMain {
           return wrap;
         }
         
+        /**
+         * Result fingerprint: a series that produced fewer rows or features did not do the same work,
+         * so a lower time is a regression and not a win. Uses the whole batch rows of one iteration.
+         */
+        function fingerprintPanel(withWarmup) {
+          const wrap = tag('div', 'panel');
+          wrap.appendChild(tag('h2', null, 'Result fingerprint'));
+          wrap.appendChild(tag('p', 'note',
+              'feature lists in the project and the newest feature list after each iteration -'
+              + ' these must match, otherwise the series did not do the same work'));
+        
+          const bySeries = new Map();
+          for (const row of DATA) {
+            if (row.status !== 'FINISHED' || row.step !== 0) continue;
+            if (!withWarmup && row.phase !== 'PRODUCTION') continue;
+            if (!bySeries.has(row.series)) bySeries.set(row.series, new Set());
+            bySeries.get(row.series).add([row.featureLists, row.rows, row.features].join(' / '));
+          }
+        
+          const table = tag('table');
+          const head = tag('tr');
+          for (const column of ['series', 'feature lists / rows / features']) {
+            head.appendChild(tag('th', column === 'series' ? 'step' : null, column));
+          }
+          table.appendChild(head);
+          // every series should contribute exactly one distinct fingerprint
+          const distinct = new Set();
+          for (const series of seriesOrder) {
+            const values = [...(bySeries.get(series) ?? [])];
+            values.forEach(v => distinct.add(v));
+            const tr = tag('tr');
+            tr.appendChild(tag('td', 'step', series));
+            const td = tag('td');
+            td.appendChild(tag('span', values.length > 1 ? 'slower' : null,
+                values.length ? values.join(', ') : '-'));
+            tr.appendChild(td);
+            table.appendChild(tr);
+          }
+          wrap.appendChild(table);
+          if (distinct.size > 1) {
+            wrap.appendChild(tag('p', 'note slower',
+                'The series produced different results, the timings are not comparable.'));
+          }
+          return wrap;
+        }
+        
+        /**
+         * Share of the whole batch per step, one row per series. Shows whether a win comes from the
+         * step that was actually changed.
+         */
+        function sharePanel(groups, baseline, metricLabel) {
+          const wrap = tag('div', 'panel');
+          wrap.appendChild(tag('h2', null, 'Share of the whole batch per step'));
+          wrap.appendChild(tag('p', 'note', metricLabel + ' - median of each step relative to the'
+              + ' summed step medians, hover a segment for details'));
+        
+          const steps = groups.filter(g => rank(g.meta) === 0);
+          const H = 26, W = 800, labelW = 150;
+          const svg = el('svg', { viewBox: '0 0 ' + W + ' ' + (seriesOrder.length * (H + 8) + 4) });
+          seriesOrder.forEach((series, si) => {
+            const values = steps.map(g => ({ meta: g.meta,
+                med: g.boxes.find(b => b.series === series)?.stats?.med ?? 0 }));
+            const total = values.reduce((a, b) => a + b.med, 0);
+            const y = si * (H + 8);
+            svg.appendChild(el('text', { class: 'xlabel', x: 0, y: y + H / 2 + 3 }, series));
+            if (total <= 0) return;
+            let x = labelW;
+            values.forEach((value, i) => {
+              const width = (W - labelW) * value.med / total;
+              const g = el('g', {});
+              g.appendChild(el('title', {}, value.meta.label + ': ' + fmt(value.med) + ' ('
+                  + (value.med / total * 100).toFixed(1) + '%)'));
+              g.appendChild(el('rect', { x: x, y: y, width: Math.max(width, 0.5), height: H,
+                  fill: COLORS[i % COLORS.length], 'fill-opacity': 0.75 }));
+              svg.appendChild(g);
+              x += width;
+            });
+          });
+          wrap.appendChild(svg);
+          const legend = tag('p', 'note', steps.map((g, i) => (i + 1) + '. ' + g.meta.label)
+              .join('  |  '));
+          wrap.appendChild(legend);
+          return wrap;
+        }
+        
+        /**
+         * Value over the iteration index per series, to spot a machine that got slower during the run
+         * (thermal throttling, temp files piling up) instead of a real difference between series.
+         */
+        function driftPanel(metric, metricLabel, withWarmup) {
+          const wrap = tag('div', 'panel');
+          wrap.appendChild(tag('h2', null, 'Drift over the iterations - ' + metricLabel));
+          wrap.appendChild(tag('p', 'note', 'whole batch per iteration in run order, a trend means'
+              + ' the machine changed during the run'));
+        
+          const bySeries = new Map();
+          for (const row of DATA) {
+            if (row.status !== 'FINISHED' || row.step !== 0) continue;
+            if (!withWarmup && row.phase !== 'PRODUCTION') continue;
+            const value = row[metric];
+            if (typeof value !== 'number' || !isFinite(value)) continue;
+            const key = row.series + ' ' + row.runId;
+            if (!bySeries.has(key)) bySeries.set(key, { series: row.series, points: [] });
+            bySeries.get(key).points.push({ x: row.iteration, y: value, phase: row.phase });
+          }
+          const series = [...bySeries.values()];
+          if (!series.length) {
+            return wrap;
+          }
+          const all = series.flatMap(s => s.points);
+          const W = 800, H = 240, mL = 54, mR = 12, mT = 10, mB = 28;
+          const plotH = H - mT - mB;
+          const maxX = Math.max(...all.map(p => p.x), 1);
+          const { min, max } = axisRange([{ min: Math.min(...all.map(p => p.y)),
+              max: Math.max(...all.map(p => p.y)) }], false, false);
+          const scaleY = makeScale(min, max, false, mT, plotH);
+          const scaleX = x => mL + (W - mL - mR) * (maxX === 1 ? 0.5 : (x - 1) / (maxX - 1));
+        
+          const svg = el('svg', { viewBox: '0 0 ' + W + ' ' + H });
+          drawGrid(svg, min, max, false, scaleY, mL, mR, mT, plotH, W);
+          for (const s of series) {
+            const color = colorOf(s.series);
+            const sorted = [...s.points].sort((a, b) => a.x - b.x);
+            svg.appendChild(el('polyline', { fill: 'none', stroke: color, 'stroke-width': 1.4,
+                points: sorted.map(p => scaleX(p.x) + ',' + scaleY(p.y)).join(' ') }));
+            for (const p of sorted) {
+              const dot = el('circle', { cx: scaleX(p.x), cy: scaleY(p.y), r: 2.6, fill: color,
+                  'fill-opacity': p.phase === 'PRODUCTION' ? 1 : 0.35 });
+              dot.appendChild(el('title', {}, s.series + ' ' + p.phase + ' iteration ' + p.x + ': '
+                  + fmt(p.y)));
+              svg.appendChild(dot);
+            }
+          }
+          for (let x = 1; x <= maxX; x++) {
+            svg.appendChild(el('text', { class: 'xlabel', x: scaleX(x), y: H - mB + 16,
+                'text-anchor': 'middle' }, String(x)));
+          }
+          wrap.appendChild(svg);
+          return wrap;
+        }
+        
+        /**
+         * The comparison table as markdown, for pasting into a pull request.
+         */
+        function tableAsMarkdown(groups, baseline, metricLabel) {
+          const statsOf = (group, series) => group.boxes.find(b => b.series === series)?.stats ?? null;
+          const lines = ['| step | ' + seriesOrder.map(s => s === baseline ? s + ' (baseline)' : s)
+              .join(' | ') + ' |',
+              '|---|' + seriesOrder.map(() => '---:').join('|') + '|'];
+          for (const group of groups) {
+            const base = statsOf(group, baseline);
+            const cells = seriesOrder.map(series => {
+              const s = statsOf(group, series);
+              if (!s) return '-';
+              if (!base || series === baseline || base.med <= 0) return fmt(s.med);
+              const change = (s.med - base.med) / base.med * 100;
+              return fmt(s.med) + ' (' + (change >= 0 ? '+' : '') + change.toFixed(1) + '%)';
+            });
+            lines.push('| ' + group.meta.label + ' | ' + cells.join(' | ') + ' |');
+          }
+          return metricLabel + ', median of ' + META.measurements + ' measurements\\n\\n'
+              + lines.join('\\n') + '\\n';
+        }
+        
+        /**
+         * The groups of the last render, so that the markdown button uses what is on screen.
+         */
+        let lastRender = null;
+        
+        function render() {
+          const metric = document.getElementById('metric').value;
+          const metricDef = METRICS.find(m => m.key === metric);
+          const metricLabel = metricDef.label;
+          const baseline = document.getElementById('baseline').value;
+          const withWarmup = document.getElementById('warmup').checked;
+          const log = document.getElementById('log').checked;
+          const fromZero = document.getElementById('zero').checked && !log;
+          const withTotal = document.getElementById('total').checked;
+          const withShare = document.getElementById('share').checked;
+          const withDrift = document.getElementById('drift').checked;
+          for (const id of ['fingerprint', 'table', 'shareBox', 'overview', 'driftBox', 'panels']) {
+            document.getElementById(id).textContent = '';
+          }
+        
+          document.getElementById('fingerprint').appendChild(fingerprintPanel(withWarmup));
+        
+          // per iteration metrics are identical on every step row, only the whole batch is meaningful
+          const groups = groupRows(metric, withWarmup)
+              .filter(g => !metricDef.perIteration || rank(g.meta) === 1);
+          lastRender = { groups, baseline, metricLabel };
+          if (!groups.length) return;
+        
+          document.getElementById('table')
+              .appendChild(comparisonTable(groups, baseline, metricLabel));
+          if (withShare && !metricDef.perIteration) {
+            document.getElementById('shareBox')
+                .appendChild(sharePanel(groups, baseline, metricLabel));
+          }
+          const forOverview = groups.filter(g => withTotal || rank(g.meta) === 0);
+          if (forOverview.length) {
+            document.getElementById('overview')
+                .appendChild(overviewPanel(forOverview, metricLabel, log, fromZero));
+          }
+          if (withDrift) {
+            document.getElementById('driftBox')
+                .appendChild(driftPanel(metric, metricLabel, withWarmup));
+          }
+          for (const group of groups) {
+            document.getElementById('panels')
+                .appendChild(panel(group.meta.label, group.boxes, log, fromZero));
+          }
+        }
+        
+        function fillSelect(id, values, selected) {
+          const select = document.getElementById(id);
+          for (const value of values) {
+            const option = document.createElement('option');
+            option.value = value.key;
+            option.textContent = value.label;
+            if (value.key === selected) option.selected = true;
+            select.appendChild(option);
+          }
+        }
+        
         function renderLegend() {
           const legend = document.getElementById('legend');
           seriesOrder.forEach((series, i) => {
             const item = document.createElement('div');
-            const swatch = document.createElement('span');
-            swatch.className = 'swatch';
+            const swatch = tag('span', 'swatch');
             swatch.style.background = COLORS[i % COLORS.length];
             item.appendChild(swatch);
             item.appendChild(document.createTextNode((i + 1) + ' - ' + series));
@@ -541,13 +899,51 @@ public class SpeedReportMain {
           });
         }
         
-        document.getElementById('sub').textContent = META.measurements + ' measurements, '
-            + stepOrder.length + ' steps, ' + seriesOrder.length + ' versions - '
-            + META.source;
+        /**
+         * The harness documents the configuration instead of pinning it, so warn when the compared
+         * series were not measured with the same environment, or when iterations did not finish.
+         */
+        function renderWarnings() {
+          const messages = [];
+          const environments = [...new Set(DATA.map(r => r.environment))];
+          if (environments.length > 1) {
+            messages.push('Different environments in this file, the series may not be comparable:\\n'
+                + environments.map(e => '  - ' + e).join('\\n'));
+          }
+          const failed = DATA.filter(r => r.status !== 'FINISHED').length;
+          if (failed) messages.push(failed + ' measurements did not finish and are excluded.');
+          document.getElementById('warnings').textContent = messages.join('\\n');
+        }
+        
+        const production = DATA.filter(r => r.phase === 'PRODUCTION').length;
+        document.getElementById('sub').textContent = META.measurements + ' measurements ('
+            + production + ' production, ' + (META.measurements - production) + ' warmup), '
+            + stepOrder.length + ' steps, ' + seriesOrder.length + ' series - ' + META.source;
+        fillSelect('metric', METRICS.map(m => ({ key: m.key, label: m.label })), 'timeSeconds');
+        fillSelect('baseline', seriesOrder.map(s => ({ key: s, label: s })), seriesOrder[0]);
         renderLegend();
-        for (const id of ['metric', 'log', 'zero', 'total']) {
+        renderWarnings();
+        for (const id of ['metric', 'baseline', 'warmup', 'log', 'zero', 'total', 'share',
+            'drift']) {
           document.getElementById(id).addEventListener('change', render);
         }
+        document.getElementById('markdown').addEventListener('click', () => {
+          const button = document.getElementById('markdown');
+          if (!lastRender) return;
+          const markdown = tableAsMarkdown(lastRender.groups, lastRender.baseline,
+              lastRender.metricLabel);
+          // the clipboard is not available for local files in every browser, fall back to a prompt
+          const done = () => {
+            button.textContent = 'copied';
+            setTimeout(() => button.textContent = 'copy table as markdown', 1500);
+          };
+          if (navigator.clipboard) {
+            navigator.clipboard.writeText(markdown).then(done, () => window.prompt('markdown',
+                markdown));
+          } else {
+            window.prompt('markdown', markdown);
+          }
+        });
         render();
         </script>
         </body>

--- a/mzmine-community/src/test/java/import_data/speed/SpeedReportMain.java
+++ b/mzmine-community/src/test/java/import_data/speed/SpeedReportMain.java
@@ -1,0 +1,558 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package import_data.speed;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Reads the csv written by {@link BatchSpeedTestMain} (see speed.csv next to this class) and
+ * creates a standalone html page with box plots. Each batch step ({@code name} column) becomes one
+ * panel and each panel contains one box per version. The version is taken from the last comma
+ * separated part of the description, e.g. {@code "inMemory=none, mzmine4.10.25_master GUI"} becomes
+ * {@code "mzmine4.10.25_master GUI"}. Repeated runs of the same batch provide the replicates of a
+ * box.
+ * <p>
+ * Usage: {@code SpeedReportMain [speed.csv] [report.html]}, both arguments are optional and default
+ * to the csv next to this class and speed_report.html in the same folder.
+ */
+public class SpeedReportMain {
+
+  private static final Logger logger = Logger.getLogger(SpeedReportMain.class.getName());
+
+  private static final Path DEFAULT_CSV = Path.of(
+      "D:\\git\\mzmine3\\mzmine-community\\src\\test\\java\\import_data\\speed\\speed.csv");
+
+  public static void main(String[] args) {
+    final Path csv = args.length > 0 ? Path.of(args[0]) : resolveDefaultCsv();
+    final Path html = args.length > 1 ? Path.of(args[1])
+        : csv.resolveSibling(stripExtension(csv.getFileName().toString()) + "_report.html");
+
+    try {
+      final List<SpeedReportRow> rows = readCsv(csv);
+      if (rows.isEmpty()) {
+        logger.warning("No measurements found in " + csv.toAbsolutePath());
+        return;
+      }
+      writeHtml(rows, csv, html);
+      logger.info("Wrote speed report of %d measurements to %s".formatted(rows.size(),
+          html.toAbsolutePath()));
+    } catch (IOException e) {
+      logger.log(Level.SEVERE, "Failed to create speed report: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * The main is usually started from the repository root but may also run with the module as
+   * working directory.
+   */
+  @NotNull
+  private static Path resolveDefaultCsv() {
+    if (Files.exists(DEFAULT_CSV)) {
+      return DEFAULT_CSV;
+    }
+    // working directory is the module itself
+    final Path fromModule = Path.of("src", "test", "java", "import_data", "speed", "speed.csv");
+    return Files.exists(fromModule) ? fromModule : DEFAULT_CSV;
+  }
+
+  @NotNull
+  public static List<SpeedReportRow> readCsv(@NotNull final Path csv) throws IOException {
+    final List<String> lines = Files.readAllLines(csv, StandardCharsets.UTF_8);
+    final List<SpeedReportRow> rows = new ArrayList<>();
+
+    Map<String, Integer> columns = null;
+    for (final String line : lines) {
+      if (line.isBlank()) {
+        continue;
+      }
+      final List<String> values = splitCsvLine(line);
+      if (columns == null) {
+        columns = new LinkedHashMap<>();
+        for (int i = 0; i < values.size(); i++) {
+          columns.put(values.get(i).trim(), i);
+        }
+        continue;
+      }
+      // headers are appended again on every new file - skip repeated header lines
+      if ("name".equals(values.get(columns.get("name")).trim())) {
+        continue;
+      }
+      final String step = value(values, columns, "name");
+      final String description = value(values, columns, "description");
+      if (step.isBlank()) {
+        continue;
+      }
+      rows.add(new SpeedReportRow(step, extractVersion(description),
+          (int) parseDouble(value(values, columns, "files"), 0),
+          parseDouble(value(values, columns, "timeSeconds"), Double.NaN),
+          parseNullableDouble(value(values, columns, "gbRamUsed"))));
+    }
+    rows.removeIf(row -> Double.isNaN(row.timeSeconds()));
+    return rows;
+  }
+
+  @NotNull
+  private static String value(final List<String> values, final Map<String, Integer> columns,
+      final String column) {
+    final Integer index = columns.get(column);
+    return index == null || index >= values.size() ? "" : values.get(index).trim();
+  }
+
+  /**
+   * Usually the last comma separated part of the description holds the mzmine version.
+   */
+  @NotNull
+  public static String extractVersion(@NotNull final String description) {
+    final int comma = description.lastIndexOf(',');
+    final String version = comma < 0 ? description : description.substring(comma + 1);
+    return version.isBlank() ? description.trim() : version.trim();
+  }
+
+  @NotNull
+  private static List<String> splitCsvLine(@NotNull final String line) {
+    final List<String> values = new ArrayList<>();
+    final StringBuilder current = new StringBuilder();
+    boolean quoted = false;
+    for (int i = 0; i < line.length(); i++) {
+      final char c = line.charAt(i);
+      if (c == '"') {
+        // escaped quote inside a quoted value
+        if (quoted && i + 1 < line.length() && line.charAt(i + 1) == '"') {
+          current.append('"');
+          i++;
+        } else {
+          quoted = !quoted;
+        }
+      } else if (c == ',' && !quoted) {
+        values.add(current.toString());
+        current.setLength(0);
+      } else {
+        current.append(c);
+      }
+    }
+    values.add(current.toString());
+    return values;
+  }
+
+  private static double parseDouble(final String value, final double defaultValue) {
+    try {
+      return value.isBlank() ? defaultValue : Double.parseDouble(value);
+    } catch (NumberFormatException e) {
+      return defaultValue;
+    }
+  }
+
+  @Nullable
+  private static Double parseNullableDouble(final String value) {
+    final double parsed = parseDouble(value, Double.NaN);
+    return Double.isNaN(parsed) ? null : parsed;
+  }
+
+  private static void writeHtml(@NotNull final List<SpeedReportRow> rows, @NotNull final Path csv,
+      @NotNull final Path html) throws IOException {
+    final ObjectMapper mapper = JsonMapper.builder().addModule(new JavaTimeModule()).build();
+    final String data = mapper.writeValueAsString(rows);
+    final String meta = mapper.writeValueAsString(
+        Map.of("source", csv.toAbsolutePath().toString(), "measurements", rows.size()));
+
+    final String page = template().replace("/*__DATA__*/null", data)
+        .replace("/*__META__*/null", meta);
+    Files.writeString(html, page, StandardCharsets.UTF_8);
+  }
+
+  @NotNull
+  private static String stripExtension(@NotNull final String fileName) {
+    final int dot = fileName.lastIndexOf('.');
+    return dot <= 0 ? fileName : fileName.substring(0, dot);
+  }
+
+  @NotNull
+  private static String template() {
+    return """
+        <!doctype html>
+        <html lang="en">
+        <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>mzmine batch speed report</title>
+        <style>
+          :root { color-scheme: light dark; --fg: #1c1c1e; --muted: #6b7280; --bg: #ffffff;
+                  --panel: #f6f7f9; --grid: #d9dce1; }
+          @media (prefers-color-scheme: dark) {
+            :root { --fg: #e8e8ea; --muted: #9aa0a6; --bg: #16181c; --panel: #1e2126;
+                    --grid: #33383f; }
+          }
+          body { margin: 0; padding: 20px 24px 40px; background: var(--bg); color: var(--fg);
+                 font: 14px/1.45 system-ui, -apple-system, Segoe UI, sans-serif; }
+          h1 { font-size: 19px; margin: 0 0 4px; }
+          .sub { color: var(--muted); font-size: 12px; margin-bottom: 14px; }
+          .controls { display: flex; flex-wrap: wrap; gap: 16px; align-items: center;
+                      margin-bottom: 12px; font-size: 13px; }
+          .legend { display: flex; flex-wrap: wrap; gap: 6px 18px; margin-bottom: 18px;
+                    font-size: 12px; }
+          .legend div { display: flex; align-items: center; gap: 6px; }
+          .swatch { width: 11px; height: 11px; border-radius: 3px; flex: none; }
+          .panels { display: grid; gap: 14px;
+                    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); }
+          .panel { background: var(--panel); border-radius: 10px; padding: 10px 10px 4px; }
+          #overview .panel { margin-bottom: 14px; }
+          #overview svg { min-width: 100%; }
+          .scroll { overflow-x: auto; }
+          .panel h2 { font-size: 13px; margin: 0 0 2px; }
+          .panel .note { color: var(--muted); font-size: 11px; margin: 0 0 4px; }
+          svg { width: 100%; height: auto; display: block; }
+          text { fill: var(--fg); }
+          .axis { stroke: var(--grid); stroke-width: 1; }
+          .tick { fill: var(--muted); font-size: 9px; }
+          .xlabel { fill: var(--muted); font-size: 10px; }
+        </style>
+        </head>
+        <body>
+        <h1>mzmine batch speed report</h1>
+        <div class="sub" id="sub"></div>
+        <div class="controls">
+          <label>Metric
+            <select id="metric">
+              <option value="timeSeconds">time (seconds)</option>
+              <option value="gbRamUsed">RAM (GB)</option>
+            </select>
+          </label>
+          <label><input type="checkbox" id="log"> log scale</label>
+          <label><input type="checkbox" id="zero" checked> start axis at 0</label>
+          <label><input type="checkbox" id="total" checked> include WHOLE BATCH in overview</label>
+        </div>
+        <div class="legend" id="legend"></div>
+        <div id="overview"></div>
+        <div class="panels" id="panels"></div>
+        <script>
+        const DATA = /*__DATA__*/null;
+        const META = /*__META__*/null;
+        const COLORS = ['#4c78a8', '#f58518', '#54a24b', '#e45756', '#9d755d', '#b279a2',
+                        '#72b7b2', '#eeca3b'];
+        const SVGNS = 'http://www.w3.org/2000/svg';
+        
+        // grouping: panel per step, box per version, replicates from repeated runs
+        const seriesOrder = [];
+        const steps = new Map();
+        for (const row of DATA) {
+          if (!seriesOrder.includes(row.series)) seriesOrder.push(row.series);
+          if (!steps.has(row.step)) steps.set(row.step, new Map());
+          const bySeries = steps.get(row.step);
+          if (!bySeries.has(row.series)) bySeries.set(row.series, []);
+          bySeries.get(row.series).push(row);
+        }
+        // the total is most interesting last
+        const stepOrder = [...steps.keys()].sort((a, b) => rank(a) - rank(b));
+        function rank(step) {
+          return step.toUpperCase().includes('WHOLE BATCH') ? 1 : 0;
+        }
+        
+        const el = (tag, attrs, text) => {
+          const node = document.createElementNS(SVGNS, tag);
+          for (const key in attrs) node.setAttribute(key, attrs[key]);
+          if (text !== undefined) node.textContent = text;
+          return node;
+        };
+        
+        function stats(values) {
+          const v = [...values].sort((a, b) => a - b);
+          const q = p => {
+            const idx = (v.length - 1) * p, lo = Math.floor(idx), hi = Math.ceil(idx);
+            return lo === hi ? v[lo] : v[lo] + (v[hi] - v[lo]) * (idx - lo);
+          };
+          const q1 = q(0.25), med = q(0.5), q3 = q(0.75), iqr = q3 - q1;
+          const loFence = q1 - 1.5 * iqr, hiFence = q3 + 1.5 * iqr;
+          const inner = v.filter(x => x >= loFence && x <= hiFence);
+          const mean = v.reduce((a, b) => a + b, 0) / v.length;
+          return {
+            n: v.length, q1, med, q3, mean, min: v[0], max: v[v.length - 1],
+            whiskerLo: inner.length ? inner[0] : v[0],
+            whiskerHi: inner.length ? inner[inner.length - 1] : v[v.length - 1],
+            outliers: v.filter(x => x < loFence || x > hiFence), values: v
+          };
+        }
+        
+        const fmt = x => Math.abs(x) >= 100 ? x.toFixed(0)
+                       : Math.abs(x) >= 10 ? x.toFixed(1) : x.toFixed(2);
+        
+        function ticks(min, max, log) {
+          if (log) {
+            const out = [];
+            for (let e = Math.floor(Math.log10(min)); e <= Math.ceil(Math.log10(max)); e++) {
+              for (const m of [1, 2, 5]) {
+                const t = m * Math.pow(10, e);
+                if (t >= min && t <= max) out.push(t);
+              }
+            }
+            return out.length > 1 ? out : [min, max];
+          }
+          const raw = (max - min) / 5;
+          const mag = Math.pow(10, Math.floor(Math.log10(raw)));
+          const step = [1, 2, 2.5, 5, 10].map(m => m * mag).find(s => s >= raw) ?? mag * 10;
+          const out = [];
+          for (let t = Math.ceil(min / step) * step; t <= max + step * 1e-6; t += step) out.push(t);
+          return out;
+        }
+        
+        /**
+         * All boxes of one step, in the global version order. Steps without values for the current
+         * metric return an empty array.
+         */
+        function boxesOfStep(step, metric) {
+          const bySeries = steps.get(step);
+          return seriesOrder.map(series => {
+            const values = (bySeries.get(series) ?? [])
+                .map(r => r[metric]).filter(v => typeof v === 'number' && isFinite(v));
+            return { series, stats: values.length ? stats(values) : null };
+          }).filter(b => b.stats);
+        }
+        
+        function axisRange(allStats, log, fromZero) {
+          let max = Math.max(...allStats.map(s => s.max));
+          let min = Math.min(...allStats.map(s => s.min));
+          if (log) {
+            min = Math.max(min * 0.8, 1e-3);
+            max = max * 1.2;
+          } else {
+            const pad = (max - min) * 0.08 || Math.max(max * 0.08, 0.01);
+            min = fromZero ? 0 : Math.max(0, min - pad);
+            max = max + pad;
+          }
+          if (max <= min) max = min + 1;
+          return { min, max };
+        }
+        
+        function makeScale(min, max, log, mT, plotH) {
+          return v => {
+            const t = log
+                ? (Math.log10(Math.max(v, 1e-3)) - Math.log10(min))
+                  / (Math.log10(max) - Math.log10(min))
+                : (v - min) / (max - min);
+            return mT + plotH - t * plotH;
+          };
+        }
+        
+        function drawGrid(svg, min, max, log, scale, mL, mR, mT, plotH, W) {
+          for (const t of ticks(min, max, log)) {
+            const y = scale(t);
+            svg.appendChild(el('line', { class: 'axis', x1: mL, x2: W - mR, y1: y, y2: y }));
+            svg.appendChild(el('text', { class: 'tick', x: mL - 5, y: y + 3,
+                'text-anchor': 'end' }, fmt(t)));
+          }
+          svg.appendChild(el('line', { class: 'axis', x1: mL, x2: mL, y1: mT, y2: mT + plotH }));
+        }
+        
+        function drawBox(svg, s, cx, bw, color, scale, tooltip) {
+          const g = el('g', {});
+          g.appendChild(el('title', {}, tooltip + '\\n' + 'n=' + s.n + ', median ' + fmt(s.med)
+              + ', mean ' + fmt(s.mean) + ', min ' + fmt(s.min) + ', max ' + fmt(s.max)));
+          // whiskers
+          g.appendChild(el('line', { x1: cx, x2: cx, y1: scale(s.whiskerLo),
+              y2: scale(s.whiskerHi), stroke: color, 'stroke-width': 1 }));
+          for (const v of [s.whiskerLo, s.whiskerHi]) {
+            g.appendChild(el('line', { x1: cx - bw / 4, x2: cx + bw / 4, y1: scale(v),
+                y2: scale(v), stroke: color, 'stroke-width': 1 }));
+          }
+          // box and median
+          g.appendChild(el('rect', { x: cx - bw / 2, y: scale(s.q3), width: bw,
+              height: Math.max(scale(s.q1) - scale(s.q3), 1), fill: color,
+              'fill-opacity': 0.25, stroke: color, 'stroke-width': 1, rx: 2 }));
+          g.appendChild(el('line', { x1: cx - bw / 2, x2: cx + bw / 2, y1: scale(s.med),
+              y2: scale(s.med), stroke: color, 'stroke-width': 2 }));
+          // all replicates as jittered points, deterministic offsets
+          s.values.forEach((v, j) => {
+            const offset = ((j % 5) - 2) * (bw / 12);
+            g.appendChild(el('circle', { cx: cx + offset, cy: scale(v), r: 1.9, fill: color,
+                'fill-opacity': 0.85 }));
+          });
+          for (const v of s.outliers) {
+            g.appendChild(el('circle', { cx: cx, cy: scale(v), r: 2.6, fill: 'none',
+                stroke: color, 'stroke-width': 1 }));
+          }
+          svg.appendChild(g);
+        }
+        
+        const colorOf = series => COLORS[seriesOrder.indexOf(series) % COLORS.length];
+        
+        function render() {
+          const metric = document.getElementById('metric').value;
+          const log = document.getElementById('log').checked;
+          const fromZero = document.getElementById('zero').checked && !log;
+          const withTotal = document.getElementById('total').checked;
+          const overview = document.getElementById('overview');
+          const panels = document.getElementById('panels');
+          overview.textContent = '';
+          panels.textContent = '';
+        
+          const groups = stepOrder.map(step => ({ step, boxes: boxesOfStep(step, metric) }))
+              .filter(g => g.boxes.length);
+          if (!groups.length) return;
+        
+          const forOverview = groups.filter(g => withTotal || rank(g.step) === 0);
+          if (forOverview.length) {
+            overview.appendChild(overviewPanel(forOverview, metric, log, fromZero));
+          }
+          for (const group of groups) {
+            panels.appendChild(panel(group.step, group.boxes, log, fromZero));
+          }
+        }
+        
+        /**
+         * Combined plot: grouped by step on the x axis, one box per version within each step.
+         */
+        function overviewPanel(groups, metric, log, fromZero) {
+          const mL = 54, mR = 12, mT = 10, mB = 104, H = 400;
+          const boxSlot = 22;
+          const groupPad = 14;
+          const groupW = groups.map(g => g.boxes.length * boxSlot + groupPad);
+          const W = Math.max(760, mL + mR + groupW.reduce((a, b) => a + b, 0));
+          const plotH = H - mT - mB;
+        
+          const wrap = document.createElement('div');
+          wrap.className = 'panel';
+          const title = document.createElement('h2');
+          title.textContent = 'All steps'
+              + (metric === 'timeSeconds' ? ' - time (seconds)' : ' - RAM (GB)');
+          const note = document.createElement('p');
+          note.className = 'note';
+          note.textContent = 'grouped by step, one box per version - hover a box for details';
+          wrap.appendChild(title);
+          wrap.appendChild(note);
+        
+          const allStats = groups.flatMap(g => g.boxes.map(b => b.stats));
+          const { min, max } = axisRange(allStats, log, fromZero);
+          const scale = makeScale(min, max, log, mT, plotH);
+        
+          const svg = el('svg', { viewBox: '0 0 ' + W + ' ' + H, width: W, height: H });
+          drawGrid(svg, min, max, log, scale, mL, mR, mT, plotH, W);
+        
+          let x = mL;
+          groups.forEach((group, gi) => {
+            const width = groupW[gi];
+            group.boxes.forEach((box, i) => {
+              const cx = x + groupPad / 2 + boxSlot * (i + 0.5);
+              drawBox(svg, box.stats, cx, boxSlot * 0.62, colorOf(box.series), scale,
+                  group.step + ' - ' + box.series);
+            });
+            // separator between step groups
+            if (gi > 0) {
+              svg.appendChild(el('line', { class: 'axis', x1: x, x2: x, y1: mT, y2: mT + plotH,
+                  'stroke-dasharray': '2 3' }));
+            }
+            const cx = x + width / 2;
+            const y = mT + plotH + 8;
+            // long step names are shortened, the full name stays in the tooltip
+            const label = el('text', { class: 'xlabel', x: cx, y: y, 'text-anchor': 'end',
+                transform: 'rotate(-35 ' + cx + ' ' + y + ')' },
+                group.step.length > 26 ? group.step.slice(0, 25) + '...' : group.step);
+            label.appendChild(el('title', {}, group.step));
+            svg.appendChild(label);
+            x += width;
+          });
+          const scroller = document.createElement('div');
+          scroller.className = 'scroll';
+          scroller.appendChild(svg);
+          wrap.appendChild(scroller);
+          return wrap;
+        }
+        
+        function panel(step, boxes, log, fromZero) {
+          const W = 420, H = 250, mL = 48, mR = 10, mT = 8, mB = 34;
+          const wrap = document.createElement('div');
+          wrap.className = 'panel';
+          const title = document.createElement('h2');
+          title.textContent = step;
+          const note = document.createElement('p');
+          note.className = 'note';
+          note.textContent = boxes.map(b => b.series + ': n=' + b.stats.n + ', median '
+              + fmt(b.stats.med)).join('  |  ');
+          wrap.appendChild(title);
+          wrap.appendChild(note);
+        
+          const { min, max } = axisRange(boxes.map(b => b.stats), log, fromZero);
+          const plotH = H - mT - mB;
+          const scale = makeScale(min, max, log, mT, plotH);
+        
+          const svg = el('svg', { viewBox: '0 0 ' + W + ' ' + H });
+          drawGrid(svg, min, max, log, scale, mL, mR, mT, plotH, W);
+        
+          const slot = (W - mL - mR) / boxes.length;
+          const bw = Math.min(slot * 0.55, 46);
+          boxes.forEach((box, i) => {
+            const s = box.stats;
+            const cx = mL + slot * (i + 0.5);
+            drawBox(svg, s, cx, bw, colorOf(box.series), scale, box.series);
+            svg.appendChild(el('text', { class: 'xlabel', x: cx, y: H - mB + 14,
+                'text-anchor': 'middle' }, String(seriesOrder.indexOf(box.series) + 1)));
+            svg.appendChild(el('text', { class: 'xlabel', x: cx, y: H - mB + 26,
+                'text-anchor': 'middle' }, fmt(s.med)));
+          });
+          wrap.appendChild(svg);
+          return wrap;
+        }
+        
+        function renderLegend() {
+          const legend = document.getElementById('legend');
+          seriesOrder.forEach((series, i) => {
+            const item = document.createElement('div');
+            const swatch = document.createElement('span');
+            swatch.className = 'swatch';
+            swatch.style.background = COLORS[i % COLORS.length];
+            item.appendChild(swatch);
+            item.appendChild(document.createTextNode((i + 1) + ' - ' + series));
+            legend.appendChild(item);
+          });
+        }
+        
+        document.getElementById('sub').textContent = META.measurements + ' measurements, '
+            + stepOrder.length + ' steps, ' + seriesOrder.length + ' versions - '
+            + META.source;
+        renderLegend();
+        for (const id of ['metric', 'log', 'zero', 'total']) {
+          document.getElementById(id).addEventListener('change', render);
+        }
+        render();
+        </script>
+        </body>
+        </html>
+        """;
+  }
+
+}

--- a/mzmine-community/src/test/java/import_data/speed/SpeedReportRow.java
+++ b/mzmine-community/src/test/java/import_data/speed/SpeedReportRow.java
@@ -25,16 +25,15 @@
 
 package import_data.speed;
 
-import java.io.File;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-public record BatchSpeedJob(String description, int iterations, String batchFile,
-                            List<String> files) {
+/**
+ * One measurement flattened for the HTML speed report. The {@link #series()} is the grouping on the
+ * x axis (usually the mzmine version, taken from the last part of the description) while
+ * {@link #step()} defines the panel (batch step name).
+ */
+public record SpeedReportRow(@NotNull String step, @NotNull String series, int files,
+                             double timeSeconds, @Nullable Double gbRamUsed) {
 
-  @NotNull
-  public String getBatchFileName() {
-    return new File(batchFile).getName();
-  }
 }
-

--- a/mzmine-community/src/test/java/import_data/speed/SpeedReportRow.java
+++ b/mzmine-community/src/test/java/import_data/speed/SpeedReportRow.java
@@ -29,11 +29,31 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * One measurement flattened for the HTML speed report. The {@link #series()} is the grouping on the
- * x axis (usually the mzmine version, taken from the last part of the description) while
- * {@link #step()} defines the panel (batch step name).
+ * One measurement flattened for the HTML speed report. The {@link #series()} is the grouping of the
+ * comparison (the description the user provided to qualify what was tested) while {@link #step()} and
+ * {@link #name()} define the panel. Replicates come from the iterations of one or several runs.
+ *
+ * @param step        1-based step number, 0 for the whole batch. Together with the name this
+ *                    separates steps that apply the same module twice in one batch.
+ * @param name        module name of the step
+ * @param phase       {@link SpeedTestPhase}, warmup rows are excluded by default in the report
+ * @param iteration   1-based index within the phase
+ * @param runId       groups the iterations of one JVM start
+ * @param status      only {@code FINISHED} rows are plotted
+ * @param environment human readable summary of the mzmine and JVM configuration, the report warns
+ *                    when the compared series were measured with different environments
+ * @see SpeedIterationStats the fields from {@code featureLists} on are measured once per iteration
+ * and therefore repeated on every step row of that iteration
  */
-public record SpeedReportRow(@NotNull String step, @NotNull String series, int files,
-                             double timeSeconds, @Nullable Double gbRamUsed) {
+public record SpeedReportRow(int step, @NotNull String name, @NotNull String series,
+                             @NotNull String phase, int iteration, @NotNull String runId,
+                             @NotNull String status, int files, double timeSeconds,
+                             @Nullable Double gbRamUsed, @Nullable Double tempFilesCreated,
+                             @Nullable Double reservedTempFileGB, @Nullable Double usedTempFileGB,
+                             @Nullable Double liveTempFiles, @Nullable Double liveTempFileUsedGB,
+                             int featureLists, @Nullable Double rows, @Nullable Double features,
+                             @Nullable Double tempDirUsedGB, @Nullable Double peakHeapGB,
+                             @Nullable Double gcCount, @Nullable Double gcTimeSeconds,
+                             @NotNull String environment) {
 
 }

--- a/mzmine-community/src/test/java/import_data/speed/SpeedTestEnvironment.java
+++ b/mzmine-community/src/test/java/import_data/speed/SpeedTestEnvironment.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package import_data.speed;
+
+import io.github.mzmine.gui.preferences.MZminePreferences;
+import io.github.mzmine.main.ConfigService;
+import io.github.mzmine.util.io.SemverVersionReader;
+import java.lang.management.ManagementFactory;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Everything about the machine, the JVM and the mzmine configuration that influences a speed
+ * measurement. These settings are only documented in the results, they are never changed by the
+ * harness - so two runs that should be compared need to use the same configuration and VM options.
+ * The report can use these columns to spot runs that are not comparable.
+ *
+ * @param mzmineVersion       mzmine version of the running build
+ * @param inMemory            the {@code -m} command line argument, see
+ *                            {@link io.github.mzmine.util.MemoryMapStorage}
+ * @param runGCafterBatchStep {@link MZminePreferences#runGCafterBatchStep}, influences the timing
+ *                            and is required for the heap measurements to be meaningful
+ * @param numOfThreads        {@link MZminePreferences#numOfThreads} as resolved to a number
+ * @param availableProcessors processors visible to the JVM
+ * @param maxHeapGB           {@code -Xmx} as seen by the JVM
+ * @param javaVersion         runtime version of the JVM
+ * @param memoryVmArgs        the {@code -X} and {@code -XX} VM options, other arguments are dropped
+ *                            because they are usually IDE specific and not related to performance
+ * @param osName              operating system name and version
+ */
+public record SpeedTestEnvironment(@NotNull String mzmineVersion, @NotNull String inMemory,
+                                   boolean runGCafterBatchStep, int numOfThreads,
+                                   int availableProcessors, double maxHeapGB,
+                                   @NotNull String javaVersion, @NotNull String memoryVmArgs,
+                                   @NotNull String osName) {
+
+  @NotNull
+  public static SpeedTestEnvironment detect(@NotNull final String inMemory) {
+    final boolean gc = Objects.requireNonNullElse(
+        ConfigService.getPreference(MZminePreferences.runGCafterBatchStep), false);
+    // only the memory and GC related options matter for a comparison, the rest is IDE noise
+    final String vmArgs = ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
+        .filter(arg -> arg.startsWith("-X")).collect(Collectors.joining(" "));
+
+    return new SpeedTestEnvironment(SemverVersionReader.getMZmineVersion().toString(), inMemory, gc,
+        ConfigService.getConfiguration().getNumOfThreads(),
+        Runtime.getRuntime().availableProcessors(),
+        Math.round(Runtime.getRuntime().maxMemory() / 1e7) / 100d, Runtime.version().toString(),
+        vmArgs, System.getProperty("os.name") + " " + System.getProperty("os.version"));
+  }
+
+  /**
+   * Human readable summary for the log and the report header.
+   */
+  @NotNull
+  public String describe() {
+    return String.join(", ", "mzmine " + mzmineVersion, "inMemory=" + inMemory,
+        "runGCafterBatchStep=" + runGCafterBatchStep,
+        "threads=" + numOfThreads + "/" + availableProcessors, "maxHeap=" + maxHeapGB + " GB",
+        "java " + javaVersion, memoryVmArgs.isBlank() ? "no -X VM options" : memoryVmArgs, osName);
+  }
+}

--- a/mzmine-community/src/test/java/import_data/speed/SpeedTestPhase.java
+++ b/mzmine-community/src/test/java/import_data/speed/SpeedTestPhase.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2004-2026 The mzmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package import_data.speed;
+
+/**
+ * Marks whether an iteration was still warming up the JVM (JIT, file system caches) or is meant to
+ * be used for the actual comparison. Warmup iterations are exported as well so that they can be
+ * inspected, but they are excluded from the report by default.
+ */
+public enum SpeedTestPhase {
+  WARMUP, PRODUCTION
+}

--- a/mzmine-community/src/test/java/import_data/speed/speed_report.html
+++ b/mzmine-community/src/test/java/import_data/speed/speed_report.html
@@ -1,0 +1,346 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>mzmine batch speed report</title>
+<style>
+  :root { color-scheme: light dark; --fg: #1c1c1e; --muted: #6b7280; --bg: #ffffff;
+          --panel: #f6f7f9; --grid: #d9dce1; }
+  @media (prefers-color-scheme: dark) {
+    :root { --fg: #e8e8ea; --muted: #9aa0a6; --bg: #16181c; --panel: #1e2126;
+            --grid: #33383f; }
+  }
+  body { margin: 0; padding: 20px 24px 40px; background: var(--bg); color: var(--fg);
+         font: 14px/1.45 system-ui, -apple-system, Segoe UI, sans-serif; }
+  h1 { font-size: 19px; margin: 0 0 4px; }
+  .sub { color: var(--muted); font-size: 12px; margin-bottom: 14px; }
+  .controls { display: flex; flex-wrap: wrap; gap: 16px; align-items: center;
+              margin-bottom: 12px; font-size: 13px; }
+  .legend { display: flex; flex-wrap: wrap; gap: 6px 18px; margin-bottom: 18px;
+            font-size: 12px; }
+  .legend div { display: flex; align-items: center; gap: 6px; }
+  .swatch { width: 11px; height: 11px; border-radius: 3px; flex: none; }
+  .panels { display: grid; gap: 14px;
+            grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); }
+  .panel { background: var(--panel); border-radius: 10px; padding: 10px 10px 4px; }
+  #overview .panel { margin-bottom: 14px; }
+  #overview svg { min-width: 100%; }
+  .scroll { overflow-x: auto; }
+  .panel h2 { font-size: 13px; margin: 0 0 2px; }
+  .panel .note { color: var(--muted); font-size: 11px; margin: 0 0 4px; }
+  svg { width: 100%; height: auto; display: block; }
+  text { fill: var(--fg); }
+  .axis { stroke: var(--grid); stroke-width: 1; }
+  .tick { fill: var(--muted); font-size: 9px; }
+  .xlabel { fill: var(--muted); font-size: 10px; }
+</style>
+</head>
+<body>
+<h1>mzmine batch speed report</h1>
+<div class="sub" id="sub"></div>
+<div class="controls">
+  <label>Metric
+    <select id="metric">
+      <option value="timeSeconds">time (seconds)</option>
+      <option value="gbRamUsed">RAM (GB)</option>
+    </select>
+  </label>
+  <label><input type="checkbox" id="log"> log scale</label>
+  <label><input type="checkbox" id="zero" checked> start axis at 0</label>
+  <label><input type="checkbox" id="total" checked> include WHOLE BATCH in overview</label>
+</div>
+<div class="legend" id="legend"></div>
+<div id="overview"></div>
+<div class="panels" id="panels"></div>
+<script>
+const DATA = [{"step":"Chromatogram builder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":41.437,"gbRamUsed":4.09},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":4.327,"gbRamUsed":2.96},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":3.302,"gbRamUsed":2.83},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":7.708,"gbRamUsed":3.5},{"step":"Join aligner","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":45.186,"gbRamUsed":3.66},{"step":"Feature list rows filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":36.282,"gbRamUsed":3.68},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":46.344,"gbRamUsed":3.21},{"step":"Duplicate peak filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":138.346,"gbRamUsed":3.36},{"step":"Spectral library search","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":10.465,"gbRamUsed":3.24},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":34.466,"gbRamUsed":3.25},{"step":"Intensity normalizer","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":199.93,"gbRamUsed":3.35},{"step":"WHOLE BATCH","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":573.883,"gbRamUsed":3.35},{"step":"Chromatogram builder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":55.224,"gbRamUsed":4.1},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":4.056,"gbRamUsed":2.97},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":3.351,"gbRamUsed":2.84},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":6.625,"gbRamUsed":3.5},{"step":"Join aligner","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":41.034,"gbRamUsed":3.67},{"step":"Feature list rows filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":38.157,"gbRamUsed":3.69},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":43.425,"gbRamUsed":3.22},{"step":"Duplicate peak filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":151.757,"gbRamUsed":3.37},{"step":"Spectral library search","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":9.076,"gbRamUsed":3.24},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":33.233,"gbRamUsed":3.25},{"step":"Intensity normalizer","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":213.59,"gbRamUsed":3.35},{"step":"WHOLE BATCH","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":605.243,"gbRamUsed":3.35},{"step":"Chromatogram builder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":56.78,"gbRamUsed":4.1},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":4.356,"gbRamUsed":2.97},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":3.257,"gbRamUsed":2.84},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":6.92,"gbRamUsed":3.5},{"step":"Join aligner","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":40.908,"gbRamUsed":3.68},{"step":"Feature list rows filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":30.866,"gbRamUsed":3.69},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":28.231,"gbRamUsed":3.22},{"step":"Duplicate peak filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":86.196,"gbRamUsed":3.37},{"step":"Spectral library search","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":8.007,"gbRamUsed":3.24},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":21.619,"gbRamUsed":3.25},{"step":"Intensity normalizer","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":123.557,"gbRamUsed":3.35},{"step":"WHOLE BATCH","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":416.021,"gbRamUsed":3.35},{"step":"Chromatogram builder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":45.883,"gbRamUsed":4.1},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":3.449,"gbRamUsed":2.98},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":2.766,"gbRamUsed":2.84},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":5.903,"gbRamUsed":3.51},{"step":"Join aligner","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":22.441,"gbRamUsed":3.67},{"step":"Feature list rows filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":23.678,"gbRamUsed":3.69},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":27.89,"gbRamUsed":3.22},{"step":"Duplicate peak filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":83.672,"gbRamUsed":3.37},{"step":"Spectral library search","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":6.773,"gbRamUsed":3.24},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":22.183,"gbRamUsed":3.25},{"step":"Intensity normalizer","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":120.299,"gbRamUsed":3.35},{"step":"WHOLE BATCH","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":369.824,"gbRamUsed":3.35},{"step":"Chromatogram builder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":44.186,"gbRamUsed":4.1},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":3.424,"gbRamUsed":2.97},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":2.577,"gbRamUsed":2.84},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":5.903,"gbRamUsed":3.5},{"step":"Join aligner","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":20.035,"gbRamUsed":3.67},{"step":"Feature list rows filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":21.839,"gbRamUsed":3.69},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":25.649,"gbRamUsed":3.22},{"step":"Duplicate peak filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":83.684,"gbRamUsed":3.37},{"step":"Spectral library search","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":6.832,"gbRamUsed":3.24},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":21.336,"gbRamUsed":3.25},{"step":"Intensity normalizer","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":126.666,"gbRamUsed":3.35},{"step":"WHOLE BATCH","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":366.939,"gbRamUsed":3.35},{"step":"Chromatogram builder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":43.201,"gbRamUsed":4.09},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":3.331,"gbRamUsed":2.96},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":2.491,"gbRamUsed":2.83},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":7.75,"gbRamUsed":3.49},{"step":"Join aligner","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":20.885,"gbRamUsed":3.67},{"step":"Feature list rows filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":21.656,"gbRamUsed":3.69},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":26.645,"gbRamUsed":3.21},{"step":"Duplicate peak filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":80.402,"gbRamUsed":3.36},{"step":"Spectral library search","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":7.584,"gbRamUsed":3.23},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":21.258,"gbRamUsed":3.25},{"step":"Intensity normalizer","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":110.62,"gbRamUsed":3.35},{"step":"WHOLE BATCH","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":350.878,"gbRamUsed":3.35},{"step":"Chromatogram builder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":43.494,"gbRamUsed":4.1},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":3.572,"gbRamUsed":2.97},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":2.74,"gbRamUsed":2.84},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":5.718,"gbRamUsed":3.51},{"step":"Join aligner","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":20.281,"gbRamUsed":3.67},{"step":"Feature list rows filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":21.641,"gbRamUsed":3.69},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":25.987,"gbRamUsed":3.22},{"step":"Duplicate peak filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":110.516,"gbRamUsed":3.37},{"step":"Spectral library search","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":8.72,"gbRamUsed":3.24},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":30.691,"gbRamUsed":3.25},{"step":"Intensity normalizer","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":195.6,"gbRamUsed":3.35},{"step":"WHOLE BATCH","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":474.288,"gbRamUsed":3.35},{"step":"Chromatogram builder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":58.381,"gbRamUsed":4.1},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":4.169,"gbRamUsed":2.98},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":3.263,"gbRamUsed":2.84},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":6.376,"gbRamUsed":3.5},{"step":"Join aligner","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":37.172,"gbRamUsed":3.67},{"step":"Feature list rows filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":48.004,"gbRamUsed":3.69},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":42.584,"gbRamUsed":3.22},{"step":"Duplicate peak filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":120.917,"gbRamUsed":3.37},{"step":"Spectral library search","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":8.345,"gbRamUsed":3.24},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":29.241,"gbRamUsed":3.25},{"step":"Intensity normalizer","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":171.656,"gbRamUsed":3.35},{"step":"WHOLE BATCH","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":535.724,"gbRamUsed":3.35},{"step":"Chromatogram builder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":55.011,"gbRamUsed":4.1},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":4.104,"gbRamUsed":2.97},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":3.14,"gbRamUsed":2.84},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":6.39,"gbRamUsed":3.5},{"step":"Join aligner","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":35.539,"gbRamUsed":3.68},{"step":"Feature list rows filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":35.563,"gbRamUsed":3.7},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":39.876,"gbRamUsed":3.22},{"step":"Duplicate peak filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":113.827,"gbRamUsed":3.37},{"step":"Spectral library search","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":9.858,"gbRamUsed":3.24},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":31.643,"gbRamUsed":3.25},{"step":"Intensity normalizer","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":177.32,"gbRamUsed":3.35},{"step":"WHOLE BATCH","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":518.203,"gbRamUsed":3.35},{"step":"Chromatogram builder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":58.468,"gbRamUsed":4.1},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":4.273,"gbRamUsed":2.97},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":3.352,"gbRamUsed":2.84},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":6.774,"gbRamUsed":3.5},{"step":"Join aligner","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":38.693,"gbRamUsed":3.68},{"step":"Feature list rows filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":30.147,"gbRamUsed":3.7},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":37.276,"gbRamUsed":3.22},{"step":"Duplicate peak filter","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":124.543,"gbRamUsed":3.37},{"step":"Spectral library search","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":9.451,"gbRamUsed":3.24},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":32.148,"gbRamUsed":3.25},{"step":"Intensity normalizer","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":174.997,"gbRamUsed":3.35},{"step":"WHOLE BATCH","series":"mzmine4.10.25_master GUIimport once","files":250,"timeSeconds":525.977,"gbRamUsed":3.35},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":51.055,"gbRamUsed":2.9},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":4.119,"gbRamUsed":2.34},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":3.442,"gbRamUsed":2.29},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":7.206,"gbRamUsed":2.87},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":24.808,"gbRamUsed":2.93},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":7.791,"gbRamUsed":2.94},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":12.865,"gbRamUsed":2.6},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":8.29,"gbRamUsed":2.69},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":10.891,"gbRamUsed":2.62},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":30.284,"gbRamUsed":2.63},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":57.108,"gbRamUsed":2.7},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":223.272,"gbRamUsed":2.7},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":60.235,"gbRamUsed":2.91},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":4.607,"gbRamUsed":2.35},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":3.378,"gbRamUsed":2.29},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":8.322,"gbRamUsed":2.87},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":25.234,"gbRamUsed":2.94},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":8.139,"gbRamUsed":2.95},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":12.635,"gbRamUsed":2.61},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":7.866,"gbRamUsed":2.69},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":9.025,"gbRamUsed":2.62},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":30.1,"gbRamUsed":2.63},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":64.055,"gbRamUsed":2.69},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":239.171,"gbRamUsed":2.69},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":50.067,"gbRamUsed":2.91},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":3.908,"gbRamUsed":2.35},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":3.211,"gbRamUsed":2.29},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":7.482,"gbRamUsed":2.87},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":24.723,"gbRamUsed":2.94},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":9.582,"gbRamUsed":2.95},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":13.967,"gbRamUsed":2.61},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":8.951,"gbRamUsed":2.69},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":8.3,"gbRamUsed":2.62},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":31.769,"gbRamUsed":2.63},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":70.722,"gbRamUsed":2.69},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":237.743,"gbRamUsed":2.69},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":52.141,"gbRamUsed":2.91},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":4.106,"gbRamUsed":2.34},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":2.814,"gbRamUsed":2.29},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":6.719,"gbRamUsed":2.87},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":26.846,"gbRamUsed":2.94},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":8.213,"gbRamUsed":2.95},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":13.828,"gbRamUsed":2.61},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":7.89,"gbRamUsed":2.69},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":8.375,"gbRamUsed":2.62},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":30.755,"gbRamUsed":2.63},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":61.676,"gbRamUsed":2.7},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":228.471,"gbRamUsed":2.7},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":55.885,"gbRamUsed":2.91},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":4.095,"gbRamUsed":2.35},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":3.751,"gbRamUsed":2.29},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":8.441,"gbRamUsed":2.87},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":24.138,"gbRamUsed":2.94},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":8.367,"gbRamUsed":2.95},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":12.883,"gbRamUsed":2.61},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":8.733,"gbRamUsed":2.69},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":8.561,"gbRamUsed":2.62},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":29.817,"gbRamUsed":2.63},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":64.75,"gbRamUsed":2.7},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":234.713,"gbRamUsed":2.7},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":55.191,"gbRamUsed":2.9},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":5.731,"gbRamUsed":2.33},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":3.968,"gbRamUsed":2.28},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":9.241,"gbRamUsed":2.86},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":24.578,"gbRamUsed":2.92},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":8.363,"gbRamUsed":2.93},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":15.61,"gbRamUsed":2.59},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":9.228,"gbRamUsed":2.68},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":11.324,"gbRamUsed":2.61},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":29.95,"gbRamUsed":2.62},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":53.978,"gbRamUsed":2.69},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":232.832,"gbRamUsed":2.69},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":63.833,"gbRamUsed":2.9},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":3.974,"gbRamUsed":2.34},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":3.661,"gbRamUsed":2.28},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":7.57,"gbRamUsed":2.86},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":24.728,"gbRamUsed":2.93},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":8.203,"gbRamUsed":2.94},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":13.72,"gbRamUsed":2.6},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":9.943,"gbRamUsed":2.68},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":10.153,"gbRamUsed":2.61},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":30.863,"gbRamUsed":2.62},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":53.829,"gbRamUsed":2.69},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":235.749,"gbRamUsed":2.69},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":39.423,"gbRamUsed":2.9},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":3.507,"gbRamUsed":2.33},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":2.473,"gbRamUsed":2.27},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":6.267,"gbRamUsed":2.86},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":13.009,"gbRamUsed":2.92},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":4.708,"gbRamUsed":2.93},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":9.652,"gbRamUsed":2.59},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":5.48,"gbRamUsed":2.68},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":7.706,"gbRamUsed":2.61},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":19.503,"gbRamUsed":2.62},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":36.243,"gbRamUsed":2.68},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":152.554,"gbRamUsed":2.68},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":37.574,"gbRamUsed":2.9},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":3.406,"gbRamUsed":2.33},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":2.344,"gbRamUsed":2.27},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":5.473,"gbRamUsed":2.86},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":12.841,"gbRamUsed":2.92},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":4.609,"gbRamUsed":2.93},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":9.749,"gbRamUsed":2.59},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":5.778,"gbRamUsed":2.68},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":7.792,"gbRamUsed":2.61},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":19.498,"gbRamUsed":2.62},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":37.986,"gbRamUsed":2.68},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":151.211,"gbRamUsed":2.68},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":39.506,"gbRamUsed":2.9},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":2.921,"gbRamUsed":2.34},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":2.325,"gbRamUsed":2.28},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":5.597,"gbRamUsed":2.86},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":12.731,"gbRamUsed":2.93},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":4.674,"gbRamUsed":2.94},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":9.797,"gbRamUsed":2.6},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":5.823,"gbRamUsed":2.68},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":6.729,"gbRamUsed":2.61},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":19.328,"gbRamUsed":2.62},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":38.322,"gbRamUsed":2.69},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":151.994,"gbRamUsed":2.69},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":39.188,"gbRamUsed":2.9},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":3.052,"gbRamUsed":2.34},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":2.336,"gbRamUsed":2.28},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":5.649,"gbRamUsed":2.86},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":12.973,"gbRamUsed":2.93},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":4.286,"gbRamUsed":2.94},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":9.794,"gbRamUsed":2.6},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":5.802,"gbRamUsed":2.68},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":6.868,"gbRamUsed":2.61},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":19.583,"gbRamUsed":2.62},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":61.937,"gbRamUsed":2.69},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":175.699,"gbRamUsed":2.69},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":61.021,"gbRamUsed":2.9},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":6.384,"gbRamUsed":2.34},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":5.178,"gbRamUsed":2.28},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":12.577,"gbRamUsed":2.86},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":27.459,"gbRamUsed":2.93},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":8.557,"gbRamUsed":2.94},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":17.862,"gbRamUsed":2.6},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":10.253,"gbRamUsed":2.68},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":12.104,"gbRamUsed":2.61},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":35.679,"gbRamUsed":2.62},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":68.954,"gbRamUsed":2.69},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":272.247,"gbRamUsed":2.69},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":60.483,"gbRamUsed":2.9},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":6.954,"gbRamUsed":2.34},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":5.402,"gbRamUsed":2.28},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":11.678,"gbRamUsed":2.86},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":27.904,"gbRamUsed":2.93},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":8.453,"gbRamUsed":2.94},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":16.855,"gbRamUsed":2.6},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":10.676,"gbRamUsed":2.68},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":11.902,"gbRamUsed":2.61},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":34.631,"gbRamUsed":2.62},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":65.102,"gbRamUsed":2.69},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":266.673,"gbRamUsed":2.69},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":56.909,"gbRamUsed":2.89},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":4.004,"gbRamUsed":2.33},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":2.622,"gbRamUsed":2.27},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":5.973,"gbRamUsed":2.86},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":19.781,"gbRamUsed":2.92},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":21.713,"gbRamUsed":2.93},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":28.965,"gbRamUsed":2.59},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":89.504,"gbRamUsed":2.68},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":9.607,"gbRamUsed":2.61},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":21.853,"gbRamUsed":2.62},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":122.705,"gbRamUsed":2.69},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":388.358,"gbRamUsed":2.69},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":56.388,"gbRamUsed":2.9},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":5.056,"gbRamUsed":2.34},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":4.588,"gbRamUsed":2.28},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":9.626,"gbRamUsed":2.86},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":23.684,"gbRamUsed":2.93},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":22.258,"gbRamUsed":2.94},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":42.526,"gbRamUsed":2.6},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":143.029,"gbRamUsed":2.68},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":10.93,"gbRamUsed":2.61},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":40.23,"gbRamUsed":2.62},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":199.66,"gbRamUsed":2.68},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":563.722,"gbRamUsed":2.68},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":63.889,"gbRamUsed":2.9},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":6.649,"gbRamUsed":2.34},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":5.157,"gbRamUsed":2.28},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":11.032,"gbRamUsed":2.86},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":48.269,"gbRamUsed":2.93},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":48.137,"gbRamUsed":2.94},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":43.016,"gbRamUsed":2.6},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":156.042,"gbRamUsed":2.6},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":10.969,"gbRamUsed":2.61},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":35.155,"gbRamUsed":2.62},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":194.849,"gbRamUsed":2.69},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":629.372,"gbRamUsed":2.69},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":63.744,"gbRamUsed":2.9},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":5.863,"gbRamUsed":2.33},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":4.611,"gbRamUsed":2.28},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":11.272,"gbRamUsed":2.86},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":39.714,"gbRamUsed":2.93},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":40.338,"gbRamUsed":2.94},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":50.401,"gbRamUsed":2.6},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":158.016,"gbRamUsed":2.68},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":11.555,"gbRamUsed":2.61},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":34.427,"gbRamUsed":2.62},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":149.269,"gbRamUsed":2.69},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":575.334,"gbRamUsed":2.69},{"step":"Chromatogram builder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":73.633,"gbRamUsed":2.9},{"step":"Local minimum feature resolver","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":7.828,"gbRamUsed":2.33},{"step":"13C isotope filter (formerly: isotope grouper)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":7.072,"gbRamUsed":2.28},{"step":"Isotopic peaks finder","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":9.145,"gbRamUsed":2.86},{"step":"Join aligner","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":39.391,"gbRamUsed":2.93},{"step":"Feature list rows filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":39.821,"gbRamUsed":2.94},{"step":"Feature finder (multithreaded)","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":52.246,"gbRamUsed":2.6},{"step":"Duplicate peak filter","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":226.547,"gbRamUsed":2.68},{"step":"Spectral library search","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":9.919,"gbRamUsed":2.61},{"step":"Spectral / Molecular Networking","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":41.609,"gbRamUsed":2.62},{"step":"Intensity normalizer","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":258.252,"gbRamUsed":2.69},{"step":"WHOLE BATCH","series":"mzmine4.10.25_fastercopy GUIimport once","files":250,"timeSeconds":771.843,"gbRamUsed":2.69}];
+const META = {"measurements":336,"source":"D:\\git\\mzmine3\\mzmine-community\\src\\test\\java\\import_data\\speed\\speed.csv"};
+const COLORS = ['#4c78a8', '#f58518', '#54a24b', '#e45756', '#9d755d', '#b279a2',
+                '#72b7b2', '#eeca3b'];
+const SVGNS = 'http://www.w3.org/2000/svg';
+
+// grouping: panel per step, box per version, replicates from repeated runs
+const seriesOrder = [];
+const steps = new Map();
+for (const row of DATA) {
+  if (!seriesOrder.includes(row.series)) seriesOrder.push(row.series);
+  if (!steps.has(row.step)) steps.set(row.step, new Map());
+  const bySeries = steps.get(row.step);
+  if (!bySeries.has(row.series)) bySeries.set(row.series, []);
+  bySeries.get(row.series).push(row);
+}
+// the total is most interesting last
+const stepOrder = [...steps.keys()].sort((a, b) => rank(a) - rank(b));
+function rank(step) {
+  return step.toUpperCase().includes('WHOLE BATCH') ? 1 : 0;
+}
+
+const el = (tag, attrs, text) => {
+  const node = document.createElementNS(SVGNS, tag);
+  for (const key in attrs) node.setAttribute(key, attrs[key]);
+  if (text !== undefined) node.textContent = text;
+  return node;
+};
+
+function stats(values) {
+  const v = [...values].sort((a, b) => a - b);
+  const q = p => {
+    const idx = (v.length - 1) * p, lo = Math.floor(idx), hi = Math.ceil(idx);
+    return lo === hi ? v[lo] : v[lo] + (v[hi] - v[lo]) * (idx - lo);
+  };
+  const q1 = q(0.25), med = q(0.5), q3 = q(0.75), iqr = q3 - q1;
+  const loFence = q1 - 1.5 * iqr, hiFence = q3 + 1.5 * iqr;
+  const inner = v.filter(x => x >= loFence && x <= hiFence);
+  const mean = v.reduce((a, b) => a + b, 0) / v.length;
+  return {
+    n: v.length, q1, med, q3, mean, min: v[0], max: v[v.length - 1],
+    whiskerLo: inner.length ? inner[0] : v[0],
+    whiskerHi: inner.length ? inner[inner.length - 1] : v[v.length - 1],
+    outliers: v.filter(x => x < loFence || x > hiFence), values: v
+  };
+}
+
+const fmt = x => Math.abs(x) >= 100 ? x.toFixed(0)
+               : Math.abs(x) >= 10 ? x.toFixed(1) : x.toFixed(2);
+
+function ticks(min, max, log) {
+  if (log) {
+    const out = [];
+    for (let e = Math.floor(Math.log10(min)); e <= Math.ceil(Math.log10(max)); e++) {
+      for (const m of [1, 2, 5]) {
+        const t = m * Math.pow(10, e);
+        if (t >= min && t <= max) out.push(t);
+      }
+    }
+    return out.length > 1 ? out : [min, max];
+  }
+  const raw = (max - min) / 5;
+  const mag = Math.pow(10, Math.floor(Math.log10(raw)));
+  const step = [1, 2, 2.5, 5, 10].map(m => m * mag).find(s => s >= raw) ?? mag * 10;
+  const out = [];
+  for (let t = Math.ceil(min / step) * step; t <= max + step * 1e-6; t += step) out.push(t);
+  return out;
+}
+
+/**
+ * All boxes of one step, in the global version order. Steps without values for the current
+ * metric return an empty array.
+ */
+function boxesOfStep(step, metric) {
+  const bySeries = steps.get(step);
+  return seriesOrder.map(series => {
+    const values = (bySeries.get(series) ?? [])
+        .map(r => r[metric]).filter(v => typeof v === 'number' && isFinite(v));
+    return { series, stats: values.length ? stats(values) : null };
+  }).filter(b => b.stats);
+}
+
+function axisRange(allStats, log, fromZero) {
+  let max = Math.max(...allStats.map(s => s.max));
+  let min = Math.min(...allStats.map(s => s.min));
+  if (log) {
+    min = Math.max(min * 0.8, 1e-3);
+    max = max * 1.2;
+  } else {
+    const pad = (max - min) * 0.08 || Math.max(max * 0.08, 0.01);
+    min = fromZero ? 0 : Math.max(0, min - pad);
+    max = max + pad;
+  }
+  if (max <= min) max = min + 1;
+  return { min, max };
+}
+
+function makeScale(min, max, log, mT, plotH) {
+  return v => {
+    const t = log
+        ? (Math.log10(Math.max(v, 1e-3)) - Math.log10(min))
+          / (Math.log10(max) - Math.log10(min))
+        : (v - min) / (max - min);
+    return mT + plotH - t * plotH;
+  };
+}
+
+function drawGrid(svg, min, max, log, scale, mL, mR, mT, plotH, W) {
+  for (const t of ticks(min, max, log)) {
+    const y = scale(t);
+    svg.appendChild(el('line', { class: 'axis', x1: mL, x2: W - mR, y1: y, y2: y }));
+    svg.appendChild(el('text', { class: 'tick', x: mL - 5, y: y + 3,
+        'text-anchor': 'end' }, fmt(t)));
+  }
+  svg.appendChild(el('line', { class: 'axis', x1: mL, x2: mL, y1: mT, y2: mT + plotH }));
+}
+
+function drawBox(svg, s, cx, bw, color, scale, tooltip) {
+  const g = el('g', {});
+  g.appendChild(el('title', {}, tooltip + '\n' + 'n=' + s.n + ', median ' + fmt(s.med)
+      + ', mean ' + fmt(s.mean) + ', min ' + fmt(s.min) + ', max ' + fmt(s.max)));
+  // whiskers
+  g.appendChild(el('line', { x1: cx, x2: cx, y1: scale(s.whiskerLo),
+      y2: scale(s.whiskerHi), stroke: color, 'stroke-width': 1 }));
+  for (const v of [s.whiskerLo, s.whiskerHi]) {
+    g.appendChild(el('line', { x1: cx - bw / 4, x2: cx + bw / 4, y1: scale(v),
+        y2: scale(v), stroke: color, 'stroke-width': 1 }));
+  }
+  // box and median
+  g.appendChild(el('rect', { x: cx - bw / 2, y: scale(s.q3), width: bw,
+      height: Math.max(scale(s.q1) - scale(s.q3), 1), fill: color,
+      'fill-opacity': 0.25, stroke: color, 'stroke-width': 1, rx: 2 }));
+  g.appendChild(el('line', { x1: cx - bw / 2, x2: cx + bw / 2, y1: scale(s.med),
+      y2: scale(s.med), stroke: color, 'stroke-width': 2 }));
+  // all replicates as jittered points, deterministic offsets
+  s.values.forEach((v, j) => {
+    const offset = ((j % 5) - 2) * (bw / 12);
+    g.appendChild(el('circle', { cx: cx + offset, cy: scale(v), r: 1.9, fill: color,
+        'fill-opacity': 0.85 }));
+  });
+  for (const v of s.outliers) {
+    g.appendChild(el('circle', { cx: cx, cy: scale(v), r: 2.6, fill: 'none',
+        stroke: color, 'stroke-width': 1 }));
+  }
+  svg.appendChild(g);
+}
+
+const colorOf = series => COLORS[seriesOrder.indexOf(series) % COLORS.length];
+
+function render() {
+  const metric = document.getElementById('metric').value;
+  const log = document.getElementById('log').checked;
+  const fromZero = document.getElementById('zero').checked && !log;
+  const withTotal = document.getElementById('total').checked;
+  const overview = document.getElementById('overview');
+  const panels = document.getElementById('panels');
+  overview.textContent = '';
+  panels.textContent = '';
+
+  const groups = stepOrder.map(step => ({ step, boxes: boxesOfStep(step, metric) }))
+      .filter(g => g.boxes.length);
+  if (!groups.length) return;
+
+  const forOverview = groups.filter(g => withTotal || rank(g.step) === 0);
+  if (forOverview.length) {
+    overview.appendChild(overviewPanel(forOverview, metric, log, fromZero));
+  }
+  for (const group of groups) {
+    panels.appendChild(panel(group.step, group.boxes, log, fromZero));
+  }
+}
+
+/**
+ * Combined plot: grouped by step on the x axis, one box per version within each step.
+ */
+function overviewPanel(groups, metric, log, fromZero) {
+  const mL = 54, mR = 12, mT = 10, mB = 104, H = 400;
+  const boxSlot = 22;
+  const groupPad = 14;
+  const groupW = groups.map(g => g.boxes.length * boxSlot + groupPad);
+  const W = Math.max(760, mL + mR + groupW.reduce((a, b) => a + b, 0));
+  const plotH = H - mT - mB;
+
+  const wrap = document.createElement('div');
+  wrap.className = 'panel';
+  const title = document.createElement('h2');
+  title.textContent = 'All steps'
+      + (metric === 'timeSeconds' ? ' - time (seconds)' : ' - RAM (GB)');
+  const note = document.createElement('p');
+  note.className = 'note';
+  note.textContent = 'grouped by step, one box per version - hover a box for details';
+  wrap.appendChild(title);
+  wrap.appendChild(note);
+
+  const allStats = groups.flatMap(g => g.boxes.map(b => b.stats));
+  const { min, max } = axisRange(allStats, log, fromZero);
+  const scale = makeScale(min, max, log, mT, plotH);
+
+  const svg = el('svg', { viewBox: '0 0 ' + W + ' ' + H, width: W, height: H });
+  drawGrid(svg, min, max, log, scale, mL, mR, mT, plotH, W);
+
+  let x = mL;
+  groups.forEach((group, gi) => {
+    const width = groupW[gi];
+    group.boxes.forEach((box, i) => {
+      const cx = x + groupPad / 2 + boxSlot * (i + 0.5);
+      drawBox(svg, box.stats, cx, boxSlot * 0.62, colorOf(box.series), scale,
+          group.step + ' - ' + box.series);
+    });
+    // separator between step groups
+    if (gi > 0) {
+      svg.appendChild(el('line', { class: 'axis', x1: x, x2: x, y1: mT, y2: mT + plotH,
+          'stroke-dasharray': '2 3' }));
+    }
+    const cx = x + width / 2;
+    const y = mT + plotH + 8;
+    // long step names are shortened, the full name stays in the tooltip
+    const label = el('text', { class: 'xlabel', x: cx, y: y, 'text-anchor': 'end',
+        transform: 'rotate(-35 ' + cx + ' ' + y + ')' },
+        group.step.length > 26 ? group.step.slice(0, 25) + '...' : group.step);
+    label.appendChild(el('title', {}, group.step));
+    svg.appendChild(label);
+    x += width;
+  });
+  const scroller = document.createElement('div');
+  scroller.className = 'scroll';
+  scroller.appendChild(svg);
+  wrap.appendChild(scroller);
+  return wrap;
+}
+
+function panel(step, boxes, log, fromZero) {
+  const W = 420, H = 250, mL = 48, mR = 10, mT = 8, mB = 34;
+  const wrap = document.createElement('div');
+  wrap.className = 'panel';
+  const title = document.createElement('h2');
+  title.textContent = step;
+  const note = document.createElement('p');
+  note.className = 'note';
+  note.textContent = boxes.map(b => b.series + ': n=' + b.stats.n + ', median '
+      + fmt(b.stats.med)).join('  |  ');
+  wrap.appendChild(title);
+  wrap.appendChild(note);
+
+  const { min, max } = axisRange(boxes.map(b => b.stats), log, fromZero);
+  const plotH = H - mT - mB;
+  const scale = makeScale(min, max, log, mT, plotH);
+
+  const svg = el('svg', { viewBox: '0 0 ' + W + ' ' + H });
+  drawGrid(svg, min, max, log, scale, mL, mR, mT, plotH, W);
+
+  const slot = (W - mL - mR) / boxes.length;
+  const bw = Math.min(slot * 0.55, 46);
+  boxes.forEach((box, i) => {
+    const s = box.stats;
+    const cx = mL + slot * (i + 0.5);
+    drawBox(svg, s, cx, bw, colorOf(box.series), scale, box.series);
+    svg.appendChild(el('text', { class: 'xlabel', x: cx, y: H - mB + 14,
+        'text-anchor': 'middle' }, String(seriesOrder.indexOf(box.series) + 1)));
+    svg.appendChild(el('text', { class: 'xlabel', x: cx, y: H - mB + 26,
+        'text-anchor': 'middle' }, fmt(s.med)));
+  });
+  wrap.appendChild(svg);
+  return wrap;
+}
+
+function renderLegend() {
+  const legend = document.getElementById('legend');
+  seriesOrder.forEach((series, i) => {
+    const item = document.createElement('div');
+    const swatch = document.createElement('span');
+    swatch.className = 'swatch';
+    swatch.style.background = COLORS[i % COLORS.length];
+    item.appendChild(swatch);
+    item.appendChild(document.createTextNode((i + 1) + ' - ' + series));
+    legend.appendChild(item);
+  });
+}
+
+document.getElementById('sub').textContent = META.measurements + ' measurements, '
+    + stepOrder.length + ' steps, ' + seriesOrder.length + ' versions - '
+    + META.source;
+renderLegend();
+for (const id of ['metric', 'log', 'zero', 'total']) {
+  document.getElementById(id).addEventListener('change', render);
+}
+render();
+</script>
+</body>
+</html>


### PR DESCRIPTION
- gradle task to run benchmark with fixed memory min and max (currently 32 gb but can be adjusted)
- warm up and real iterations marked
- option to import only once


# Report
- for each step and across steps
- drift analysis to see if later runs throttle because of heat constraints or if jit optimizes the later runs