### PR TITLE
Parser for MDL molfiles

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/structures/SimpleMolecularStructure.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/structures/SimpleMolecularStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2024 The mzmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -98,12 +98,25 @@ public record SimpleMolecularStructure(@NotNull IAtomContainer structure) implem
    * @return a structure with precomputed values
    */
   public PrecomputedMolecularStructure precomputeValues() {
+    return precomputeValues(isomericSmiles());
+  }
+
+  /**
+   * Precompute values in case they are access more often.
+   *
+   * @param isomericSmiles the already generated {@link #isomericSmiles()} of this structure, so
+   *                       that a caller which needed it before precomputing does not generate it a
+   *                       second time (its often used in caches as a unique identifier for the
+   *                       structure)
+   * @return a structure with precomputed values
+   */
+  public PrecomputedMolecularStructure precomputeValues(@Nullable String isomericSmiles) {
     InchiStructure inchiStr = StructureUtils.getInchiStructure(structure);
     String inchi = inchiStr != null ? inchiStr.inchi() : null;
     String inchiKey = inchiStr != null ? inchiStr.inchiKey() : null;
 
     return new PrecomputedMolecularStructure(structure, formula(), canonicalSmiles(),
-        isomericSmiles(), inchi, inchiKey, monoIsotopicMass(), mostAbundantMass(),
+        isomericSmiles, inchi, inchiKey, monoIsotopicMass(), mostAbundantMass(),
         totalFormalCharge());
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/structures/StructureInputType.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/structures/StructureInputType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2025 The mzmine Development Team
+ * Copyright (c) 2004-2026 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -26,5 +26,10 @@
 package io.github.mzmine.datamodel.structures;
 
 public enum StructureInputType {
-  SMILES, INCHI
+  SMILES, INCHI,
+  /**
+   * MDL molfile connection table, V2000 or V3000. The three molfile header lines are optional, see
+   * {@link StructureParser#parseMol(String)}.
+   */
+  MOL
 }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/structures/StructureParser.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/structures/StructureParser.java
@@ -70,10 +70,11 @@ public class StructureParser {
 
   // decision: two-tier cache. RAW_CACHE stores the original (un-harmonized) input strings the
   // caller passed in — these may repeat exactly across imports but are not reused for downstream
-  // computations, so a smaller bound is fine. CLEAN_CACHE stores the canonical/isomeric SMILES,
-  // standard InChI and InChIKey derived after a successful parse; downstream code uses these
-  // strings repeatedly (lookups, joins, comparisons), so they get a much larger bound. Multiple
-  // clean keys point to the SAME MolecularStructure instance — instance identity is intentional.
+  // computations, so a smaller bound is fine. CLEAN_CACHE stores the isomeric SMILES, standard
+  // InChI and InChIKey derived after a successful parse; downstream code uses these strings
+  // repeatedly (lookups, joins, comparisons), so they get a much larger bound. Multiple clean keys
+  // point to the SAME MolecularStructure instance — instance identity is intentional and the
+  // isomeric SMILES is also what a newly parsed structure is deduplicated on.
   // assumption: callers treat MolecularStructure as immutable. Mutating a returned structure
   // will corrupt cached entries for other callers.
   private static final Cache<String, MolecularStructure> RAW_CACHE = Caffeine.newBuilder()
@@ -130,8 +131,8 @@ public class StructureParser {
 
   /**
    * Snapshot of cumulative clean-form cache statistics since JVM start. The clean cache is keyed by
-   * canonical SMILES, isomeric SMILES, standard InChI and InChIKey derived after a successful
-   * parse. Multiple keys can point to the same {@link MolecularStructure} instance.
+   * isomeric SMILES, standard InChI and InChIKey derived after a successful parse. Multiple keys
+   * can point to the same {@link MolecularStructure} instance.
    */
   @NotNull
   public static CacheStats getCleanCacheStats() {
@@ -149,7 +150,7 @@ public class StructureParser {
   /**
    * @return current number of entries in the clean-form cache (best-effort under concurrent
    * access). Note: this counts cache keys, not distinct structures — each structure contributes up
-   * to four keys.
+   * to three keys.
    */
   public static long getCleanCacheSize() {
     return CLEAN_CACHE.estimatedSize();
@@ -213,21 +214,37 @@ public class StructureParser {
       return null;
     }
 
+    // deduplicate on the isomeric smiles before a new instance is built. It is the only clean form
+    // that identifies the molecule, being canonically ordered and carrying stereo and isotopes
+    final String parsedIsomericSmiles = parsed.isomericSmiles();
+    if (parsedIsomericSmiles != null) {
+      final MolecularStructure cached = CLEAN_CACHE.getIfPresent(parsedIsomericSmiles);
+      if (cached != null) {
+        // the raw input cannot be one of the cached structure's clean keys, the lookup above would
+        // have hit, so no putRaw guard is needed here
+        if (cacheRawInput) {
+          RAW_CACHE.put(structure, cached);
+        }
+        return cached;
+      }
+    }
+
     // decision: keep the derived values instead of discarding them. Generating them for the cache
     // keys costs roughly 1400 us per structure while an on demand inchiKey() call costs another
     // ~220 us and formulaString() ~16 us. Since a cached structure is handed to many callers,
     // storing what was already paid for makes value access about 8x cheaper at zero extra cost.
-    final MolecularStructure mol = parsed.precomputeValues();
+    // the isomeric smiles was already generated for the deduplication lookup above
+    final MolecularStructure mol = parsed.precomputeValues(parsedIsomericSmiles);
 
-    // Populate CLEAN_CACHE with all derivable clean keys → same MolecularStructure instance.
-    final HashSet<String> cleanKeys = HashSet.newHashSet(4);
-    putClean(cleanKeys, mol, mol.canonicalSmiles());
+    // Populate CLEAN_CACHE with all identifying clean keys → same MolecularStructure instance.
+    // the canonical smiles is not a key. It drops stereo, so a lookup might result in wrong structure
+    final HashSet<String> cleanKeys = HashSet.newHashSet(3);
     putClean(cleanKeys, mol, mol.isomericSmiles());
     putClean(cleanKeys, mol, mol.inchi());
     putClean(cleanKeys, mol, mol.inchiKey());
 
     // Populate RAW_CACHE with the original caller inputs — skip if the input string already
-    // appears in CLEAN_CACHE (avoids redundant storage of already-canonical inputs).
+    // appears in CLEAN_CACHE (avoids redundant storage of inputs that are already a clean form).
     if (cacheRawInput) {
       putRaw(cleanKeys, mol, structure);
     }

--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/structures/StructureParser.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/structures/StructureParser.java
@@ -31,7 +31,10 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import io.github.mzmine.util.StringUtils;
+import java.io.IOException;
+import java.io.StringReader;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -43,6 +46,9 @@ import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.inchi.InChIGeneratorFactory;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
+import org.openscience.cdk.io.ISimpleChemObjectReader;
+import org.openscience.cdk.io.MDLV2000Reader;
+import org.openscience.cdk.io.MDLV3000Reader;
 import org.openscience.cdk.smarts.SmartsPattern;
 import org.openscience.cdk.smiles.SmilesParser;
 
@@ -54,6 +60,13 @@ public class StructureParser {
   private static final Logger logger = Logger.getLogger(StructureParser.class.getName());
 
   public static final Pattern SMILES_SPECIAL_CHARS = Pattern.compile("[\\[\\]()=#\\-./:\\\\@+%*]");
+
+  // molfile counts line, " 18 20  0  0  0  0  0  0  0  0999 V2000" for V2000 and
+  // "  0  0  0     0  0            999 V3000" for V3000, where the real counts move into the CTAB.
+  // decision: the version tag is required for the match. It is the only marker that cannot be
+  // confused with a title line, and molfiles written without it are pre-1992.
+  private static final Pattern MOL_COUNTS_LINE = Pattern.compile(
+      "\\s*\\d+\\s+\\d+[\\s\\d]*V[23]000\\s*");
 
   // decision: two-tier cache. RAW_CACHE stores the original (un-harmonized) input strings the
   // caller passed in — these may repeat exactly across imports but are not reused for downstream
@@ -180,11 +193,18 @@ public class StructureParser {
       return parseStructureWithoutCache(structure, inputType, options);
     }
 
+    // decision: molblocks are multi kilobyte strings that hardly ever repeat verbatim, so they are
+    // neither looked up in nor written to RAW_CACHE. Caching them would evict smiles and inchi
+    // entries for keys that never hit. The derived clean forms are still cached below.
+    final boolean cacheRawInput = inputType != StructureInputType.MOL;
+
     // Cache lookup — raw first (smaller, more likely to hit on repeated identical inputs),
     // then clean (hits when the caller already passes a canonical form, e.g. an inchikey).
-    MolecularStructure cached = lookupCaches(structure);
-    if (cached != null) {
-      return cached;
+    if (cacheRawInput) {
+      final MolecularStructure cached = lookupCaches(structure);
+      if (cached != null) {
+        return cached;
+      }
     }
 
     final SimpleMolecularStructure parsed = parseStructureWithoutCache(structure, inputType,
@@ -208,7 +228,9 @@ public class StructureParser {
 
     // Populate RAW_CACHE with the original caller inputs — skip if the input string already
     // appears in CLEAN_CACHE (avoids redundant storage of already-canonical inputs).
-    putRaw(cleanKeys, mol, structure);
+    if (cacheRawInput) {
+      putRaw(cleanKeys, mol, structure);
+    }
     return mol;
   }
 
@@ -244,6 +266,32 @@ public class StructureParser {
     return new SimpleMolecularStructure(harmonized);
   }
 
+  /**
+   * Parse a MDL molfile connection table with cache activated, see
+   * {@link #parseStructure(String, StructureInputType)}. V2000 and V3000 are both read, the version
+   * is taken from the counts line. The three molfile header lines (title, program, comment) are
+   * optional, a block that starts directly at the counts line is accepted.
+   *
+   * @param molBlock molfile content, V2000 or V3000, with or without header lines
+   * @return the structure or null
+   */
+  @Nullable
+  public MolecularStructure parseMol(@Nullable String molBlock) {
+    return parseStructure(molBlock, StructureInputType.MOL);
+  }
+
+  /**
+   * Parse a MDL molfile connection table, see {@link #parseMol(String)}.
+   *
+   * @param options harmonization to apply, see {@link StructureHarmonizer}
+   * @return the structure or null
+   */
+  @Nullable
+  public MolecularStructure parseMol(@Nullable String molBlock,
+      @NotNull HarmonizationOptions options) {
+    return parseStructure(molBlock, StructureInputType.MOL, options);
+  }
+
   @Nullable
   private IAtomContainer parseToContainer(@NotNull String structure,
       @NotNull StructureInputType inputType) {
@@ -253,8 +301,9 @@ public class StructureParser {
         case INCHI ->
             inchiFactory.getInChIToStructure(structure, DefaultChemObjectBuilder.getInstance())
                 .getAtomContainer();
+        case MOL -> parseMolToContainer(structure);
       };
-    } catch (CDKException e) {
+    } catch (CDKException | IOException | RuntimeException e) {
       final String message = "Cannot parse 'structure' %s as %s".formatted(structure, inputType);
       if (verbose) {
         logger.log(Level.WARNING, message, e);
@@ -263,6 +312,50 @@ public class StructureParser {
       }
       return null;
     }
+  }
+
+  /**
+   * A molfile starts with three header lines (title, program, comment), then the counts line that
+   * carries the format version, then the connection table. Both readers need the header lines and
+   * both refuse a block written in the other version, so the counts line decides.
+   */
+  @NotNull
+  private static IAtomContainer parseMolToContainer(@NotNull String molBlock)
+      throws CDKException, IOException {
+    // the counts line, which can only sit in the first four lines
+    final List<String> lines = molBlock.lines().limit(4).toList();
+    final int countsLine = indexOfCountsLine(lines);
+
+    // decision: the header lines are optional. Databases and web services often hand out the
+    // connection table alone, which the readers then misread as header plus a broken counts line
+    // (V2000) or reject outright (V3000).
+    // assumption: header lines are missing rather than the counts line being shifted, so padding
+    // to the expected offset restores a readable block
+    final String withHeader =
+        countsLine >= 0 && countsLine < 3 ? "\n".repeat(3 - countsLine) + molBlock : molBlock;
+
+    // decision: fall back to V2000 when no version tag was found. That covers pre-1992 molfiles
+    // written without one, and for anything else the reader reports its own error.
+    final boolean v3000 = countsLine >= 0 && lines.get(countsLine).contains("V3000");
+    final IChemObjectBuilder builder = DefaultChemObjectBuilder.getInstance();
+    try (final ISimpleChemObjectReader reader = v3000 ? new MDLV3000Reader(
+        new StringReader(withHeader)) : new MDLV2000Reader(new StringReader(withHeader))) {
+      return reader.read(builder.newInstance(IAtomContainer.class));
+    }
+  }
+
+  /**
+   * @param lines the leading lines of a molfile, all of them are inspected
+   * @return index of the molfile counts line, or -1 if none of the given lines carries a version
+   * tag
+   */
+  private static int indexOfCountsLine(@NotNull List<String> lines) {
+    for (int i = 0; i < lines.size(); i++) {
+      if (MOL_COUNTS_LINE.matcher(lines.get(i)).matches()) {
+        return i;
+      }
+    }
+    return -1;
   }
 
   @Nullable

--- a/mzmine-community/src/test/java/io/github/mzmine/datamodel/structures/StructureParserTest.java
+++ b/mzmine-community/src/test/java/io/github/mzmine/datamodel/structures/StructureParserTest.java
@@ -534,4 +534,72 @@ class StructureParserTest {
         "V3000 body tagged as V2000");
   }
 
+  /// the clean cache deduplicates on the isomeric smiles, so inputs that describe the same molecule
+  /// share one instance no matter how they were written. decision: none of these inputs is a clean
+  /// form of the molecule, otherwise the first cache lookup would hit before deduplication and the
+  /// test would pass without it.
+  @Test
+  void parseStructureReusesInstanceForSameMolecule() {
+    final StructureParser parser = StructureParser.silent();
+    final MolecularStructure a = parser.parseStructure("OC(=O)CCCCCCCC", StructureInputType.SMILES);
+    final MolecularStructure b = parser.parseStructure("C(CCCCCCCC)(=O)O",
+        StructureInputType.SMILES);
+    final MolecularStructure c = parser.parseStructure("CCCCCCCCC(=O)[OH]",
+        StructureInputType.SMILES);
+    Assertions.assertNotNull(a);
+
+    Assertions.assertEquals("CCCCCCCCC(=O)O", a.isomericSmiles());
+    Assertions.assertSame(a, b, "second writing of the same molecule");
+    Assertions.assertSame(a, c, "third writing of the same molecule");
+    // the isomeric smiles is a clean key, so it resolves to the very same instance as well
+    Assertions.assertSame(a, parser.parseStructure(a.isomericSmiles(), StructureInputType.SMILES));
+  }
+
+  /// a different molecule must not be deduplicated onto an existing instance
+  @Test
+  void parseStructureKeepsInstancesForDifferentMolecules() {
+    final StructureParser parser = StructureParser.silent();
+    final MolecularStructure nonanoic = parser.parseStructure("OC(=O)CCCCCCCC",
+        StructureInputType.SMILES);
+    final MolecularStructure decanoic = parser.parseStructure("OC(=O)CCCCCCCCC",
+        StructureInputType.SMILES);
+    Assertions.assertNotNull(nonanoic);
+    Assertions.assertNotNull(decanoic);
+
+    Assertions.assertNotSame(nonanoic, decanoic);
+    Assertions.assertNotEquals(nonanoic.isomericSmiles(), decanoic.isomericSmiles());
+  }
+
+  /// the canonical smiles drops stereo, so it is deliberately not a clean cache key. Serving it
+  /// would hand a stereo free input back whichever stereoisomer was parsed before it.
+  @Test
+  void canonicalSmilesIsNotACleanCacheKey() {
+    final StructureParser parser = StructureParser.silent();
+    // parse the stereo defined molecule first so its canonical smiles could pollute the cache
+    final MolecularStructure stereo = parser.parseStructure("C/C=C/CCCCCCCC",
+        StructureInputType.SMILES);
+    Assertions.assertNotNull(stereo);
+    final String canonicalSmiles = stereo.canonicalSmiles();
+    Assertions.assertNotEquals(canonicalSmiles, stereo.isomericSmiles(),
+        "test needs a molecule whose canonical smiles differs from its isomeric smiles");
+
+    // the canonical smiles as input describes the molecule without the double bond geometry
+    final MolecularStructure withoutStereo = parser.parseStructure(canonicalSmiles,
+        StructureInputType.SMILES);
+    Assertions.assertNotNull(withoutStereo);
+
+    Assertions.assertNotSame(stereo, withoutStereo);
+    Assertions.assertNotEquals(stereo.isomericSmiles(), withoutStereo.isomericSmiles());
+    Assertions.assertNotEquals(stereo.inchiKey(), withoutStereo.inchiKey());
+    // without any stereo to write, both smiles flavors give the same string
+    Assertions.assertEquals(canonicalSmiles, withoutStereo.isomericSmiles());
+
+    // and the cached result equals what a parse without any cache gives
+    final MolecularStructure uncached = parser.parseStructureWithoutCache(canonicalSmiles,
+        StructureInputType.SMILES);
+    Assertions.assertNotNull(uncached);
+    Assertions.assertEquals(uncached.inchiKey(), withoutStereo.inchiKey());
+    Assertions.assertEquals(uncached.isomericSmiles(), withoutStereo.isomericSmiles());
+  }
+
 }

--- a/mzmine-community/src/test/java/io/github/mzmine/datamodel/structures/StructureParserTest.java
+++ b/mzmine-community/src/test/java/io/github/mzmine/datamodel/structures/StructureParserTest.java
@@ -339,4 +339,199 @@ class StructureParserTest {
         molInchi.inchiKey()));
   }
 
+  /// Mo(CO)5 bound to a bicyclic C7 hydrocarbon, as a V2000 connection table. decision: this block
+  /// starts directly at the counts line, the three molfile header lines (title, program, comment)
+  /// are missing. That is how several databases hand out molfiles, so it is the case worth
+  /// testing.
+  private static final String MOL_V2000 = """
+       18 20  0  0  0  0  0  0  0  0999 V2000
+         15.0000  -17.0000    0.0000 O   0  0  0     0  3  0  0  0  0
+         11.0000   -1.0000    0.0000 C   0  0  0     0  0  0  0  0  0
+         36.0000   -1.0000    0.0000 O   0  0  0     0  3  0  0  0  0
+         21.0000    7.0000    0.0000 C   0  0  0     0  0  0  0  0  0
+         40.0000   15.0000    0.0000 O   0  0  0     0  3  0  0  0  0
+         23.0000   15.0000    0.0000 C   0  0  0     0  0  0  0  0  0
+         36.0000   32.0000    0.0000 O   0  0  0     0  3  0  0  0  0
+         21.0000   24.0000    0.0000 C   0  0  0     0  0  0  0  0  0
+         23.0000   44.0000    0.0000 O   0  0  0     0  3  0  0  0  0
+         15.0000   29.0000    0.0000 C   0  0  0     0  0  0  0  0  0
+          6.0000   15.0000    0.0000 Mo  0  0  0     0  7  0  0  0  0
+         -4.0000   -4.0000    0.0000 C   0  0  0     0  0  0  0  0  0
+        -22.0000    8.0000    0.0000 C   0  0  0     0  0  0  0  0  0
+         -9.0000   16.0000    0.0000 C   0  0  0     0  0  0  0  0  0
+        -27.0000   28.0000    0.0000 C   0  0  0     0  0  0  0  0  0
+          5.0000   33.0000    0.0000 C   0  0  0     0  0  0  0  0  0
+        -12.0000   46.0000    0.0000 C   0  0  0     0  0  0  0  0  0
+        -40.0000   24.0000    0.0000 C   0  0  0     0  0  0  0  0  0
+        1  2  3  0  0  0  0
+        2 11  1  0  0  0  0
+        3  4  3  0  0  0  0
+        4 11  1  0  0  0  0
+        5  6  3  0  0  0  0
+        6 11  1  0  0  0  0
+        7  8  3  0  0  0  0
+        8 11  1  0  0  0  0
+        9 10  3  0  0  0  0
+       10 11  1  0  0  0  0
+       11 12  1  0  0  0  0
+       11 13  1  0  0  0  0
+       12 14  1  0  0  0  0
+       12 13  1  0  0  0  0
+       13 15  1  0  0  0  0
+       14 16  1  0  0  0  0
+       14 18  1  0  0  0  0
+       15 17  1  0  0  0  0
+       15 18  1  0  0  0  0
+       16 17  1  0  0  0  0
+      M  END""";
+
+  /// the same molecule as {@link #MOL_V2000} written as a V3000 connection table, where the counts
+  /// line no longer carries the counts and the tables moved into the M V30 CTAB block. Also without
+  /// header lines.
+  private static final String MOL_V3000 = """
+        0  0  0     0  0            999 V3000
+      M  V30 BEGIN CTAB
+      M  V30 COUNTS 18 20 0 0 0
+      M  V30 BEGIN ATOM
+      M  V30 1 O 15 -17 0 0
+      M  V30 2 C 11 -1 0 0
+      M  V30 3 O 36 -1 0 0
+      M  V30 4 C 21 7 0 0
+      M  V30 5 O 40 15 0 0
+      M  V30 6 C 23 15 0 0
+      M  V30 7 O 36 32 0 0
+      M  V30 8 C 21 24 0 0
+      M  V30 9 O 23 44 0 0
+      M  V30 10 C 15 29 0 0
+      M  V30 11 Mo 6 15 0 0
+      M  V30 12 C -4 -4 0 0
+      M  V30 13 C -22 8 0 0
+      M  V30 14 C -9 16 0 0
+      M  V30 15 C -27 28 0 0
+      M  V30 16 C 5 33 0 0
+      M  V30 17 C -12 46 0 0
+      M  V30 18 C -40 24 0 0
+      M  V30 END ATOM
+      M  V30 BEGIN BOND
+      M  V30 1 3 1 2
+      M  V30 2 1 2 11
+      M  V30 3 3 3 4
+      M  V30 4 1 4 11
+      M  V30 5 3 5 6
+      M  V30 6 1 6 11
+      M  V30 7 3 7 8
+      M  V30 8 1 8 11
+      M  V30 9 3 9 10
+      M  V30 10 1 10 11
+      M  V30 11 1 11 12
+      M  V30 12 1 11 13
+      M  V30 13 1 12 14
+      M  V30 14 1 12 13
+      M  V30 15 1 13 15
+      M  V30 16 1 14 16
+      M  V30 17 1 14 18
+      M  V30 18 1 15 17
+      M  V30 19 1 15 18
+      M  V30 20 1 16 17
+      M  V30 END BOND
+      M  V30 END CTAB
+      M  END""";
+
+  private static final String MOL_HEADER_LINES = "some title\n  mzmine\ncomment line\n";
+
+  private static final String MOL_FORMULA = "C12H10[98]MoO5";
+  private static final String MOL_SMILES = "C1CC2CC1C3C2[Mo]3(C#O)(C#O)(C#O)(C#O)C#O";
+  private static final String MOL_INCHI_KEY = "PFCFPDWTNAFVLP-UHFFFAOYSA-N";
+
+  record MolFlavor(String name, String molBlock) {
+
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+
+  /// all of these describe the same molecule. The format version comes from the counts line and
+  /// missing header lines are padded, so every flavor has to parse to the same structure.
+  final static List<MolFlavor> molFlavors = List.of( //
+      new MolFlavor("V2000 without header lines", MOL_V2000) //
+      , new MolFlavor("V2000 with header lines", MOL_HEADER_LINES + MOL_V2000) //
+      // a title line alone is what some exports write, the counts line then sits at index 1
+      , new MolFlavor("V2000 with title line only", "some title\n" + MOL_V2000) //
+      , new MolFlavor("V2000 with crlf line endings", MOL_V2000.replace("\n", "\r\n")) //
+      , new MolFlavor("V3000 without header lines", MOL_V3000) //
+      , new MolFlavor("V3000 with header lines", MOL_HEADER_LINES + MOL_V3000) //
+      , new MolFlavor("V3000 with crlf line endings", MOL_V3000.replace("\n", "\r\n")) //
+  );
+
+  @ParameterizedTest
+  @FieldSource(value = "molFlavors")
+  void parseMolFlavors(MolFlavor flavor) {
+    final MolecularStructure structure = StructureParser.silent().parseMol(flavor.molBlock());
+    Assertions.assertNotNull(structure, flavor.name());
+
+    // the full connection table was read, not just the part before a misaligned counts line
+    Assertions.assertEquals(18, structure.structure().getAtomCount(), flavor.name());
+    Assertions.assertEquals(20, structure.structure().getBondCount(), flavor.name());
+
+    Assertions.assertEquals(MOL_FORMULA, structure.formulaString(), flavor.name());
+    Assertions.assertEquals(0, structure.totalFormalCharge(), flavor.name());
+    Assertions.assertEquals(MOL_SMILES, structure.canonicalSmiles(), flavor.name());
+    Assertions.assertEquals(MOL_SMILES, structure.isomericSmiles(), flavor.name());
+    Assertions.assertEquals(MOL_INCHI_KEY, structure.inchiKey(), flavor.name());
+  }
+
+  @Test
+  void parseMol() {
+    final MolecularStructure structure = StructureParser.silent().parseMol(MOL_V2000);
+    Assertions.assertNotNull(structure);
+
+    Assertions.assertEquals(18, structure.structure().getAtomCount());
+    Assertions.assertEquals(20, structure.structure().getBondCount());
+    Assertions.assertEquals(MOL_FORMULA, structure.formulaString());
+    Assertions.assertEquals(0, structure.totalFormalCharge());
+    Assertions.assertEquals(MOL_SMILES, structure.canonicalSmiles());
+    Assertions.assertEquals(MOL_SMILES, structure.isomericSmiles());
+    Assertions.assertEquals(MOL_INCHI_KEY, structure.inchiKey());
+  }
+
+  /// the metal is kept, see HarmonizationOptions.DEFAULT with MetalPolicy.KEEP_CENTRAL_IONS, and
+  /// the molfile route has to agree with the smiles route on the same molecule
+  @Test
+  void parseMolMatchesSmiles() {
+    final MolecularStructure fromMol = StructureParser.silent().parseMol(MOL_V2000);
+    Assertions.assertNotNull(fromMol);
+    final MolecularStructure fromSmiles = StructureParser.silent()
+        .parseStructure(fromMol.canonicalSmiles(), StructureInputType.SMILES);
+    Assertions.assertNotNull(fromSmiles);
+
+    Assertions.assertEquals(fromSmiles.formulaString(), fromMol.formulaString());
+    Assertions.assertEquals(fromSmiles.inchiKey(), fromMol.inchiKey());
+    Assertions.assertEquals(fromSmiles.canonicalSmiles(), fromMol.canonicalSmiles());
+    Assertions.assertEquals(fromSmiles.monoIsotopicMass(), fromMol.monoIsotopicMass(), 1e-8);
+  }
+
+  @Test
+  void parseMolInvalid() {
+    final StructureParser parser = StructureParser.silent();
+    Assertions.assertNull(parser.parseMol(null));
+    Assertions.assertNull(parser.parseMol(""));
+    Assertions.assertNull(parser.parseMol("   "));
+    Assertions.assertNull(parser.parseMol("CCCO"), "smiles is not a molfile");
+    // a molblock cut off mid atom block makes MDLV2000Reader throw a raw NullPointerException
+    Assertions.assertNull(parser.parseMol(MOL_V2000.substring(0, 300)));
+    Assertions.assertNull(parser.parseMol(MOL_V3000.substring(0, 300)));
+  }
+
+  /// the version tag decides which reader is used, so a body that does not match its tag is
+  /// rejected instead of silently parsed as a truncated structure
+  @Test
+  void parseMolWrongVersionTag() {
+    final StructureParser parser = StructureParser.silent();
+    Assertions.assertNull(parser.parseMol(MOL_V2000.replace("V2000", "V3000")),
+        "V2000 body tagged as V3000");
+    Assertions.assertNull(parser.parseMol(MOL_V3000.replace("V3000", "V2000")),
+        "V3000 body tagged as V2000");
+  }
+
 }


### PR DESCRIPTION
- parsers for MDL mol files
- actually deduplicate structure instances based on isomeric smiles to reduce number of mol instances