### PR TITLE
Wizard RT correction before deisotoping

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/WizardBatchBuilderLcDDA.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/WizardBatchBuilderLcDDA.java
@@ -103,12 +103,12 @@ public class WizardBatchBuilderLcDDA extends BaseWizardBatchBuilder {
       makeAndAddSmoothingStep(q, rtSmoothing, minImsDataPoints, imsSmoothing);
     }
 
-    makeAndAddDeisotopingStep(q, intraSampleRtTol);
-    makeAndAddFeatureFilterStep(q);
-    makeAndAddIsotopeFinderStep(q);
     if (scanRtCorrection) {
       makeAndAddScanRtCorrectionStep(q, mzTolInterSample, interSampleRtTol);
     }
+    makeAndAddDeisotopingStep(q, intraSampleRtTol);
+    makeAndAddFeatureFilterStep(q);
+    makeAndAddIsotopeFinderStep(q);
     makeAndAddJoinAlignmentStep(q, interSampleRtTol);
     makeAndAddRowFilterStep(q);
     makeAndAddGapFillStep(q, interSampleRtTol, minRtDataPoints);

--- a/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/WizardBatchBuilderLcDIA.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/tools/batchwizard/builders/WizardBatchBuilderLcDIA.java
@@ -127,14 +127,15 @@ public class WizardBatchBuilderLcDIA extends BaseWizardBatchBuilder {
       makeAndAddSmoothingStep(q, rtSmoothing, minRtDataPoints, imsSmoothing);
     }
 
+    if (scanRtCorrection) {
+      makeAndAddScanRtCorrectionStep(q, mzTolInterSample, interSampleRtTol);
+    }
+
     makeAndAddDeisotopingStep(q, intraSampleRtTol);
     makeAndAddFeatureFilterStep(q);
     makeAndAddDiaMs2GroupingStep(q);
 
     makeAndAddIsotopeFinderStep(q);
-    if (scanRtCorrection) {
-      makeAndAddScanRtCorrectionStep(q, mzTolInterSample, interSampleRtTol);
-    }
     makeAndAddJoinAlignmentStep(q, interSampleRtTol);
     makeAndAddRowFilterStep(q);
     makeAndAddGapFillStep(q, interSampleRtTol, minRtDataPoints);


### PR DESCRIPTION
I usually put the RT correction before deisotoping because those signals might be well suited to average the RT changes the M+1 might also have less interferences. 
But both work fine so totally optional