### PR TITLE
wizard: always add ms1 mobility scan mass detection step

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/WizardBatchBuilderImagingDda.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/WizardBatchBuilderImagingDda.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2004-2026 The mzmine Development Team
+ *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
  * files (the "Software"), to deal in the Software without
@@ -234,8 +235,11 @@ public class WizardBatchBuilderImagingDda extends BaseWizardBatchBuilder {
   }
 
   protected void makeAndAddMassDetectorSteps(final BatchQueue q) {
-    if (isImsActive && imsInstrumentType == MobilityType.TIMS) {
+    if (isImsActive && (imsInstrumentType == MobilityType.TIMS
+        || imsInstrumentType == MobilityType.TRAVELING_WAVE)) {
       makeAndAddMassDetectionStep(q, 1, SelectedScanTypes.FRAMES);
+      makeAndAddMassDetectionStep(q, 1,
+          SelectedScanTypes.MOBLITY_SCANS); // in theory not needed due to advanced import, but if the file was imported manually it can throw
       makeAndAddMassDetectionStep(q, 2, SelectedScanTypes.MOBLITY_SCANS);
     } else {
       makeAndAddMassDetectionStep(q, 1, SelectedScanTypes.SCANS);


### PR DESCRIPTION
when importing an ims imaging file manually but then running the wizard on it, the batch would fail because the ims file did not have mass detection run on ims scans, because the wizard assumed the mass lists were present due to the advanced import