### PR TITLE
[performance]: better isotope utils

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/util/IsotopesUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/IsotopesUtils.java
@@ -25,7 +25,6 @@
 
 package io.github.mzmine.util;
 
-import com.google.common.collect.Range;
 import com.google.common.primitives.Doubles;
 import io.github.mzmine.datamodel.DataPoint;
 import io.github.mzmine.datamodel.MassSpectrum;
@@ -304,8 +303,10 @@ public class IsotopesUtils {
 
       // Compute theoretical m/z value representing the difference between possible isotope
       // candidate newMz and possible isotope difference
-      double theoreticalMz = newMz - isotopeMzDiff;
-      Range<Double> theoreticalMzTolRange = mzTolerance.getToleranceRange(theoreticalMz);
+      final double theoreticalMz = newMz - isotopeMzDiff;
+      final double theoreticalMzTol = mzTolerance.getMzToleranceForMass(theoreticalMz);
+      final double upperLimit = theoreticalMz + theoreticalMzTol;
+      final double lowerLimit = theoreticalMz - theoreticalMzTol;
 
       // Go left over m/z's of previously detected peaks and check whether current peak is an
       // isotope of one of them
@@ -319,13 +320,13 @@ public class IsotopesUtils {
         double realMz = knownMzs.getDouble(mzIndex);
 
         // Do not go left further if the theoretical m/z is higher than real
-        if (Doubles.compare(theoreticalMzTolRange.lowerEndpoint(), realMz) > 0) {
+        if (lowerLimit > realMz) {
           break;
         }
 
         // If the theoretical and real m/z values are equal up to tolerance, then m/z of the mzIndex
         // peak corresponds to the mass of the isotope
-        if (theoreticalMzTolRange.contains(realMz)) {
+        if (realMz <= upperLimit) {
           return true;
         }
       }
@@ -343,8 +344,10 @@ public class IsotopesUtils {
 
       // Compute theoretical m/z value representing the difference between possible isotope
       // candidate newMz and possible isotope difference
-      double theoreticalMz = newMz - isotopeMzDiff;
-      Range<Double> theoreticalMzTolRange = mzTolerance.getToleranceRange(theoreticalMz);
+      final double theoreticalMz = newMz - isotopeMzDiff;
+      final double theoreticalMzTol = mzTolerance.getMzToleranceForMass(theoreticalMz);
+      final double upperLimit = theoreticalMz + theoreticalMzTol;
+      final double lowerLimit = theoreticalMz - theoreticalMzTol;
 
       // Go left over m/z's of previously detected peaks and check whether current peak is an
       // isotope of one of them
@@ -358,13 +361,13 @@ public class IsotopesUtils {
         double realMz = knownMzs.get(mzIndex).getMZ();
 
         // Do not go left further if the theoretical m/z is higher than real
-        if (Doubles.compare(theoreticalMzTolRange.lowerEndpoint(), realMz) > 0) {
+        if (lowerLimit > realMz) {
           break;
         }
 
         // If the theoretical and real m/z values are equal up to tolerance, then m/z of the mzIndex
         // peak corresponds to the mass of the isotope
-        if (theoreticalMzTolRange.contains(realMz)) {
+        if (realMz <= upperLimit) {
           return true;
         }
       }
@@ -385,9 +388,10 @@ public class IsotopesUtils {
 
       // Compute theoretical m/z value representing the difference between possible isotope
       // candidate newMz and possible isotope difference
-      double theoreticalMz = newMz + isotopeMzDiff;
-
-      Range<Double> theoreticalMzTolRange = mzTolerance.getToleranceRange(theoreticalMz);
+      final double theoreticalMz = newMz + isotopeMzDiff;
+      final double theoreticalMzTol = mzTolerance.getMzToleranceForMass(theoreticalMz);
+      final double upperLimit = theoreticalMz + theoreticalMzTol;
+      final double lowerLimit = theoreticalMz - theoreticalMzTol;
 
       // Go left over m/z's of previously detected peaks and check whether current peak is an
       // isotope of one of them
@@ -401,13 +405,13 @@ public class IsotopesUtils {
         double realMz = knownMzs.get(mzIndex).getMZ();
 
         // Do not go left further if the theoretical m/z is higher than real
-        if (realMz > theoreticalMzTolRange.upperEndpoint()) {
+        if (realMz > upperLimit) {
           break;
         }
 
         // If the theoretical and real m/z values are equal up to tolerance, then m/z of the mzIndex
         // peak corresponds to the mass of the isotope
-        if (theoreticalMzTolRange.contains(realMz)) {
+        if (lowerLimit <= realMz && realMz <= upperLimit) {
           return true;
         }
       }
@@ -476,7 +480,7 @@ public class IsotopesUtils {
         }
       }
     }
-    candidates.sort(mzSorter);
+    // candidates.sort(mzSorter);
     return candidates;
   }
 

--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/MonaJsonParser.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/MonaJsonParser.java
@@ -37,7 +37,6 @@ import jakarta.json.JsonArray;
 import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
-import jakarta.json.JsonReaderFactory;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
 import jakarta.json.JsonValue.ValueType;
@@ -67,8 +66,6 @@ import org.jetbrains.annotations.Nullable;
 public class MonaJsonParser extends SpectralDBTextParser {
 
   private static final String COMPOUND = "compound", MONA_ID = "id", META_DATA = "metaData", SPECTRUM = "spectrum", SPLASH = "splash", SUBMITTER = "submitter";
-
-  private static final JsonReaderFactory READER_FACTORY = Json.createReaderFactory(null);
 
   private static final Logger logger = Logger.getLogger(MonaJsonParser.class.getName());
 
@@ -160,7 +157,7 @@ public class MonaJsonParser extends SpectralDBTextParser {
   @Nullable
   private SpectralLibraryEntry parseToEntry(LibraryParsingErrors errors, SpectralLibrary library,
       String line) {
-    try (JsonReader reader = READER_FACTORY.createReader(new StringReader(line))) {
+    try (JsonReader reader = Json.createReader(new StringReader(line))) {
       JsonObject json = reader.readObject();
       return getDBEntry(errors, library, json);
     }

--- a/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/MonaJsonParser.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/spectraldb/parser/MonaJsonParser.java
@@ -37,6 +37,7 @@ import jakarta.json.JsonArray;
 import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
+import jakarta.json.JsonReaderFactory;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
 import jakarta.json.JsonValue.ValueType;
@@ -66,6 +67,8 @@ import org.jetbrains.annotations.Nullable;
 public class MonaJsonParser extends SpectralDBTextParser {
 
   private static final String COMPOUND = "compound", MONA_ID = "id", META_DATA = "metaData", SPECTRUM = "spectrum", SPLASH = "splash", SUBMITTER = "submitter";
+
+  private static final JsonReaderFactory READER_FACTORY = Json.createReaderFactory(null);
 
   private static final Logger logger = Logger.getLogger(MonaJsonParser.class.getName());
 
@@ -157,7 +160,7 @@ public class MonaJsonParser extends SpectralDBTextParser {
   @Nullable
   private SpectralLibraryEntry parseToEntry(LibraryParsingErrors errors, SpectralLibrary library,
       String line) {
-    try (JsonReader reader = Json.createReader(new StringReader(line))) {
+    try (JsonReader reader = READER_FACTORY.createReader(new StringReader(line))) {
       JsonObject json = reader.readObject();
       return getDBEntry(errors, library, json);
     }


### PR DESCRIPTION
Fixes two small issues:

- Google Range() is not suited for usage in hot-path of the code, i.e. when iterating over huge lists. Complexity of the self-rolled solution is also low. This should bring a ~30% Performance improvement.

- JSONReader creation causes a full classscan on each factory initialization, 