### PR TITLE
refactor getTIC() to return primitive

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/MassSpectrum.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/MassSpectrum.java
@@ -26,6 +26,7 @@
 package io.github.mzmine.datamodel;
 
 import com.google.common.collect.Range;
+import io.github.mzmine.datamodel.data_access.ScanDataAccess;
 import io.github.mzmine.datamodel.impl.SimpleMassSpectrum;
 import io.github.mzmine.util.collections.BinarySearch;
 import java.util.Arrays;
@@ -114,10 +115,9 @@ public interface MassSpectrum extends Iterable<DataPoint> {
   @Nullable Range<Double> getDataPointMZRange();
 
   /**
-   * @return The sum of intensities of all data points or null if the spectrum has 0 data points.
+   * @return The sum of intensities of all data points. 0 if the spectrum has no data points.
    */
-  @Nullable Double getTIC();
-
+  double getTIC();
 
   /**
    * Searches for the given mz value - or the closest available signal in this spectrum. Copied from

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/MassSpectrum.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/MassSpectrum.java
@@ -26,7 +26,6 @@
 package io.github.mzmine.datamodel;
 
 import com.google.common.collect.Range;
-import io.github.mzmine.datamodel.data_access.ScanDataAccess;
 import io.github.mzmine.datamodel.impl.SimpleMassSpectrum;
 import io.github.mzmine.util.collections.BinarySearch;
 import java.util.Arrays;

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/MetadataOnlyScan.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/MetadataOnlyScan.java
@@ -40,7 +40,7 @@ public abstract class MetadataOnlyScan implements Scan {
   }
 
   @Override
-  public @Nullable Double getTIC() {
+  public double getTIC() {
     throw new UnsupportedOperationException(
         "This scan contains no data, only metadata and is only used to build a scan while reading data.");
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/data_access/MobilityScanDataAccess.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/data_access/MobilityScanDataAccess.java
@@ -421,9 +421,7 @@ public class MobilityScanDataAccess implements MobilityScan {
     return eligibleFrames;
   }
 
-  @Nullable
-  @Override
-  public Double getTIC() {
+  public double getTIC() {
     return ArrayUtils.sum(intensities, 0, currentNumberOfDataPoints);
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/data_access/ScanDataAccess.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/data_access/ScanDataAccess.java
@@ -298,11 +298,13 @@ public abstract class ScanDataAccess implements Scan {
     return masses == null ? null : masses.getDataPointMZRange();
   }
 
-  @Nullable
   @Override
-  public Double getTIC() {
+  public double getTIC() {
     MassSpectrum masses = getCurrentDataSource();
-    return masses == null ? null : masses.getTIC();
+    if (masses == null) {
+      throw new UnsupportedOperationException("No datasource loaded.");
+    }
+    return masses.getTIC();
   }
 
   /**

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/AbstractMassSpectrum.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/AbstractMassSpectrum.java
@@ -122,7 +122,7 @@ public abstract class AbstractMassSpectrum implements MassSpectrum {
   }
 
   @Override
-  public @NotNull Double getTIC() {
+  public double getTIC() {
     return totalIonCurrent;
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/BuildingMobilityScan.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/BuildingMobilityScan.java
@@ -182,9 +182,8 @@ public class BuildingMobilityScan implements MobilityScan {
     throw new UnsupportedOperationException("Not supported by " + this.getClass().getName());
   }
 
-  @Nullable
   @Override
-  public Double getTIC() {
+  public double getTIC() {
     throw new UnsupportedOperationException("Not supported by " + this.getClass().getName());
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/MZmineToMSDKMsScan.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/MZmineToMSDKMsScan.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Simple implementation of the Scan interface.
@@ -99,8 +100,8 @@ public class MZmineToMSDKMsScan implements MsScan {
   }
 
   @Override
-  public Float getTIC() {
-    return mzmineScan.getTIC().floatValue();
+  public @NonNull Float getTIC() {
+    return (float) mzmineScan.getTIC();
   }
 
   @Override

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/MultiChargeStateIsotopePattern.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/MultiChargeStateIsotopePattern.java
@@ -181,7 +181,7 @@ public class MultiChargeStateIsotopePattern implements IsotopePattern {
   }
 
   @Override
-  public @NotNull Double getTIC() {
+  public double getTIC() {
     return getPreferredIsotopePattern().getTIC();
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/SimpleIsotopePattern.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/SimpleIsotopePattern.java
@@ -187,7 +187,7 @@ public class SimpleIsotopePattern implements IsotopePattern {
   }
 
   @Override
-  public @NotNull Double getTIC() {
+  public double getTIC() {
     return tic;
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/SimpleMassSpectrum.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/SimpleMassSpectrum.java
@@ -133,9 +133,8 @@ public class SimpleMassSpectrum implements MassSpectrum {
     return mzRange;
   }
 
-  @Nullable
   @Override
-  public Double getTIC() {
+  public double getTIC() {
     if (tic == null) {
       tic = Arrays.stream(intensityValues).sum();
     }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/StoredMobilityScan.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/StoredMobilityScan.java
@@ -125,9 +125,8 @@ public class StoredMobilityScan implements MobilityScan {
         : Range.singleton(getNumberOfDataPoints() == 0 ? 0d : getMzValue(0));
   }
 
-  @Nullable
   @Override
-  public Double getTIC() {
+  public double getTIC() {
     double tic = 0d;
     for (int i = 0; i < getNumberOfDataPoints(); i++) {
       tic += getIntensityValue(i);

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/masslist/ScanPointerMassList.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/masslist/ScanPointerMassList.java
@@ -126,9 +126,8 @@ public class ScanPointerMassList implements MassList {
     return scan.getDataPointMZRange();
   }
 
-  @Nullable
   @Override
-  public Double getTIC() {
+  public double getTIC() {
     return scan.getTIC();
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/masslist/StoredMobilityScanMassList.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/impl/masslist/StoredMobilityScanMassList.java
@@ -121,9 +121,8 @@ public class StoredMobilityScanMassList implements MassList {
         : Range.singleton(getNumberOfDataPoints() == 0 ? 0d : getMzValue(0));
   }
 
-  @Nullable
   @Override
-  public Double getTIC() {
+  public double getTIC() {
     throw new UnsupportedOperationException("Intentionally unimplemented to safe RAM.");
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/CachedFrame.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/CachedFrame.java
@@ -205,9 +205,8 @@ public class CachedFrame implements Frame {
         "Not intended. This frame is used for visualisation only");
   }
 
-  @Nullable
   @Override
-  public Double getTIC() {
+  public double getTIC() {
     throw new UnsupportedOperationException(
         "Not intended. This frame is used for visualisation only");
   }

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/CachedMobilityScan.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/CachedMobilityScan.java
@@ -136,9 +136,8 @@ public class CachedMobilityScan implements MobilityScan {
     return originalMobilityScan.getDataPointMZRange();
   }
 
-  @Nullable
   @Override
-  public Double getTIC() {
+  public double getTIC() {
     return tic;
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/LipidSpectrumProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/LipidSpectrumProvider.java
@@ -124,10 +124,9 @@ public class LipidSpectrumProvider implements PlotXYDataProvider {
         return null;
       }
 
-      @Nullable
       @Override
-      public Double getTIC() {
-        return null;
+      public double getTIC() {
+        return 0;
       }
 
       @NotNull

--- a/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/MassSpectrumProvider.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/gui/chartbasics/simplechart/providers/impl/spectra/MassSpectrumProvider.java
@@ -118,10 +118,9 @@ public class MassSpectrumProvider implements PlotXYDataProvider {
         return null;
       }
 
-      @Nullable
       @Override
-      public Double getTIC() {
-        return null;
+      public double getTIC() {
+        return 0;
       }
 
       @NotNull

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/filter_diams2/rt_corr/DiaMs2RtCorrTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/filter_diams2/rt_corr/DiaMs2RtCorrTask.java
@@ -257,15 +257,15 @@ public class DiaMs2RtCorrTask extends AbstractTaskSubProcessor {
     }
 
     PseudoSpectrum mostIntense = correlatedMs2s.stream()
-        .max(Comparator.comparing(ps -> Objects.requireNonNullElse(ps.getTIC(), 0d))).orElse(null);
+        .max(Comparator.comparing(PseudoSpectrum::getTIC)).orElse(null);
     if (mostIntense == null) {
       return null;
     }
 
     // only compare ions with other spectra that have at least 25% of the tic of the most intense
-    final double minTic = Objects.requireNonNullElse(mostIntense.getTIC(), 0d) * 0.25;
+    final double minTic = mostIntense.getTIC() * 0.25;
     final List<@NotNull PseudoSpectrum> minTicSpectra = correlatedMs2s.stream()
-        .filter(ms2 -> Objects.requireNonNullElse(ms2.getTIC(), 0d) >= minTic).toList();
+        .filter(ms2 -> ms2.getTIC() >= minTic).toList();
 
     DoubleArrayList mzs = new DoubleArrayList();
     DoubleArrayList intensities = new DoubleArrayList();

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/TotalRawSignalNormalizationTypeModule.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/norm_intensity/TotalRawSignalNormalizationTypeModule.java
@@ -69,7 +69,7 @@ public final class TotalRawSignalNormalizationTypeModule extends
     ScanUtils.assertMassLists(scans);
 
     final double avgTIC = scans.stream().map(Scan::getMassList)
-        .mapToDouble(scan -> Objects.requireNonNullElse(scan.getTIC(), 0d)).average().orElse(0d);
+        .mapToDouble(scan -> scan.getTIC()).average().orElse(0d);
     if (Double.compare(avgTIC, 0d) == 0) {
       throw new IllegalStateException("No TIC found for file: " + file.getName());
     }

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_msmsquality/MsMsQualityExportTask.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/export_msmsquality/MsMsQualityExportTask.java
@@ -278,7 +278,7 @@ public class MsMsQualityExportTask extends AbstractTask {
       score = new MSMSScore(Result.SUCCESS_WITHOUT_FORMULA);
     }
 
-    final Double tic = msmsScan.getTIC();
+    final double tic = msmsScan.getTIC();
     final Double bpi = msmsScan.getBasePeakIntensity();
     final List<String> spotNames = getSpotNames(mergedMsMs);
     final IonTimeSeries<? extends Scan> eic = feature.getFeatureData();

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/msdk/data/BuildingMzMLMsScan.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/import_rawdata_mzml/msdk/data/BuildingMzMLMsScan.java
@@ -215,15 +215,11 @@ public class BuildingMzMLMsScan extends MetadataOnlyScan {
   }
 
   @Override
-  public @Nullable Double getTIC() {
-    if (tic != null) {
-      return tic;
-    }
+  public double getTIC() {
     if (intensityValues == null) {
       throw new UnsupportedOperationException(
           "No data yet. Call load method to load data and memory map the scan.");
     }
-    tic = Arrays.stream(getIntensityValues(new double[getNumberOfDataPoints()])).sum();
     return tic;
   }
 
@@ -647,6 +643,7 @@ public class BuildingMzMLMsScan extends MetadataOnlyScan {
         this.mzValues = StorageUtils.storeValuesToDoubleBuffer(storage, specData.mzs());
         this.intensityValues = StorageUtils.storeValuesToDoubleBuffer(storage,
             specData.intensities());
+        this.tic = Arrays.stream(specData.intensities()).sum();
       }
 
     } catch (MSDKException | IOException e) {
@@ -798,6 +795,7 @@ public class BuildingMzMLMsScan extends MetadataOnlyScan {
       this.wavelengthValues = StorageUtils.storeValuesToDoubleBuffer(storage, specData.mzs());
       this.intensityValues = StorageUtils.storeValuesToDoubleBuffer(storage,
           specData.intensities());
+      this.tic = Arrays.stream(specData.intensities()).sum();
 
     } catch (MSDKException | IOException e) {
       logger.warning("Could not load data of scan #%d".formatted(getScanNumber()));

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectload/CachedIMSFrame.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/io/projectload/CachedIMSFrame.java
@@ -203,7 +203,7 @@ public class CachedIMSFrame implements Frame {
   }
 
   @Override
-  public @Nullable Double getTIC() {
+  public double getTIC() {
     throw new UnsupportedOperationException("Unsupported during project load.");
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/msmsspectramerge/MergedSpectrum.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/msmsspectramerge/MergedSpectrum.java
@@ -93,6 +93,11 @@ public class MergedSpectrum implements MassSpectrum {
    */
   public int removedScansByLowCosine;
 
+  /**
+   * Total Ion Current
+   */
+  private final double tic;
+
   private final static MergedSpectrum EMPTY = new MergedSpectrum(new MergedDataPoint[0],
       new RawDataFile[0], new int[0], 0d, PolarityType.UNKNOWN, 0, 0, 0, 0d);
 
@@ -138,6 +143,7 @@ public class MergedSpectrum implements MassSpectrum {
     this.removedScansByLowCosine = 0;
     this.removedScansByLowQuality = 0;
     this.precursorMz = Objects.requireNonNullElse(single.getPrecursorMz(), 0d);
+    this.tic = Arrays.stream(data).mapToDouble(p -> p.intensity).sum();
   }
 
   public MergedSpectrum(MergedDataPoint[] data, RawDataFile[] origins, int[] scanIds,
@@ -152,6 +158,7 @@ public class MergedSpectrum implements MassSpectrum {
     this.removedScansByLowCosine = removedScansByLowCosine;
     this.polarity = polarity;
     this.precursorCharge = precursorCharge;
+    this.tic = Arrays.stream(data).mapToDouble(p -> p.intensity).sum();
   }
 
   @Override
@@ -260,11 +267,7 @@ public class MergedSpectrum implements MassSpectrum {
   /**
    * @return calculate the total ion count of this merged spectrum
    */
-  public Double getTIC() {
-    double tic = 0d;
-    for (MergedDataPoint p : data) {
-      tic += p.intensity;
-    }
+  public double getTIC() {
     return tic;
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/dash_lipidqc/matched/MatchedSignalsPane.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/dash_lipidqc/matched/MatchedSignalsPane.java
@@ -126,8 +126,7 @@ public class MatchedSignalsPane extends DashboardComputationPane {
     if (scans.isEmpty()) {
       return null;
     }
-    return scans.stream().max(Comparator.comparingDouble(scan -> scan.getTIC() == null ? 0d
-        : scan.getTIC())).orElse(scans.getFirst());
+    return scans.stream().max(Comparator.comparingDouble(Scan::getTIC)).orElse(scans.getFirst());
   }
 
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/util/scans/FragmentScanSorter.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/scans/FragmentScanSorter.java
@@ -43,7 +43,7 @@ public abstract class FragmentScanSorter {
    * MS1>MS2>MS3 then highest TIC then highest number of data points
    */
   public static final Comparator<Scan> DEFAULT_TIC = comparingInt(Scan::getMSLevel) //
-      .thenComparing(Scan::getTIC, nullsLast(reverseOrder()))
+      .thenComparing(Comparator.comparingDouble(Scan::getTIC).reversed())
       .thenComparing(Scan::getNumberOfDataPoints, reverseOrder());
 
   /**

--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/LibraryEntryWrappedScan.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/entry/LibraryEntryWrappedScan.java
@@ -128,7 +128,7 @@ public class LibraryEntryWrappedScan implements Scan {
   }
 
   @Override
-  public @Nullable Double getTIC() {
+  public double getTIC() {
     return entry.getTIC();
   }
 


### PR DESCRIPTION
This aligns the interface with the actual internal behaviour - nearly all classes store a primitive TIC value internally. A
lso a null-TIC does not really make sense, if there are no datapoints a tic of 0 is appropriate, a true `null` can only happen if something is not loaded (in which case asking for the TIC should rather error out).

This has heavy influence on the GC, as we avoid a massive amount of boxing/unboxing when accessing the TIC (i.e. while sorting).