### PR TITLE
NPE in GC networking when NIST spectral match present

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/networking/visual/enums/NodeAtt.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/visualization/networking/visual/enums/NodeAtt.java
@@ -193,8 +193,7 @@ public enum NodeAtt implements GraphElementAttr {
           .map(match -> match.getSimilarity().getExplainedLibraryIntensity()).findFirst()
           .orElse(null);
       case MATCHED_SIGNALS -> row.getSpectralLibraryMatches().stream()
-          .map(match -> match.getSimilarity().getAlignedDataPoints().length).findFirst()
-          .orElse(null);
+          .map(match -> match.getSimilarity().getOverlap()).findFirst().orElse(null);
     };
   }
 


### PR DESCRIPTION
- GC networking when NIST spectral match has overlapping signals null hits NPE - .overlap is safe