### PR TITLE
sciex: fix wiff time

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_wiff2/Wiff2ImportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_wiff2/Wiff2ImportTask.java
@@ -46,9 +46,11 @@ import io.github.mzmine.taskcontrol.AbstractRawDataFileTask;
 import io.github.mzmine.util.MemoryMapStorage;
 import io.github.mzmine.util.RawDataFileType;
 import io.github.mzmine.util.StringUtils;
+import io.github.mzmine.util.date.DateTimeUtils;
 import io.github.mzmine.util.date.LocalDateTimeParser;
 import io.github.mzmine.util.files.FileAndPathUtil;
 import java.io.File;
+import java.time.DateTimeException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -167,7 +169,7 @@ public class Wiff2ImportTask extends AbstractRawDataFileTask implements RawDataI
 
         final List<SimpleScan> scans = new ArrayList<>();
         final String startTimestamp = sample.getStartTimestamp();
-        rawDataFile.setStartTimeStamp(LocalDateTimeParser.parseAnyFirstDate(startTimestamp));
+        rawDataFile.setStartTimeStamp(DateTimeUtils.parseOrElse(startTimestamp, null));
 
         final List<Experiment> experiments = access.getExperiments(sample);
         for (Experiment experiment : experiments) {


### PR DESCRIPTION
Used LocalDateTimeParser which only supports dates+times with - in the time (i guess for use in filenames). 
That way only the date was parsed and time was always 00:00:00
The DateTimeParser parses successfully